### PR TITLE
chore(acton-config): fix cargo warning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -877,10 +877,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ffi-test"
-version = "0.1.0"
-
-[[package]]
 name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/crates/acton-config/Cargo.toml
+++ b/crates/acton-config/Cargo.toml
@@ -7,4 +7,4 @@ edition = "2024"
 anyhow = "1.0.100"
 serde = { version = "1.0.228", features = ["derive"] }
 clap = "4.5.54"
-toml = "0.9.11+spec-1.1.0"
+toml = "0.9.11"


### PR DESCRIPTION
```
acton/crates/acton-config/Cargo.toml: version requirement `0.9.11+spec-1.1.0` for dependency `toml` includes semver metadata which will be ignored, removing the metadata is recommended to avoid confusion
```