### PR TITLE
chore(acton): prohibited the use of `std::fs::canonicalize` via `clippy`

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,1 +1,5 @@
 allow-unwrap-in-tests = true
+
+disallowed-methods = [
+    { path = "std::fs::canonicalize", reason = "use dunce::canonicalize" },
+]


### PR DESCRIPTION
Closed #338

No more uses of `fs::canonicalize` in the project, only `dunce::canonicalize`