### PR TITLE
chore(ci): use ubuntu 22.04

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,8 @@
 # uncomment for flamegraph collection
 #[build]
 #rustflags = ["-C", "force-frame-pointers=yes"]
+
+# Enforce dynamic linking against the system glibc version,
+# which is important for Tree-sitter and OpenSSL, among others.
+[target.x86_64-unknown-linux-gnu]
+rustflags = ["-C", "target-feature=-crt-static"]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,6 +46,15 @@ jobs:
         with:
           tool: nextest,just
 
+      - name: Install LLVM and Clang
+        uses: KyleMayes/install-llvm-action@ebc0426251bc40c7cd31162802432c68818ab8f0 # v2.0.9
+        with:
+          # adds itself to PATH and LD_LIBRARY_PATH
+          # accessible via env.LLVM_PATH
+          version: "16.0.6"
+          cached: true
+          env: true # sets CC and CXX
+
       - name: Get TON commit hash
         id: ton-commit
         run: |
@@ -62,40 +71,15 @@ jobs:
           key: ton-artifacts-${{ matrix.os }}-${{ steps.ton-commit.outputs.commit }}
           restore-keys: ton-artifacts-${{ matrix.os }}-
 
-      - name: Cache LLVM and Clang
-        id: cache-llvm
-        uses: actions/cache@v5
-        with:
-          path: |
-            /usr/lib/llvm-16
-            /usr/bin/lld-16
-            /usr/bin/clang-16
-            /usr/bin/clang++-16
-            /usr/bin/llvm-ar-16
-            /usr/bin/llvm-ranlib-16
-          key: llvm-${{ matrix.os }}
-
-      - run: echo nothingburger
-
       - name: Check cache hits
         run: |
           echo 'TON artifacts: ${{ steps.cache-ton-artifacts.outputs.cache-hit }}'
-          echo 'LLVM and Clang: ${{ steps.cache-llvm.outputs.cache-hit }}'
-
-      - name: Install LLVM and Clang
-        if: steps.cache-llvm.outputs.cache-hit != 'true'
-        run: |
-          wget https://apt.llvm.org/llvm.sh
-          chmod +x llvm.sh
-          sudo ./llvm.sh 16 clang
-          rm llvm.sh
 
       - name: Install system dependencies (cache not exist)
         if: steps.cache-ton-artifacts.outputs.cache-hit != 'true'
         run: |
           sudo apt-get update
-          sudo apt-get install -y build-essential cmake ninja-build pkg-config autoconf automake libssl-dev libtool zlib1g-dev libsecp256k1-dev libmicrohttpd-dev libsodium-dev liblz4-dev libjemalloc-dev ccache clang-16 llvm-16 libc++-16-dev libc++abi-16-dev graphviz
-          echo "/usr/lib/llvm-16/bin" >> "$GITHUB_PATH"
+          sudo apt-get install -y build-essential cmake ninja-build pkg-config autoconf automake libssl-dev libtool zlib1g-dev libsecp256k1-dev libmicrohttpd-dev libsodium-dev liblz4-dev libjemalloc-dev ccache graphviz
 
       - name: Install system dependencies (cache exist)
         if: steps.cache-ton-artifacts.outputs.cache-hit == 'true'
@@ -122,16 +106,70 @@ jobs:
 
       - name: Build TON static libraries
         if: steps.cache-ton-artifacts.outputs.cache-hit != 'true'
-        env:
-          CC: clang-16
-          CXX: clang++-16
-          AR: llvm-ar-16
-          RANLIB: llvm-ranlib-16
         run: |
           cd ton-repo
-          cp assembly/native/build-ubuntu-static.sh .
-          chmod +x build-ubuntu-static.sh
-          ./build-ubuntu-static.sh -a -c
+          mkdir -p ~/.ccache
+          export CCACHE_DIR=~/.ccache
+          ccache -M 0
+          if [ ! -d "build" ]; then
+            mkdir build
+            cd build
+          else
+            cd build
+            rm -rf .ninja* CMakeCache.txt
+          fi
+          if [ ! -d "../openssl_3" ]; then
+            git clone https://github.com/openssl/openssl ../openssl_3
+            cd ../openssl_3
+            opensslPath=`pwd`
+            git checkout openssl-3.1.4
+            ./config
+            make build_libs -j$(nproc)
+            test $? -eq 0 || { echo "Can't compile openssl_3"; exit 1; }
+            cd ../build
+          else
+            opensslPath=$(pwd)/../openssl_3
+            echo "Using compiled openssl_3"
+          fi
+          cmake -GNinja -DTON_USE_JEMALLOC=ON .. \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DOPENSSL_ROOT_DIR=$opensslPath \
+          -DOPENSSL_INCLUDE_DIR=$opensslPath/include \
+          -DOPENSSL_CRYPTO_LIBRARY=$opensslPath/libcrypto.so \
+          -DEMULATOR_STATIC=1
+          test $? -eq 0 || { echo "Can't configure ton"; exit 1; }
+          ninja emulator tolkfiftlib
+          test $? -eq 0 || { echo "Can't compile ton"; exit 1; }
+          emulator_deps=$(ninja -n -v emulator | tr ' ' '\n' | grep '\.a$' | sort -u)
+          rm -f libemulator.a
+          {
+            echo "create libemulator.a"
+            echo "addlib emulator/libemulator_static.a"
+            echo "addlib emulator/libemulator.a"
+            for a in $emulator_deps; do
+              echo "addlib $a"
+            done
+            if [ -f /usr/lib/x86_64-linux-gnu/libsodium.a ]; then echo "addlib /usr/lib/x86_64-linux-gnu/libsodium.a"; fi
+            if [ -f "$OPENSSL_CRYPTO_A" ]; then echo "addlib $OPENSSL_CRYPTO_A"; fi
+            if [ -f /usr/lib/x86_64-linux-gnu/libz.a ]; then echo "addlib /usr/lib/x86_64-linux-gnu/libz.a"; fi
+            echo "save"
+            echo "end"
+          } | llvm-ar -M
+          ranlib libemulator.a
+          rm -f libtolk.a
+          llvm-objcopy-16 \
+            --redefine-sym version=tolk_version \
+            tolk/libtolkfiftlib.a \
+            libtolk.a
+          cd ..
+          echo Creating artifacts...
+          rm -rf artifacts
+          mkdir artifacts
+          cp build/libemulator.a artifacts/
+          cp build/libtolk.a artifacts/
+          cp -r crypto/smartcont/tolk-stdlib artifacts/tolk-stdlib
+          cp -r crypto/fift/lib artifacts/fift-stdlib
+          chmod -R +x artifacts/*
 
       - name: Show ccache stats
         if: steps.cache-ton-artifacts.outputs.cache-hit != 'true'
@@ -151,9 +189,6 @@ jobs:
         uses: oven-sh/setup-bun@v1
 
       - name: Build acton binary
-        env:
-          CC: clang-16
-          CXX: clang++-16
         run: |
           just build-ui
           cargo build --bin acton

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,25 +46,12 @@ jobs:
         with:
           tool: nextest,just
 
-      - name: Install LLVM and Clang
-        uses: KyleMayes/install-llvm-action@ebc0426251bc40c7cd31162802432c68818ab8f0 # v2.0.9
-        with:
-          # adds itself to PATH and LD_LIBRARY_PATH
-          # accessible via env.LLVM_PATH
-          version: "16.0.6"
-          cached: true
-          env: true # sets CC and CXX
-
-      - name: Symlink LLVM and Clang
+      - name: Install LLVM and Clang (don't cache)
         run: |
-          ls -s llvm-16 llvm
-          cd ../bin
-          ln -s lld-16 lld
-          ln -s llvm-ar-16 llvm-ar
-          ln -s llvm-ranlib-16 llvm-ranlib
-          ln -s clang-16 clang
-          ln -s clang++-16 clang++
-        working-directory: ${{ env.LLVM_PATH }}/lib
+          wget https://apt.llvm.org/llvm.sh
+          chmod +x llvm.sh
+          sudo ./llvm.sh 16 clang
+          rm llvm.sh
 
       - name: Get TON commit hash
         id: ton-commit
@@ -90,7 +77,8 @@ jobs:
         if: steps.cache-ton-artifacts.outputs.cache-hit != 'true'
         run: |
           sudo apt-get update
-          sudo apt-get install -y build-essential cmake ninja-build pkg-config autoconf automake libssl-dev libtool zlib1g-dev libsecp256k1-dev libmicrohttpd-dev libsodium-dev liblz4-dev libjemalloc-dev ccache graphviz
+          sudo apt-get install -y build-essential cmake ninja-build pkg-config autoconf automake libssl-dev libtool zlib1g-dev libsecp256k1-dev libmicrohttpd-dev libsodium-dev liblz4-dev libjemalloc-dev ccache clang-16 llvm-16 libc++-16-dev libc++abi-16-dev graphviz
+          echo "/usr/lib/llvm-16/bin" >> "$GITHUB_PATH"
 
       - name: Install system dependencies (cache exist)
         if: steps.cache-ton-artifacts.outputs.cache-hit == 'true'
@@ -117,70 +105,16 @@ jobs:
 
       - name: Build TON static libraries
         if: steps.cache-ton-artifacts.outputs.cache-hit != 'true'
+        env:
+          CC: clang-16
+          CXX: clang++-16
+          AR: llvm-ar-16
+          RANLIB: llvm-ranlib-16
         run: |
           cd ton-repo
-          mkdir -p ~/.ccache
-          export CCACHE_DIR=~/.ccache
-          ccache -M 0
-          if [ ! -d "build" ]; then
-            mkdir build
-            cd build
-          else
-            cd build
-            rm -rf .ninja* CMakeCache.txt
-          fi
-          if [ ! -d "../openssl_3" ]; then
-            git clone https://github.com/openssl/openssl ../openssl_3
-            cd ../openssl_3
-            opensslPath=`pwd`
-            git checkout openssl-3.1.4
-            ./config
-            make build_libs -j$(nproc)
-            test $? -eq 0 || { echo "Can't compile openssl_3"; exit 1; }
-            cd ../build
-          else
-            opensslPath=$(pwd)/../openssl_3
-            echo "Using compiled openssl_3"
-          fi
-          cmake -GNinja -DTON_USE_JEMALLOC=ON .. \
-          -DCMAKE_BUILD_TYPE=Release \
-          -DOPENSSL_ROOT_DIR=$opensslPath \
-          -DOPENSSL_INCLUDE_DIR=$opensslPath/include \
-          -DOPENSSL_CRYPTO_LIBRARY=$opensslPath/libcrypto.so \
-          -DEMULATOR_STATIC=1
-          test $? -eq 0 || { echo "Can't configure ton"; exit 1; }
-          ninja emulator tolkfiftlib
-          test $? -eq 0 || { echo "Can't compile ton"; exit 1; }
-          emulator_deps=$(ninja -n -v emulator | tr ' ' '\n' | grep '\.a$' | sort -u)
-          rm -f libemulator.a
-          {
-            echo "create libemulator.a"
-            echo "addlib emulator/libemulator_static.a"
-            echo "addlib emulator/libemulator.a"
-            for a in $emulator_deps; do
-              echo "addlib $a"
-            done
-            if [ -f /usr/lib/x86_64-linux-gnu/libsodium.a ]; then echo "addlib /usr/lib/x86_64-linux-gnu/libsodium.a"; fi
-            if [ -f "$OPENSSL_CRYPTO_A" ]; then echo "addlib $OPENSSL_CRYPTO_A"; fi
-            if [ -f /usr/lib/x86_64-linux-gnu/libz.a ]; then echo "addlib /usr/lib/x86_64-linux-gnu/libz.a"; fi
-            echo "save"
-            echo "end"
-          } | llvm-ar -M
-          ranlib libemulator.a
-          rm -f libtolk.a
-          llvm-objcopy-16 \
-            --redefine-sym version=tolk_version \
-            tolk/libtolkfiftlib.a \
-            libtolk.a
-          cd ..
-          echo Creating artifacts...
-          rm -rf artifacts
-          mkdir artifacts
-          cp build/libemulator.a artifacts/
-          cp build/libtolk.a artifacts/
-          cp -r crypto/smartcont/tolk-stdlib artifacts/tolk-stdlib
-          cp -r crypto/fift/lib artifacts/fift-stdlib
-          chmod -R +x artifacts/*
+          cp assembly/native/build-ubuntu-static.sh .
+          chmod +x build-ubuntu-static.sh
+          ./build-ubuntu-static.sh -a -c
 
       - name: Show ccache stats
         if: steps.cache-ton-artifacts.outputs.cache-hit != 'true'
@@ -200,6 +134,9 @@ jobs:
         uses: oven-sh/setup-bun@v1
 
       - name: Build acton binary
+        env:
+          CC: clang-16
+          CXX: clang++-16
         run: |
           just build-ui
           cargo build --bin acton

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,6 +45,13 @@ jobs:
         with:
           tool: nextest,just
 
+      - name: Install LLVM and Clang
+        run: |
+          wget https://apt.llvm.org/llvm.sh
+          chmod +x llvm.sh
+          sudo ./llvm.sh 16 clang
+          rm llvm.sh
+
       - name: Get TON commit hash
         id: ton-commit
         run: |
@@ -63,14 +70,6 @@ jobs:
 
       - name: Check cache hit
         run: echo '${{ steps.cache-ton-artifacts.outputs.cache-hit }}'
-
-      - name: Install LLVM and Clang
-        if: steps.cache-ton-artifacts.outputs.cache-hit != 'true'
-        run: |
-          wget https://apt.llvm.org/llvm.sh
-          chmod +x llvm.sh
-          sudo ./llvm.sh 16 clang
-          rm llvm.sh
 
       - name: Install system dependencies (cache not exist)
         if: steps.cache-ton-artifacts.outputs.cache-hit != 'true'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,7 +57,6 @@ jobs:
 
       - name: Symlink LLVM and Clang
         run: |
-          sudo ln -s libclang-11.so.1 /lib/x86_64-linux-gnu/libclang.so
           ls -s llvm-16 llvm
           cd ../bin
           ln -s lld-16 lld

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -132,15 +132,17 @@ jobs:
         uses: oven-sh/setup-bun@v1
 
       - name: Build acton binary
-        # env:
-        #   CC: gcc
-        #   CXX: g++
         run: |
           export CC=clang-16
           export CXX=clang++-16
           just build-ui
-          ldd --version
-          cargo build --bin acton || {
+          RUSTFLAGS="-C target-feature=-crt-static" cargo build --bin acton || {
+            tmp=$(mktemp -d);
+            pushd "$tmp";
+            wget https://ziglang.org/download/0.15.2/zig-x86_64-linux-0.15.2.tar.xz;
+            tar xJf zig-x86_64-linux-0.15.2.tar.xz
+            export PATH="$PATH:$tmp/zig-x86_64-linux-0.15.2";
+            popd;
             cargo install cargo-zigbuild;
             cargo zigbuild --release --target x86_64-unknown-linux-gnu.2.35;
           }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -103,11 +103,12 @@ jobs:
 
       - name: Build TON static libraries
         if: steps.cache-ton-artifacts.outputs.cache-hit != 'true'
+        env:
+          CC: clang-16
+          CXX: clang++-16
+          AR: llvm-ar-16
+          RANLIB: llvm-ranlib-16
         run: |
-          export CC=clang-16
-          export CXX=clang++-16
-          export AR=llvm-ar-16
-          export RANLIB=llvm-ranlib-16
           cd ton-repo
           cp assembly/native/build-ubuntu-static.sh .
           chmod +x build-ubuntu-static.sh
@@ -131,9 +132,10 @@ jobs:
         uses: oven-sh/setup-bun@v1
 
       - name: Build acton binary
+        env:
+          CC: clang-16
+          CXX: clang++-16
         run: |
-          export CC=clang-16
-          export CXX=clang++-16
           just build-ui
           cargo build --bin acton
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   build-linux:
-    runs-on: ubicloud-standard-4
+    runs-on: ubicloud-standard-4-ubuntu-2204
     if: true
 
     outputs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
   build-linux:
     strategy:
       matrix:
-        os: [ubicloud-standard-4-ubuntu-2204]
+        os: [ ubicloud-standard-4-ubuntu-2204 ]
     runs-on: ${{ matrix.os }}
     if: true
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,7 +62,7 @@ jobs:
         run: echo '${{ steps.cache-ton-artifacts.outputs.cache-hit }}'
 
       - name: Install system dependencies (cache not exist)
-        if: steps.cache-ton-artifacts.outputs.cache-hit != 'true'
+        # if: steps.cache-ton-artifacts.outputs.cache-hit != 'true'
         run: |
           sudo apt-get update
           sudo apt-get install -y build-essential cmake ninja-build pkg-config autoconf automake libssl-dev libtool zlib1g-dev libsecp256k1-dev libmicrohttpd-dev libsodium-dev liblz4-dev libjemalloc-dev ccache clang-16 llvm-16 libc++-16-dev libc++abi-16-dev graphviz
@@ -75,14 +75,14 @@ jobs:
           sudo apt-get install -y graphviz
 
       - name: Maximize Build Space
-        if: steps.cache-ton-artifacts.outputs.cache-hit != 'true'
+        # if: steps.cache-ton-artifacts.outputs.cache-hit != 'true'
         uses: jlumbroso/free-disk-space@v1.3.1
         with:
           tool-cache: false
           large-packages: false
 
       - name: Clone TON repository
-        if: steps.cache-ton-artifacts.outputs.cache-hit != 'true'
+        # if: steps.cache-ton-artifacts.outputs.cache-hit != 'true'
         uses: actions/checkout@v6
         with:
           repository: i582/ton
@@ -92,7 +92,7 @@ jobs:
           path: ton-repo
 
       - name: Build TON static libraries
-        if: steps.cache-ton-artifacts.outputs.cache-hit != 'true'
+        # if: steps.cache-ton-artifacts.outputs.cache-hit != 'true'
         run: |
           export CC=clang-16
           export CXX=clang++-16
@@ -104,7 +104,7 @@ jobs:
           ./build-ubuntu-static.sh -a -c
 
       - name: Show ccache stats
-        if: steps.cache-ton-artifacts.outputs.cache-hit != 'true'
+        # if: steps.cache-ton-artifacts.outputs.cache-hit != 'true'
         run: ccache -s
 
       - name: Copy TON artifacts to objs directory

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,6 +55,18 @@ jobs:
           cached: true
           env: true # sets CC and CXX
 
+      - name: Symlink LLVM and Clang
+        run: |
+          sudo ln -s libclang-11.so.1 /lib/x86_64-linux-gnu/libclang.so
+          ls -s llvm-16 llvm
+          cd ../bin
+          ln -s lld-16 lld
+          ln -s llvm-ar-16 llvm-ar
+          ln -s llvm-ranlib-16 llvm-ranlib
+          ln -s clang-16 clang
+          ln -s clang++-16 clang++
+        working-directory: ${{ env.LLVM_PATH }}/lib
+
       - name: Get TON commit hash
         id: ton-commit
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,10 @@ permissions:
 
 jobs:
   build-linux:
-    runs-on: ubicloud-standard-4-ubuntu-2204
+    strategy:
+      matrix:
+        os: [ubicloud-standard-4-ubuntu-2204]
+    runs-on: ${{ matrix.os }}
     if: true
 
     outputs:
@@ -55,14 +58,14 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ton-repo/artifacts
-          key: ton-artifacts-${{ runner.os }}-${{ steps.ton-commit.outputs.commit }}
-          restore-keys: ton-artifacts-${{ runner.os }}-
+          key: ton-artifacts-${{ matrix.os }}-${{ steps.ton-commit.outputs.commit }}
+          restore-keys: ton-artifacts-${{ matrix.os }}-
 
       - name: Check cache hit
         run: echo '${{ steps.cache-ton-artifacts.outputs.cache-hit }}'
 
       - name: Install LLVM and Clang
-        # if: steps.cache-ton-artifacts.outputs.cache-hit != 'true'
+        if: steps.cache-ton-artifacts.outputs.cache-hit != 'true'
         run: |
           wget https://apt.llvm.org/llvm.sh
           chmod +x llvm.sh
@@ -70,7 +73,7 @@ jobs:
           rm llvm.sh
 
       - name: Install system dependencies (cache not exist)
-        # if: steps.cache-ton-artifacts.outputs.cache-hit != 'true'
+        if: steps.cache-ton-artifacts.outputs.cache-hit != 'true'
         run: |
           sudo apt-get update
           sudo apt-get install -y build-essential cmake ninja-build pkg-config autoconf automake libssl-dev libtool zlib1g-dev libsecp256k1-dev libmicrohttpd-dev libsodium-dev liblz4-dev libjemalloc-dev ccache clang-16 llvm-16 libc++-16-dev libc++abi-16-dev graphviz
@@ -83,14 +86,14 @@ jobs:
           sudo apt-get install -y graphviz
 
       - name: Maximize Build Space
-        # if: steps.cache-ton-artifacts.outputs.cache-hit != 'true'
+        if: steps.cache-ton-artifacts.outputs.cache-hit != 'true'
         uses: jlumbroso/free-disk-space@v1.3.1
         with:
           tool-cache: false
           large-packages: false
 
       - name: Clone TON repository
-        # if: steps.cache-ton-artifacts.outputs.cache-hit != 'true'
+        if: steps.cache-ton-artifacts.outputs.cache-hit != 'true'
         uses: actions/checkout@v6
         with:
           repository: i582/ton
@@ -100,7 +103,7 @@ jobs:
           path: ton-repo
 
       - name: Build TON static libraries
-        # if: steps.cache-ton-artifacts.outputs.cache-hit != 'true'
+        if: steps.cache-ton-artifacts.outputs.cache-hit != 'true'
         run: |
           export CC=clang-16
           export CXX=clang++-16
@@ -112,7 +115,7 @@ jobs:
           ./build-ubuntu-static.sh -a -c
 
       - name: Show ccache stats
-        # if: steps.cache-ton-artifacts.outputs.cache-hit != 'true'
+        if: steps.cache-ton-artifacts.outputs.cache-hit != 'true'
         run: ccache -s
 
       - name: Copy TON artifacts to objs directory
@@ -129,11 +132,14 @@ jobs:
         uses: oven-sh/setup-bun@v1
 
       - name: Build acton binary
-        env:
-          CC: gcc
-          CXX: g++
+        # env:
+        #   CC: gcc
+        #   CXX: g++
         run: |
+          export CC=clang-16
+          export CXX=clang++-16
           just build-ui
+          ldd --version
           cargo build --bin acton
 
       - name: Test acton binary

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,6 +35,7 @@ jobs:
       - name: Cache Cargo
         uses: Swatinem/rust-cache@v2
         with:
+          key: ${{ matrix.os }}
           save-if: ${{ github.ref == 'refs/heads/master' }}
 
       - name: Install Rust
@@ -44,13 +45,6 @@ jobs:
         uses: taiki-e/install-action@v2
         with:
           tool: nextest,just
-
-      - name: Install LLVM and Clang
-        run: |
-          wget https://apt.llvm.org/llvm.sh
-          chmod +x llvm.sh
-          sudo ./llvm.sh 16 clang
-          rm llvm.sh
 
       - name: Get TON commit hash
         id: ton-commit
@@ -68,8 +62,31 @@ jobs:
           key: ton-artifacts-${{ matrix.os }}-${{ steps.ton-commit.outputs.commit }}
           restore-keys: ton-artifacts-${{ matrix.os }}-
 
-      - name: Check cache hit
-        run: echo '${{ steps.cache-ton-artifacts.outputs.cache-hit }}'
+      - name: Cache LLVM and Clang
+        id: cache-llvm
+        uses: actions/cache@v5
+        with:
+          path: |
+            /usr/lib/llvm-16
+            /usr/bin/lld-16
+            /usr/bin/clang-16
+            /usr/bin/clang++-16
+            /usr/bin/llvm-ar-16
+            /usr/bin/llvm-ranlib-16
+          key: llvm-${{ matrix.os }}
+
+      - name: Check cache hits
+        run: |
+          echo 'TON artifacts: ${{ steps.cache-ton-artifacts.outputs.cache-hit }}'
+          echo 'LLVM and Clang: ${{ steps.cache-llvm.outputs.cache-hit }}'
+
+      - name: Install LLVM and Clang
+        if: steps.cache-llvm.outputs.cache-hit != 'true'
+        run: |
+          wget https://apt.llvm.org/llvm.sh
+          chmod +x llvm.sh
+          sudo ./llvm.sh 16 clang
+          rm llvm.sh
 
       - name: Install system dependencies (cache not exist)
         if: steps.cache-ton-artifacts.outputs.cache-hit != 'true'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -135,12 +135,7 @@ jobs:
           export CC=clang-16
           export CXX=clang++-16
           just build-ui
-          # Flags here enforce dynamic linking against the system glibc version.
-          # Such linking is important for Tree-sitter and OpenSSL, among others.
-          # Alternative place for these flags could be .cargo/config.toml:
-          #     [target.x86_64-unknown-linux-gnu]
-          #     rustflags = ["-C", "target-feature=-crt-static"]
-          RUSTFLAGS="-C target-feature=-crt-static" cargo build --bin acton
+          cargo build --bin acton
 
       - name: Test acton binary
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -136,7 +136,7 @@ jobs:
           export CC=clang-16
           export CXX=clang++-16
           just build-ui
-          # Flags here enforce static linking against the system glibc version.
+          # Flags here enforce dynamic linking against the system glibc version.
           # Such linking is important for Tree-sitter and OpenSSL, among others.
           # Alternative place for these flags could be .cargo/config.toml:
           #     [target.x86_64-unknown-linux-gnu]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -140,7 +140,10 @@ jobs:
           export CXX=clang++-16
           just build-ui
           ldd --version
-          cargo build --bin acton
+          cargo build --bin acton || {
+            cargo install cargo-zigbuild;
+            cargo zigbuild --release --target x86_64-unknown-linux-gnu.2.35;
+          }
 
       - name: Test acton binary
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,6 +61,14 @@ jobs:
       - name: Check cache hit
         run: echo '${{ steps.cache-ton-artifacts.outputs.cache-hit }}'
 
+      - name: Install LLVM and Clang
+        # if: steps.cache-ton-artifacts.outputs.cache-hit != 'true'
+        run: |
+          wget https://apt.llvm.org/llvm.sh
+          chmod +x llvm.sh
+          ./llvm.sh 16 clang
+          rm llvm.sh
+
       - name: Install system dependencies (cache not exist)
         # if: steps.cache-ton-artifacts.outputs.cache-hit != 'true'
         run: |
@@ -94,16 +102,11 @@ jobs:
       - name: Build TON static libraries
         # if: steps.cache-ton-artifacts.outputs.cache-hit != 'true'
         run: |
-          cd ton-repo
-          # LLVM & Clang
-          wget https://apt.llvm.org/llvm.sh
-          chmod +x llvm.sh
-          ./llvm.sh 16 clang
           export CC=clang-16
           export CXX=clang++-16
           export AR=llvm-ar-16
           export RANLIB=llvm-ranlib-16
-          # Static libraries
+          cd ton-repo
           cp assembly/native/build-ubuntu-static.sh .
           chmod +x build-ubuntu-static.sh
           ./build-ubuntu-static.sh -a -c

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,7 +66,7 @@ jobs:
         run: |
           wget https://apt.llvm.org/llvm.sh
           chmod +x llvm.sh
-          ./llvm.sh 16 clang
+          sudo ./llvm.sh 16 clang
           rm llvm.sh
 
       - name: Install system dependencies (cache not exist)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,11 +94,16 @@ jobs:
       - name: Build TON static libraries
         # if: steps.cache-ton-artifacts.outputs.cache-hit != 'true'
         run: |
+          cd ton-repo
+          # LLVM & Clang
+          wget https://apt.llvm.org/llvm.sh
+          chmod +x llvm.sh
+          ./llvm.sh 16 clang
           export CC=clang-16
           export CXX=clang++-16
           export AR=llvm-ar-16
           export RANLIB=llvm-ranlib-16
-          cd ton-repo
+          # Static libraries
           cp assembly/native/build-ubuntu-static.sh .
           chmod +x build-ubuntu-static.sh
           ./build-ubuntu-static.sh -a -c

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -136,16 +136,12 @@ jobs:
           export CC=clang-16
           export CXX=clang++-16
           just build-ui
-          RUSTFLAGS="-C target-feature=-crt-static" cargo build --bin acton || {
-            tmp=$(mktemp -d);
-            pushd "$tmp";
-            wget https://ziglang.org/download/0.15.2/zig-x86_64-linux-0.15.2.tar.xz;
-            tar xJf zig-x86_64-linux-0.15.2.tar.xz
-            export PATH="$PATH:$tmp/zig-x86_64-linux-0.15.2";
-            popd;
-            cargo install cargo-zigbuild;
-            cargo zigbuild --release --target x86_64-unknown-linux-gnu.2.35;
-          }
+          # Flags here enforce static linking against the system glibc version.
+          # Such linking is important for Tree-sitter and OpenSSL, among others.
+          # Alternative place for these flags could be .cargo/config.toml:
+          #     [target.x86_64-unknown-linux-gnu]
+          #     rustflags = ["-C", "target-feature=-crt-static"]
+          RUSTFLAGS="-C target-feature=-crt-static" cargo build --bin acton
 
       - name: Test acton binary
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,6 +75,8 @@ jobs:
             /usr/bin/llvm-ranlib-16
           key: llvm-${{ matrix.os }}
 
+      - run: echo nothingburger
+
       - name: Check cache hits
         run: |
           echo 'TON artifacts: ${{ steps.cache-ton-artifacts.outputs.cache-hit }}'

--- a/.github/workflows/grammars.yml
+++ b/.github/workflows/grammars.yml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
   tree-sitter-grammars:
     name: Test tree-sitter
-    runs-on: ubicloud-standard-4
+    runs-on: ubicloud-standard-4-ubuntu-2204
     if: true
 
     steps:

--- a/.github/workflows/grammars.yml
+++ b/.github/workflows/grammars.yml
@@ -19,7 +19,10 @@ concurrency:
 jobs:
   tree-sitter-grammars:
     name: Test tree-sitter
-    runs-on: ubicloud-standard-4-ubuntu-2204
+    strategy:
+      matrix:
+        os: [ubicloud-standard-4-ubuntu-2204]
+    runs-on: ${{ matrix.os }}
     if: true
 
     steps:

--- a/.github/workflows/grammars.yml
+++ b/.github/workflows/grammars.yml
@@ -19,10 +19,7 @@ concurrency:
 jobs:
   tree-sitter-grammars:
     name: Test tree-sitter
-    strategy:
-      matrix:
-        os: [ubicloud-standard-4-ubuntu-2204]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubicloud-standard-4-ubuntu-2204
     if: true
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,7 +130,9 @@ jobs:
           export CC=clang-16
           export CXX=clang++-16
           just build-ui
-          cargo build --profile release-size --bin acton
+          # Flags here enforce static linking against the system glibc version.
+          # Such linking is important for Tree-sitter and OpenSSL, among others.
+          RUSTFLAGS="-C target-feature=-crt-static" cargo build --profile release-size --bin acton
 
       - name: Test acton binary
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,13 @@ jobs:
         with:
           tool: nextest,just
 
+      - name: Install LLVM and Clang
+        run: |
+          wget https://apt.llvm.org/llvm.sh
+          chmod +x llvm.sh
+          sudo ./llvm.sh 16 clang
+          rm llvm.sh
+
       - name: Get TON commit hash
         id: ton-commit
         run: |
@@ -58,14 +65,6 @@ jobs:
 
       - name: Check cache hit
         run: echo '${{ steps.cache-ton-artifacts.outputs.cache-hit }}'
-
-      - name: Install LLVM and Clang
-        if: steps.cache-ton-artifacts.outputs.cache-hit != 'true'
-        run: |
-          wget https://apt.llvm.org/llvm.sh
-          chmod +x llvm.sh
-          sudo ./llvm.sh 16 clang
-          rm llvm.sh
 
       - name: Install system dependencies (cache not exist)
         if: steps.cache-ton-artifacts.outputs.cache-hit != 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
         with:
           tool: nextest,just
 
-      - name: Install LLVM and Clang
+      - name: Install LLVM and Clang (don't cache)
         run: |
           wget https://apt.llvm.org/llvm.sh
           chmod +x llvm.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,10 @@ permissions:
 
 jobs:
   build-linux:
-    runs-on: ubicloud-standard-4-ubuntu-2204
+    strategy:
+      matrix:
+        os: [ubicloud-standard-4-ubuntu-2204]
+    runs-on: ${{ matrix.os }}
     if: true
 
     outputs:
@@ -50,11 +53,19 @@ jobs:
         uses: actions/cache/restore@v5
         with:
           path: ton-repo/artifacts
-          key: ton-artifacts-${{ runner.os }}-${{ steps.ton-commit.outputs.commit }}
-          restore-keys: ton-artifacts-${{ runner.os }}-
+          key: ton-artifacts-${{ matrix.os }}-${{ steps.ton-commit.outputs.commit }}
+          restore-keys: ton-artifacts-${{ matrix.os }}-
 
       - name: Check cache hit
         run: echo '${{ steps.cache-ton-artifacts.outputs.cache-hit }}'
+
+      - name: Install LLVM and Clang
+        if: steps.cache-ton-artifacts.outputs.cache-hit != 'true'
+        run: |
+          wget https://apt.llvm.org/llvm.sh
+          chmod +x llvm.sh
+          sudo ./llvm.sh 16 clang
+          rm llvm.sh
 
       - name: Install system dependencies (cache not exist)
         if: steps.cache-ton-artifacts.outputs.cache-hit != 'true'
@@ -115,10 +126,12 @@ jobs:
         uses: oven-sh/setup-bun@v1
 
       - name: Build acton binary
-        env:
-          CC: gcc
-          CXX: g++
+        # env:
+        #   CC: gcc
+        #   CXX: g++
         run: |
+          export CC=clang-16
+          export CXX=clang++-16
           just build-ui
           cargo build --profile release-size --bin acton
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   build-linux:
-    runs-on: ubicloud-standard-4
+    runs-on: ubicloud-standard-4-ubuntu-2204
     if: true
 
     outputs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,7 +130,7 @@ jobs:
           export CC=clang-16
           export CXX=clang++-16
           just build-ui
-          # Flags here enforce static linking against the system glibc version.
+          # Flags here enforce dynamic linking against the system glibc version.
           # Such linking is important for Tree-sitter and OpenSSL, among others.
           RUSTFLAGS="-C target-feature=-crt-static" cargo build --profile release-size --bin acton
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,13 +40,6 @@ jobs:
         with:
           tool: nextest,just
 
-      - name: Install LLVM and Clang
-        run: |
-          wget https://apt.llvm.org/llvm.sh
-          chmod +x llvm.sh
-          sudo ./llvm.sh 16 clang
-          rm llvm.sh
-
       - name: Get TON commit hash
         id: ton-commit
         run: |
@@ -63,8 +56,31 @@ jobs:
           key: ton-artifacts-${{ matrix.os }}-${{ steps.ton-commit.outputs.commit }}
           restore-keys: ton-artifacts-${{ matrix.os }}-
 
-      - name: Check cache hit
-        run: echo '${{ steps.cache-ton-artifacts.outputs.cache-hit }}'
+      - name: Cache LLVM and Clang
+        id: cache-llvm
+        uses: actions/cache@v5
+        with:
+          path: |
+            /usr/lib/llvm-16
+            /usr/bin/lld-16
+            /usr/bin/clang-16
+            /usr/bin/clang++-16
+            /usr/bin/llvm-ar-16
+            /usr/bin/llvm-ranlib-16
+          key: llvm-${{ matrix.os }}
+
+      - name: Check cache hits
+        run: |
+          echo 'TON artifacts: ${{ steps.cache-ton-artifacts.outputs.cache-hit }}'
+          echo 'LLVM and Clang: ${{ steps.cache-llvm.outputs.cache-hit }}'
+
+      - name: Install LLVM and Clang
+        if: steps.cache-llvm.outputs.cache-hit != 'true'
+        run: |
+          wget https://apt.llvm.org/llvm.sh
+          chmod +x llvm.sh
+          sudo ./llvm.sh 16 clang
+          rm llvm.sh
 
       - name: Install system dependencies (cache not exist)
         if: steps.cache-ton-artifacts.outputs.cache-hit != 'true'
@@ -97,11 +113,12 @@ jobs:
 
       - name: Build TON static libraries
         if: steps.cache-ton-artifacts.outputs.cache-hit != 'true'
+        env:
+          CC: clang-16
+          CXX: clang++-16
+          AR: llvm-ar-16
+          RANLIB: llvm-ranlib-16
         run: |
-          export CC=clang-16
-          export CXX=clang++-16
-          export AR=llvm-ar-16
-          export RANLIB=llvm-ranlib-16
           cd ton-repo
           cp assembly/native/build-ubuntu-static.sh .
           chmod +x build-ubuntu-static.sh
@@ -125,9 +142,10 @@ jobs:
         uses: oven-sh/setup-bun@v1
 
       - name: Build acton binary
+        env:
+          CC: clang-16
+          CXX: clang++-16
         run: |
-          export CC=clang-16
-          export CXX=clang++-16
           just build-ui
           cargo build --profile release-size --bin acton
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,13 @@ jobs:
         with:
           tool: nextest,just
 
+      - name: Install LLVM and Clang
+        run: |
+          wget https://apt.llvm.org/llvm.sh
+          chmod +x llvm.sh
+          sudo ./llvm.sh 16 clang
+          rm llvm.sh
+
       - name: Get TON commit hash
         id: ton-commit
         run: |
@@ -56,31 +63,9 @@ jobs:
           key: ton-artifacts-${{ matrix.os }}-${{ steps.ton-commit.outputs.commit }}
           restore-keys: ton-artifacts-${{ matrix.os }}-
 
-      - name: Cache LLVM and Clang
-        id: cache-llvm
-        uses: actions/cache@v5
-        with:
-          path: |
-            /usr/lib/llvm-16
-            /usr/bin/lld-16
-            /usr/bin/clang-16
-            /usr/bin/clang++-16
-            /usr/bin/llvm-ar-16
-            /usr/bin/llvm-ranlib-16
-          key: llvm-${{ matrix.os }}
-
       - name: Check cache hits
         run: |
           echo 'TON artifacts: ${{ steps.cache-ton-artifacts.outputs.cache-hit }}'
-          echo 'LLVM and Clang: ${{ steps.cache-llvm.outputs.cache-hit }}'
-
-      - name: Install LLVM and Clang
-        if: steps.cache-llvm.outputs.cache-hit != 'true'
-        run: |
-          wget https://apt.llvm.org/llvm.sh
-          chmod +x llvm.sh
-          sudo ./llvm.sh 16 clang
-          rm llvm.sh
 
       - name: Install system dependencies (cache not exist)
         if: steps.cache-ton-artifacts.outputs.cache-hit != 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,9 +129,7 @@ jobs:
           export CC=clang-16
           export CXX=clang++-16
           just build-ui
-          # Flags here enforce dynamic linking against the system glibc version.
-          # Such linking is important for Tree-sitter and OpenSSL, among others.
-          RUSTFLAGS="-C target-feature=-crt-static" cargo build --profile release-size --bin acton
+          cargo build --profile release-size --bin acton
 
       - name: Test acton binary
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
   build-linux:
     strategy:
       matrix:
-        os: [ubicloud-standard-4-ubuntu-2204]
+        os: [ ubicloud-standard-4-ubuntu-2204 ]
     runs-on: ${{ matrix.os }}
     if: true
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,9 +126,6 @@ jobs:
         uses: oven-sh/setup-bun@v1
 
       - name: Build acton binary
-        # env:
-        #   CC: gcc
-        #   CXX: g++
         run: |
           export CC=clang-16
           export CXX=clang++-16


### PR DESCRIPTION
Closes #528

> You can append `-ubuntu-2204` or `-ubuntu-2404` to explicitly set the operating system.
> From: https://www.ubicloud.com/docs/github-actions-integration/runner-types#available-labels

It took a bit more than a mere append, and I had to explicitly setup llvm/clang and force certain C compilation flags to be passed during `cargo build`, but in the end we have a build of `acton` binary that is dynamically linked to glibc version 2.35. That is, resulting `acton` binary should work well on Ubuntu 22.04 and all derivatives.