### PR TITLE
fix(source-map): correct handling of source location on `Windows`

### DIFF
--- a/crates/ton-source-map/src/lib.rs
+++ b/crates/ton-source-map/src/lib.rs
@@ -110,14 +110,14 @@ impl SourceLocation {
             return Ok(None);
         }
 
-        let parts = s.split(':').collect::<Vec<_>>();
+        let parts = s.rsplitn(3, ':').collect::<Vec<_>>();
         if parts.len() != 3 {
             anyhow::bail!("invalid source location, expected file:line:col, got {s}");
         }
 
-        let file = parts[0].to_owned();
+        let file = parts[2].to_owned();
         let line = parts[1].parse::<i64>()?;
-        let column = parts[2].parse::<i64>()?;
+        let column = parts[0].parse::<i64>()?;
 
         Ok(Some(SourceLocation {
             file,


### PR DESCRIPTION
Towards #56

The symbol `:` is present in the path to the drive (`C:\`), so the division into three parts does not work correctly.

After this solution, about 23 tests will begin to run :)