### PR TITLE
feat(build): add configurable fift output path

### DIFF
--- a/acton.schema.json
+++ b/acton.schema.json
@@ -3,12 +3,18 @@
   "title": "Acton Configuration Schema",
   "description": "JSON schema for Acton.toml configuration file",
   "type": "object",
-  "required": ["package"],
+  "required": [
+    "package"
+  ],
   "properties": {
     "package": {
       "type": "object",
       "description": "Package metadata for the Acton project",
-      "required": ["name", "description", "version"],
+      "required": [
+        "name",
+        "description",
+        "version"
+      ],
       "properties": {
         "name": {
           "type": "string",
@@ -38,7 +44,10 @@
       "description": "Custom network configurations",
       "additionalProperties": {
         "type": "object",
-        "required": ["v2-url", "v3-url"],
+        "required": [
+          "v2-url",
+          "v3-url"
+        ],
         "properties": {
           "v2-url": {
             "type": "string",
@@ -64,7 +73,12 @@
           "description": "List of test reporters to use",
           "items": {
             "type": "string",
-            "enum": ["console", "teamcity", "junit", "dot"]
+            "enum": [
+              "console",
+              "teamcity",
+              "junit",
+              "dot"
+            ]
           }
         },
         "debug": {
@@ -168,12 +182,29 @@
         }
       }
     },
+    "build": {
+      "type": "object",
+      "description": "Build options for acton build",
+      "properties": {
+        "out-dir": {
+          "type": "string",
+          "description": "Output directory for build artifacts"
+        },
+        "output-fift": {
+          "type": "string",
+          "description": "Directory where .fif artifacts are written"
+        }
+      }
+    },
     "contracts": {
       "type": "object",
       "description": "Definition of contracts in the project",
       "additionalProperties": {
         "type": "object",
-        "required": ["name", "src"],
+        "required": [
+          "name",
+          "src"
+        ],
         "properties": {
           "name": {
             "type": "string",
@@ -195,7 +226,9 @@
                 {
                   "type": "object",
                   "description": "Detailed dependency configuration",
-                  "required": ["name"],
+                  "required": [
+                    "name"
+                  ],
                   "properties": {
                     "name": {
                       "type": "string",
@@ -204,7 +237,10 @@
                     "kind": {
                       "type": "string",
                       "description": "Dependency type",
-                      "enum": ["embed_code", "library_ref"],
+                      "enum": [
+                        "embed_code",
+                        "library_ref"
+                      ],
                       "default": "embed_code"
                     },
                     "function": {
@@ -248,7 +284,11 @@
         "anyOf": [
           {
             "type": "string",
-            "enum": ["allow", "warn", "deny"],
+            "enum": [
+              "allow",
+              "warn",
+              "deny"
+            ],
             "description": "Global lint level for a rule"
           },
           {
@@ -256,7 +296,11 @@
             "description": "Contract-specific lint overrides",
             "additionalProperties": {
               "type": "string",
-              "enum": ["allow", "warn", "deny"]
+              "enum": [
+                "allow",
+                "warn",
+                "deny"
+              ]
             }
           }
         ]

--- a/crates/acton-config/src/config.rs
+++ b/crates/acton-config/src/config.rs
@@ -58,6 +58,7 @@ pub struct ActonConfig {
     pub libraries: Option<LibrariesConfig>,
     pub mappings: Option<BTreeMap<String, String>>,
     pub networks: Option<BTreeMap<String, CustomNetworkConfig>>,
+    pub build: Option<BuildSettings>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -138,6 +139,13 @@ pub enum LintEntry {
 pub struct LintConfig {
     #[serde(flatten)]
     pub entries: BTreeMap<String, LintEntry>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "kebab-case")]
+pub struct BuildSettings {
+    pub out_dir: Option<String>,
+    pub output_fift: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -228,6 +236,7 @@ impl Default for ActonConfig {
             scripts: None,
             mappings: None,
             networks: None,
+            build: None,
         }
     }
 }
@@ -392,6 +401,11 @@ impl ActonConfig {
     #[must_use]
     pub fn wallets(&self) -> Option<&BTreeMap<String, WalletConfig>> {
         self.wallets.as_ref().map(|w| &w.wallets)
+    }
+
+    #[must_use]
+    pub fn build_settings(&self) -> Option<&BuildSettings> {
+        self.build.as_ref()
     }
 
     #[must_use]

--- a/docs/content/docs/build-system/configuration-reference.mdx
+++ b/docs/content/docs/build-system/configuration-reference.mdx
@@ -53,6 +53,21 @@ acton build --out-dir artifacts/
 
 ## Acton.toml Configuration
 
+### Build Section
+
+You can set build output paths in the `[build]` section:
+
+```toml
+[build]
+out-dir = "build"
+output-fift = "build/fift"
+```
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `out-dir` | string | no | Directory for `acton build` JSON artifacts (defaults to `build/`) |
+| `output-fift` | string | no | Directory for generated Fift output files (defaults to disabled) |
+
 ### Contracts Section
 
 Contracts are defined using `[contracts.*]` sections where `*` is the contract key.

--- a/src/bin/acton.rs
+++ b/src/bin/acton.rs
@@ -379,10 +379,11 @@ enum Commands {
         graph: Option<String>,
         #[arg(
             long,
-            default_value = "build",
             help = "Output directory for build artifacts"
         )]
         out_dir: Option<String>,
+        #[arg(long, help = "Directory to save generated Fift output")]
+        output_fift: Option<String>,
         #[arg(long, help = "Show compiled contract info")]
         info: bool,
     },
@@ -832,6 +833,10 @@ fn example_build_usage() -> StyledStr {
             "Generate dependency graph as SVG file",
             "acton build --graph deps.svg",
         ),
+        (
+            "Build with Fift output",
+            "acton build --output-fift build/fift",
+        ),
     ]);
 
     let header = styled.get_header();
@@ -1249,8 +1254,9 @@ fn main() {
             clear_cache,
             graph,
             out_dir,
+            output_fift,
             info,
-        } => build_cmd(contract_id, clear_cache, graph, out_dir, info),
+        } => build_cmd(contract_id, clear_cache, graph, out_dir, output_fift, info),
         Commands::Compile {
             path,
             json,

--- a/src/commands/build/mod.rs
+++ b/src/commands/build/mod.rs
@@ -21,6 +21,7 @@ pub fn build_cmd(
     clear_cache: bool,
     graph_output: Option<String>,
     out_dir: Option<String>,
+    output_fift: Option<String>,
     show_info: bool,
 ) -> anyhow::Result<()> {
     stdlib::ensure_latest(Path::new("."))?;
@@ -29,7 +30,16 @@ pub fn build_cmd(
     // since first compilation WITHOUT debug mode will set debug=false forever
     enable_emulator_debug_mode()?;
 
-    let out_dir = out_dir.unwrap_or_else(|| "build".to_string());
+    let config = ActonConfig::load()?;
+    let out_dir = out_dir
+        .or_else(|| config.build_settings().and_then(|build| build.out_dir.clone()))
+        .unwrap_or_else(|| "build".to_string());
+    let output_fift = output_fift
+        .or_else(|| {
+            config
+                .build_settings()
+                .and_then(|build| build.output_fift.clone())
+        });
 
     if !Path::new(&out_dir).exists() {
         fs::create_dir_all(&out_dir)?;
@@ -42,8 +52,6 @@ pub fn build_cmd(
     }
 
     println!("   {} contracts", "Compiling".green().bold());
-
-    let config = ActonConfig::load()?;
 
     let contracts = match config.contracts() {
         Some(contracts) => contracts,
@@ -121,9 +129,9 @@ See https://i582.github.io/acton/docs/build-system/configuration-reference/#cont
             &config,
         )?;
 
-        let (code_boc64, code_hash) =
+        let (code_boc64, code_hash, code_fift) =
             match process_contract(&mut file_cache, contract_config, contract_path, &config) {
-                Ok((code, hash)) => (code, hash),
+                Ok((code, hash, fift)) => (code, hash, fift),
                 Err(err) => {
                     failure_count += 1;
                     compile_errors.insert(parent_contract.clone(), err);
@@ -146,6 +154,15 @@ See https://i582.github.io/acton/docs/build-system/configuration-reference/#cont
                 "Warning: Failed to save build artifact file for {}: {}",
                 contract_config.name, e
             );
+        }
+
+        if let Some(output_dir) = output_fift.as_deref() && !code_fift.is_empty() {
+            if let Err(e) = save_fift_artifact(output_dir, &parent_contract, &code_fift) {
+                eprintln!(
+                    "Warning: Failed to save Fift artifact for {}: {}",
+                    contract_config.name, e
+                );
+            }
         }
 
         if let Err(e) = save_boc_file(contract_config, &code_boc64) {
@@ -196,14 +213,14 @@ fn process_contract(
     contract_config: &ContractConfig,
     contract_path: &String,
     acton_config: &ActonConfig,
-) -> anyhow::Result<(String, String)> {
-    let (code_boc64, code_hash) = if contract_path.ends_with(".boc") {
+) -> anyhow::Result<(String, String, String)> {
+    let (code_boc64, code_hash, code_fift) = if contract_path.ends_with(".boc") {
         debug!("Loading BoC file: {contract_path}");
         match fs::read(contract_path) {
             Ok(boc_data) => match Boc::decode(&boc_data) {
                 Ok(boc) => {
                     let code_boc64 = Boc::encode_base64(&boc);
-                    (code_boc64, boc.repr_hash().to_string())
+                    (code_boc64, boc.repr_hash().to_string(), String::new())
                 }
                 Err(e) => {
                     anyhow::bail!("Failed to decode BoC file {contract_path}: {e}");
@@ -218,7 +235,11 @@ fn process_contract(
 
         if let Some(cached_result) = cached_result {
             debug!("Cache hit, use cached result for '{contract_path}'");
-            (cached_result.code_boc64, cached_result.code_hash_hex)
+            (
+                cached_result.code_boc64,
+                cached_result.code_hash_hex,
+                cached_result.fift_code,
+            )
         } else {
             debug!("Cache miss, recompile '{contract_path}'");
             let compile_start = Instant::now();
@@ -241,7 +262,7 @@ fn process_contract(
 
                     println!("    {} in {:?}", "Finished".green(), compile_time);
 
-                    (result.code_boc64, result.code_hash_hex)
+                    (result.code_boc64, result.code_hash_hex, result.fift_code)
                 }
                 tolkc::CompilerResult::Error(error) => {
                     anyhow::bail!(error.message);
@@ -249,7 +270,23 @@ fn process_contract(
             }
         }
     };
-    Ok((code_boc64, code_hash))
+    Ok((code_boc64, code_hash, code_fift))
+}
+
+fn save_fift_artifact(
+    output_dir: &str,
+    contract_key: &str,
+    code_fift: &str,
+) -> anyhow::Result<()> {
+    let dir = Path::new(output_dir);
+    if !dir.exists() {
+        fs::create_dir_all(dir)?;
+    }
+
+    let filename = format!("{contract_key}.fif");
+    let path = dir.join(filename);
+    fs::write(path, code_fift)?;
+    Ok(())
 }
 
 fn save_boc_file(contract_config: &ContractConfig, code_boc64: &str) -> anyhow::Result<()> {

--- a/src/commands/test/mod.rs
+++ b/src/commands/test/mod.rs
@@ -393,7 +393,7 @@ impl<'a> TestRunner<'a> {
 
 pub fn test_cmd(path: Option<String>, config: &TestConfig) -> anyhow::Result<()> {
     // First we need to build all contracts and generate all dependency files with code
-    build_cmd(None, config.clear_cache, None, None, false)?;
+    build_cmd(None, config.clear_cache, None, None, None, false)?;
     println!("     {} tests", "Running".green().bold());
 
     // If path is omitted, default to current directory


### PR DESCRIPTION
## Summary
- Add `[build]` section in Acton.toml parsing with:
  - `out-dir`
  - `output-fift`
- Add new CLI flag `--output-fift` to `acton build`
- Build now writes `<contract>.fif` artifacts into configured fift output directory
- Preserve existing `--out-dir` behavior with precedence: CLI > Acton.toml `[build]` > default
- Update docs and JSON schema

## Notes
- `.fif` output is skipped for `.boc` contract inputs
- Test harness updated to new `build_cmd` signature
