### PR TITLE
refactor(all): changed the path calculation to the `objc` folder

### DIFF
--- a/crates/emulator/build.rs
+++ b/crates/emulator/build.rs
@@ -4,16 +4,13 @@ use std::path::Path;
 fn main() {
     let workspace_root = Path::new(&env::var("CARGO_MANIFEST_DIR").unwrap())
         .join("..")
-        .join("..")
-        .join("objs");
+        .join("..");
+    let objc_dir = workspace_root.join("objs");
 
-    println!(
-        "cargo:rustc-link-search=native={}",
-        workspace_root.display()
-    );
+    println!("cargo:rustc-link-search=native={}", objc_dir.display());
     println!(
         "cargo:rerun-if-changed={}/libemulator.a",
-        workspace_root.display()
+        objc_dir.display()
     );
     println!("cargo:rustc-link-lib=static=emulator");
 

--- a/crates/emulator/build.rs
+++ b/crates/emulator/build.rs
@@ -1,10 +1,20 @@
 use std::env;
+use std::path::Path;
 
 fn main() {
-    let manifest_dir = env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR not set");
-    println!("cargo:rustc-link-search=native={manifest_dir}/../../objs/");
-    println!("cargo:rerun-if-changed={manifest_dir}/../../objs/libemulator.a");
+    let workspace_root = Path::new(&env::var("CARGO_MANIFEST_DIR").unwrap())
+        .join("..")
+        .join("..")
+        .join("objs");
 
+    println!(
+        "cargo:rustc-link-search=native={}",
+        workspace_root.display()
+    );
+    println!(
+        "cargo:rerun-if-changed={}/libemulator.a",
+        workspace_root.display()
+    );
     println!("cargo:rustc-link-lib=static=emulator");
 
     #[cfg(target_os = "macos")]

--- a/crates/tolkc/build.rs
+++ b/crates/tolkc/build.rs
@@ -4,16 +4,10 @@ use std::path::Path;
 fn main() {
     let workspace_root = Path::new(&env::var("CARGO_MANIFEST_DIR").unwrap())
         .join("..")
-        .join("..")
-        .join("objs");
+        .join("..");
+    let objc_dir = workspace_root.join("objs");
 
-    println!(
-        "cargo:rustc-link-search=native={}",
-        workspace_root.display()
-    );
-    println!(
-        "cargo:rerun-if-changed={}/libtolk.a",
-        workspace_root.display()
-    );
+    println!("cargo:rustc-link-search=native={}", objc_dir.display());
+    println!("cargo:rerun-if-changed={}/libtolk.a", objc_dir.display());
     println!("cargo:rustc-link-lib=static=tolk");
 }

--- a/crates/tolkc/build.rs
+++ b/crates/tolkc/build.rs
@@ -1,8 +1,19 @@
 use std::env;
+use std::path::Path;
 
 fn main() {
-    let manifest_dir = env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR not set");
-    println!("cargo:rustc-link-search=native={manifest_dir}/../../objs/");
+    let workspace_root = Path::new(&env::var("CARGO_MANIFEST_DIR").unwrap())
+        .join("..")
+        .join("..")
+        .join("objs");
+
+    println!(
+        "cargo:rustc-link-search=native={}",
+        workspace_root.display()
+    );
+    println!(
+        "cargo:rerun-if-changed={}/libtolk.a",
+        workspace_root.display()
+    );
     println!("cargo:rustc-link-lib=static=tolk");
-    println!("cargo:rerun-if-changed={manifest_dir}/../../objs/libtolk.a");
 }

--- a/crates/ton-executor/build.rs
+++ b/crates/ton-executor/build.rs
@@ -4,16 +4,13 @@ use std::path::Path;
 fn main() {
     let workspace_root = Path::new(&env::var("CARGO_MANIFEST_DIR").unwrap())
         .join("..")
-        .join("..")
-        .join("objs");
+        .join("..");
+    let objc_dir = workspace_root.join("objs");
 
-    println!(
-        "cargo:rustc-link-search=native={}",
-        workspace_root.display()
-    );
+    println!("cargo:rustc-link-search=native={}", objc_dir.display());
     println!(
         "cargo:rerun-if-changed={}/libemulator.a",
-        workspace_root.display()
+        objc_dir.display()
     );
     println!("cargo:rustc-link-lib=static=emulator");
 

--- a/crates/ton-executor/build.rs
+++ b/crates/ton-executor/build.rs
@@ -1,10 +1,20 @@
 use std::env;
+use std::path::Path;
 
 fn main() {
-    let manifest_dir = env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR not set");
-    println!("cargo:rustc-link-search=native={manifest_dir}/../../objs/");
-    println!("cargo:rerun-if-changed={manifest_dir}/../../objs/libemulator.a");
+    let workspace_root = Path::new(&env::var("CARGO_MANIFEST_DIR").unwrap())
+        .join("..")
+        .join("..")
+        .join("objs");
 
+    println!(
+        "cargo:rustc-link-search=native={}",
+        workspace_root.display()
+    );
+    println!(
+        "cargo:rerun-if-changed={}/libemulator.a",
+        workspace_root.display()
+    );
     println!("cargo:rustc-link-lib=static=emulator");
 
     #[cfg(target_os = "macos")]


### PR DESCRIPTION
After task https://github.com/rust-lang/cargo/issues/3946, it will be possible to remove the crutch with path calculation.