### PR TITLE
fix(tolkc): UNC support on `Windows`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3018,6 +3018,7 @@ dependencies = [
 name = "tolkc"
 version = "0.1.0"
 dependencies = [
+ "dunce",
  "include_dir",
  "rustc-hash",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -144,6 +144,7 @@ itertools = "0.14.0"
 heck = "0.5.0"
 pretty = "0.12.5"
 winnow = "0.7.13"
+dunce = "1.0.5"
 
 [dependencies]
 # local creates

--- a/crates/tolkc/Cargo.toml
+++ b/crates/tolkc/Cargo.toml
@@ -17,6 +17,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 include_dir = { workspace = true }
 rustc-hash = { workspace = true }
+dunce = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/tolkc/src/compiler.rs
+++ b/crates/tolkc/src/compiler.rs
@@ -1,11 +1,12 @@
 #![allow(unsafe_code)]
+use dunce::canonicalize;
 use include_dir::{Dir, include_dir};
 use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
 use std::cell::RefCell;
 use std::collections::{BTreeMap, HashMap};
 use std::ffi::{CStr, CString, c_char, c_int};
-use std::fs::{canonicalize, read_to_string};
+use std::fs::read_to_string;
 use std::path::{Path, PathBuf};
 use ton_source_map::{HighLevelSourceMap, SourceMap, parse_marks_dict};
 


### PR DESCRIPTION
Towards #338 and #56

This PR does not solve all problems with UNC paths, because too much work needs to be done (and the complexity is unclear). All other issues will be addressed in subsequent PRs.

After this solution, about 70 tests will begin to run :)

**Important**:

The `dunce` library does not change the behavior of `fs::canonicalize` on other systems, only on `Windows`.

https://gitlab.com/kornelski/dunce/-/blob/0ceb0ae141bf78c6d9d68488a55d22cd94658339/src/lib.rs#L62

```rust
pub fn canonicalize<P: AsRef<Path>>(path: P) -> io::Result<PathBuf> {
    let path = path.as_ref();

    #[cfg(not(windows))]
    {
        fs::canonicalize(path)
    }
    #[cfg(windows)]
    {
        canonicalize_win(path)
    }
}
```