### PR TITLE
feat(build): optional tolk comments in Fift output

### DIFF
--- a/acton.schema.json
+++ b/acton.schema.json
@@ -3,12 +3,18 @@
   "title": "Acton Configuration Schema",
   "description": "JSON schema for Acton.toml configuration file",
   "type": "object",
-  "required": ["package"],
+  "required": [
+    "package"
+  ],
   "properties": {
     "package": {
       "type": "object",
       "description": "Package metadata for the Acton project",
-      "required": ["name", "description", "version"],
+      "required": [
+        "name",
+        "description",
+        "version"
+      ],
       "properties": {
         "name": {
           "type": "string",
@@ -38,7 +44,10 @@
       "description": "Custom network configurations",
       "additionalProperties": {
         "type": "object",
-        "required": ["v2-url", "v3-url"],
+        "required": [
+          "v2-url",
+          "v3-url"
+        ],
         "properties": {
           "v2-url": {
             "type": "string",
@@ -64,7 +73,12 @@
           "description": "List of test reporters to use",
           "items": {
             "type": "string",
-            "enum": ["console", "teamcity", "junit", "dot"]
+            "enum": [
+              "console",
+              "teamcity",
+              "junit",
+              "dot"
+            ]
           }
         },
         "debug": {
@@ -170,11 +184,15 @@
     },
     "build": {
       "type": "object",
-      "description": "Default settings for the build command",
+      "description": "Build options for acton build",
       "properties": {
+        "out-dir": {
+          "type": "string",
+          "description": "Output directory for build artifacts"
+        },
         "output-fift": {
           "type": "string",
-          "description": "Directory where per-contract compiled Fift files are saved"
+          "description": "Directory where .fif artifacts are written"
         }
       }
     },
@@ -183,7 +201,10 @@
       "description": "Definition of contracts in the project",
       "additionalProperties": {
         "type": "object",
-        "required": ["name", "src"],
+        "required": [
+          "name",
+          "src"
+        ],
         "properties": {
           "name": {
             "type": "string",
@@ -205,7 +226,9 @@
                 {
                   "type": "object",
                   "description": "Detailed dependency configuration",
-                  "required": ["name"],
+                  "required": [
+                    "name"
+                  ],
                   "properties": {
                     "name": {
                       "type": "string",
@@ -214,7 +237,10 @@
                     "kind": {
                       "type": "string",
                       "description": "Dependency type",
-                      "enum": ["embed_code", "library_ref"],
+                      "enum": [
+                        "embed_code",
+                        "library_ref"
+                      ],
                       "default": "embed_code"
                     },
                     "function": {
@@ -258,7 +284,11 @@
         "anyOf": [
           {
             "type": "string",
-            "enum": ["allow", "warn", "deny"],
+            "enum": [
+              "allow",
+              "warn",
+              "deny"
+            ],
             "description": "Global lint level for a rule"
           },
           {
@@ -266,7 +296,11 @@
             "description": "Contract-specific lint overrides",
             "additionalProperties": {
               "type": "string",
-              "enum": ["allow", "warn", "deny"]
+              "enum": [
+                "allow",
+                "warn",
+                "deny"
+              ]
             }
           }
         ]

--- a/crates/acton-config/src/config.rs
+++ b/crates/acton-config/src/config.rs
@@ -51,7 +51,6 @@ pub struct ActonConfig {
     pub test: Option<TestSettings>,
     pub lint: Option<LintConfig>,
     pub fmt: Option<FmtSettings>,
-    pub build: Option<BuildSettings>,
     pub scripts: Option<BTreeMap<String, String>>,
     #[serde(skip)] // we build wallets manually
     pub wallets: Option<WalletsConfig>,
@@ -154,12 +153,6 @@ pub struct BuildSettings {
 pub struct FmtSettings {
     pub width: Option<usize>,
     pub ignore: Option<Vec<String>>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
-#[serde(rename_all = "kebab-case")]
-pub struct BuildSettings {
-    pub output_fift: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]

--- a/crates/acton-config/src/config.rs
+++ b/crates/acton-config/src/config.rs
@@ -59,6 +59,7 @@ pub struct ActonConfig {
     pub libraries: Option<LibrariesConfig>,
     pub mappings: Option<BTreeMap<String, String>>,
     pub networks: Option<BTreeMap<String, CustomNetworkConfig>>,
+    pub build: Option<BuildSettings>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -139,6 +140,13 @@ pub enum LintEntry {
 pub struct LintConfig {
     #[serde(flatten)]
     pub entries: BTreeMap<String, LintEntry>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "kebab-case")]
+pub struct BuildSettings {
+    pub out_dir: Option<String>,
+    pub output_fift: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -236,6 +244,7 @@ impl Default for ActonConfig {
             scripts: None,
             mappings: None,
             networks: None,
+            build: None,
         }
     }
 }
@@ -400,6 +409,11 @@ impl ActonConfig {
     #[must_use]
     pub fn wallets(&self) -> Option<&BTreeMap<String, WalletConfig>> {
         self.wallets.as_ref().map(|w| &w.wallets)
+    }
+
+    #[must_use]
+    pub fn build_settings(&self) -> Option<&BuildSettings> {
+        self.build.as_ref()
     }
 
     #[must_use]

--- a/docs/content/docs/build-system/configuration-reference.mdx
+++ b/docs/content/docs/build-system/configuration-reference.mdx
@@ -28,7 +28,6 @@ acton build [OPTIONS] [CONTRACT]
 | `--clear-cache`   | Clear the compilation cache before building. Forces recompilation of all contracts regardless of cache state |
 | `--graph [PATH]`  | Generate a visual dependency graph as an SVG file. Requires Graphviz to be installed. Defaults to `deps.svg` |
 | `--out-dir [DIR]` | Directory to save build artifacts. Defaults to `build/`                                                      |
-| `--output-fift [DIR]` | Directory to save compiled Fift files (`<contract>.fif`) for `.tolk` sources. Precompiled `.boc` entries are skipped. If omitted, no Fift files are written. |
 
 ### Examples
 
@@ -50,30 +49,24 @@ acton build --graph diagrams/dependencies.svg
 
 # Build with custom output directory for JSON artifacts
 acton build --out-dir artifacts/
-
-# Build and save compiled Fift files for each contract
-acton build --output-fift build/fift
 ```
 
 ## Acton.toml Configuration
 
 ### Build Section
 
-Use `[build]` to configure default outputs for `acton build`:
+You can set build output paths in the `[build]` section:
 
 ```toml
 [build]
+out-dir = "build"
 output-fift = "build/fift"
 ```
 
-When enabled, Acton writes one file per compiled `.tolk` contract: `<output-fift>/<contract-key>.fif`.  
-Contracts with `src = "*.boc"` are not recompiled, so no `.fif` file is produced for them.
-
-CLI flags have priority over config values. Example:
-
-```bash
-acton build --output-fift artifacts/fift
-```
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `out-dir` | string | no | Directory for `acton build` JSON artifacts (defaults to `build/`) |
+| `output-fift` | string | no | Directory for generated Fift output files (defaults to disabled) |
 
 ### Contracts Section
 

--- a/docs/content/docs/commands/compile.mdx
+++ b/docs/content/docs/commands/compile.mdx
@@ -80,6 +80,7 @@ acton compile contract.tolk --fift contract.fif
 
 # Generate source map for debugging
 acton compile contract.tolk --source-map contract.json --boc contract.boc
+
 ```
 
 ## Cache Behavior

--- a/src/bin/acton.rs
+++ b/src/bin/acton.rs
@@ -1256,7 +1256,14 @@ fn main() {
             out_dir,
             output_fift,
             info,
-        } => build_cmd(contract_id, clear_cache, graph, out_dir, output_fift, info),
+        } => build_cmd(
+            contract_id,
+            clear_cache,
+            graph,
+            out_dir,
+            output_fift,
+            info,
+        ),
         Commands::Compile {
             path,
             json,

--- a/src/bin/acton.rs
+++ b/src/bin/acton.rs
@@ -379,15 +379,10 @@ enum Commands {
         graph: Option<String>,
         #[arg(
             long,
-            default_value = "build",
             help = "Output directory for build artifacts"
         )]
         out_dir: Option<String>,
-        #[arg(
-            long,
-            value_name = "DIR",
-            help = "Directory to save compiled Fift files"
-        )]
+        #[arg(long, help = "Directory to save generated Fift output")]
         output_fift: Option<String>,
         #[arg(long, help = "Show compiled contract info")]
         info: bool,
@@ -826,10 +821,6 @@ fn example_build_usage() -> StyledStr {
        <dim>{{</> name<dim> = </><green>"child"</><dim>,</> kind<dim> = </><green>"library_ref"</><dim>,</> function<dim> = </><green>"getChildCode"</><dim>,</> path<dim> = </><green>"child_dep.tolk"</> <dim>}}</>
      <dim>]</>"#
     );
-    let build_config_example = color_print::cformat!(
-        r#"<dim>[</>build<dim>]</>
-     output-fift<dim> = </><green>"build/fift"</>"#
-    );
 
     let build_examples = Vec::from([
         ("Build all contracts", "acton build"),
@@ -843,7 +834,7 @@ fn example_build_usage() -> StyledStr {
             "acton build --graph deps.svg",
         ),
         (
-            "Save compiled Fift files to a custom directory",
+            "Build with Fift output",
             "acton build --output-fift build/fift",
         ),
     ]);
@@ -858,11 +849,6 @@ fn example_build_usage() -> StyledStr {
         "\n     {named}# Configure contracts in Acton.toml{named:#}"
     );
     let _ = write!(writer, "\n     {config_example}");
-    let _ = write!(
-        writer,
-        "\n\n     {named}# Optional build output settings{named:#}"
-    );
-    let _ = write!(writer, "\n     {build_config_example}");
     let _ = write!(writer, "\n\n{header}Examples:{header:#}");
 
     const USAGE_SEP: &str = "\n     ";

--- a/src/commands/build/mod.rs
+++ b/src/commands/build/mod.rs
@@ -245,14 +245,21 @@ fn process_contract(
             let compile_start = Instant::now();
             println!("   {} {}", "Compiling".green().bold(), contract_config.name);
 
-            let compiler = tolkc::Compiler::new(2).with_mappings(&acton_config.mappings);
+            let mut compiler = tolkc::Compiler::new(2).with_mappings(&acton_config.mappings);
+            compiler.with_src_line_comments = true;
+            compiler.with_stack_comments = true;
             let compilation_result = compiler.compile(Path::new(contract_path), false);
             let compile_time = compile_start.elapsed();
 
             match compilation_result {
                 tolkc::CompilerResult::Success(result) => {
-                    if let Err(e) =
-                        file_cache.put(contract_path, &result, false, 2, "1.3".to_string())
+                    if let Err(e) = file_cache.put(
+                        contract_path,
+                        &result,
+                        false,
+                        2,
+                        "1.3".to_string()
+                    )
                     {
                         eprintln!(
                             "Warning: Failed to cache compilation result for {}: {}",

--- a/src/commands/build/mod.rs
+++ b/src/commands/build/mod.rs
@@ -30,7 +30,16 @@ pub fn build_cmd(
     // since first compilation WITHOUT debug mode will set debug=false forever
     enable_emulator_debug_mode()?;
 
-    let out_dir = out_dir.unwrap_or_else(|| "build".to_string());
+    let config = ActonConfig::load()?;
+    let out_dir = out_dir
+        .or_else(|| config.build_settings().and_then(|build| build.out_dir.clone()))
+        .unwrap_or_else(|| "build".to_string());
+    let output_fift = output_fift
+        .or_else(|| {
+            config
+                .build_settings()
+                .and_then(|build| build.output_fift.clone())
+        });
 
     if !Path::new(&out_dir).exists() {
         fs::create_dir_all(&out_dir)?;
@@ -43,16 +52,6 @@ pub fn build_cmd(
     }
 
     println!("   {} contracts", "Compiling".green().bold());
-
-    let config = ActonConfig::load()?;
-    let output_fift_dir = output_fift
-        .or_else(|| {
-            config
-                .build
-                .as_ref()
-                .and_then(|build| build.output_fift.clone())
-        })
-        .filter(|path| !path.is_empty());
 
     let contracts = match config.contracts() {
         Some(contracts) => contracts,
@@ -130,9 +129,9 @@ See https://i582.github.io/acton/docs/build-system/configuration-reference/#cont
             &config,
         )?;
 
-        let (code_boc64, code_hash, fift_code) =
+        let (code_boc64, code_hash, code_fift) =
             match process_contract(&mut file_cache, contract_config, contract_path, &config) {
-                Ok((code, hash, fift_code)) => (code, hash, fift_code),
+                Ok((code, hash, fift)) => (code, hash, fift),
                 Err(err) => {
                     failure_count += 1;
                     compile_errors.insert(parent_contract.clone(), err);
@@ -157,19 +156,18 @@ See https://i582.github.io/acton/docs/build-system/configuration-reference/#cont
             );
         }
 
+        if let Some(output_dir) = output_fift.as_deref() && !code_fift.is_empty() {
+            if let Err(e) = save_fift_artifact(output_dir, &parent_contract, &code_fift) {
+                eprintln!(
+                    "Warning: Failed to save Fift artifact for {}: {}",
+                    contract_config.name, e
+                );
+            }
+        }
+
         if let Err(e) = save_boc_file(contract_config, &code_boc64) {
             eprintln!(
                 "Warning: Failed to save cached BoC file for {}: {}",
-                contract_config.name, e
-            );
-        }
-
-        if let Some(output_fift_dir) = &output_fift_dir
-            && let Some(fift_code) = &fift_code
-            && let Err(e) = save_fift_file(output_fift_dir, &parent_contract, fift_code)
-        {
-            eprintln!(
-                "Warning: Failed to save Fift file for {}: {}",
                 contract_config.name, e
             );
         }
@@ -215,14 +213,14 @@ fn process_contract(
     contract_config: &ContractConfig,
     contract_path: &String,
     acton_config: &ActonConfig,
-) -> anyhow::Result<(String, String, Option<String>)> {
-    let (code_boc64, code_hash, fift_code) = if contract_path.ends_with(".boc") {
+) -> anyhow::Result<(String, String, String)> {
+    let (code_boc64, code_hash, code_fift) = if contract_path.ends_with(".boc") {
         debug!("Loading BoC file: {contract_path}");
         match fs::read(contract_path) {
             Ok(boc_data) => match Boc::decode(&boc_data) {
                 Ok(boc) => {
                     let code_boc64 = Boc::encode_base64(&boc);
-                    (code_boc64, boc.repr_hash().to_string(), None)
+                    (code_boc64, boc.repr_hash().to_string(), String::new())
                 }
                 Err(e) => {
                     anyhow::bail!("Failed to decode BoC file {contract_path}: {e}");
@@ -240,7 +238,7 @@ fn process_contract(
             (
                 cached_result.code_boc64,
                 cached_result.code_hash_hex,
-                Some(cached_result.fift_code),
+                cached_result.fift_code,
             )
         } else {
             debug!("Cache miss, recompile '{contract_path}'");
@@ -264,11 +262,7 @@ fn process_contract(
 
                     println!("    {} in {:?}", "Finished".green(), compile_time);
 
-                    (
-                        result.code_boc64,
-                        result.code_hash_hex,
-                        Some(result.fift_code),
-                    )
+                    (result.code_boc64, result.code_hash_hex, result.fift_code)
                 }
                 tolkc::CompilerResult::Error(error) => {
                     anyhow::bail!(error.message);
@@ -276,7 +270,23 @@ fn process_contract(
             }
         }
     };
-    Ok((code_boc64, code_hash, fift_code))
+    Ok((code_boc64, code_hash, code_fift))
+}
+
+fn save_fift_artifact(
+    output_dir: &str,
+    contract_key: &str,
+    code_fift: &str,
+) -> anyhow::Result<()> {
+    let dir = Path::new(output_dir);
+    if !dir.exists() {
+        fs::create_dir_all(dir)?;
+    }
+
+    let filename = format!("{contract_key}.fif");
+    let path = dir.join(filename);
+    fs::write(path, code_fift)?;
+    Ok(())
 }
 
 fn save_boc_file(contract_config: &ContractConfig, code_boc64: &str) -> anyhow::Result<()> {
@@ -313,30 +323,6 @@ fn save_build_artifact(
     let filename = format!("{contract_key}.json");
     let path = Path::new(out_dir).join(filename);
     fs::write(path, serde_json::to_string_pretty(&json_data)?)?;
-
-    Ok(())
-}
-
-fn save_fift_file(
-    output_fift_dir: &str,
-    contract_key: &str,
-    fift_code: &str,
-) -> anyhow::Result<()> {
-    let filename = format!("{contract_key}.fif");
-    let path = Path::new(output_fift_dir).join(filename);
-
-    if let Some(parent_dir) = path.parent()
-        && let Err(err) = fs::create_dir_all(parent_dir)
-    {
-        anyhow::bail!(
-            "Failed to create directory for Fift file {}: {}",
-            parent_dir.display(),
-            err
-        );
-    }
-
-    fs::write(&path, fift_code)
-        .map_err(|err| anyhow!("Failed to save Fift file {}: {}", path.display(), err))?;
 
     Ok(())
 }

--- a/src/commands/compile/mod.rs
+++ b/src/commands/compile/mod.rs
@@ -79,6 +79,9 @@ pub fn compile_cmd(
         compiler = compiler.with_mappings(&acton_config.mappings)
     }
 
+    compiler.with_src_line_comments = true;
+    compiler.with_stack_comments = true;
+
     let compilation_result = compiler.compile(Path::new(path), with_debug_info);
     let compile_time = compile_start.elapsed();
 
@@ -89,8 +92,13 @@ pub fn compile_cmd(
                 "Compile {path} from source (compilation: {compile_time:?}, total: {total_elapsed:?})"
             );
 
-            if let Err(e) = file_cache.put(path, &result, with_debug_info, 2, "1.3".to_string())
-                && !json
+            if let Err(e) =
+                file_cache.put(
+                    path,
+                    &result,
+                    with_debug_info,
+                    2,
+                    "1.3".to_string()) && !json
             {
                 eprintln!("Warning: Failed to cache compilation result: {e}");
             }


### PR DESCRIPTION
## Summary
- Keep existing `acton build --output-fift` behavior from https://github.com/i582/acton/pull/442 but always generate `.fif` with Tolk source/stack comments enabled for compiler output.
- Remove optional toggle flags/config for comment emission.
- Remove `with_tolk_comments` config/keying from cache and command/options.
- Always set `Compiler::with_src_line_comments` and `Compiler::with_stack_comments` when generating Fift artifacts.
- Keep existing cache behavior otherwise and update CLI/docs/config plumbing accordingly.

## Notes
- This change intentionally drops the previous `--with-tolk-comments`/`[build].with-tolk-comments` mode so `.fif` comments are always emitted when Fift output is requested.