### PR TITLE
fix(tolkc): path to the assets folder

### DIFF
--- a/crates/tolkc/src/compiler.rs
+++ b/crates/tolkc/src/compiler.rs
@@ -284,8 +284,8 @@ pub struct CompilerResultError {
 }
 
 /// We embed the whole standard library of Tolk and Fift in binary for easier distribution.
-static TOLK_STDLIB_DIR: Dir = include_dir!("./crates/tolkc/assets/tolk-stdlib");
-static FIFT_STDLIB_DIR: Dir = include_dir!("./crates/tolkc/assets/fift");
+static TOLK_STDLIB_DIR: Dir = include_dir!("$CARGO_MANIFEST_DIR/assets/tolk-stdlib");
+static FIFT_STDLIB_DIR: Dir = include_dir!("$CARGO_MANIFEST_DIR/assets/fift");
 
 fn read_stdlib_file(path: &str) -> Option<&'static str> {
     TOLK_STDLIB_DIR.get_file(path)?.contents_utf8()


### PR DESCRIPTION
In Windows, the method of obtaining the path relative to the folder via `./` will not work