### PR TITLE
chore(func2tolk): diable update notifier

### DIFF
--- a/src/commands/func2tolk/mod.rs
+++ b/src/commands/func2tolk/mod.rs
@@ -14,6 +14,7 @@ pub fn func2tolk_cmd(
         TempDir::new().context("Failed to create a temporary npm cache directory")?;
     let mut cmd = Command::new("npx");
     cmd.env("npm_config_cache", npm_cache_dir.path())
+        .env("npm_config_update_notifier", "false")
         .arg("--yes")
         .arg(CONVERT_FUNC_TO_TOLK_NPM_PACKAGE);
     if warnings_as_comments {


### PR DESCRIPTION
disable message:
```
npm notice
npm notice New minor version of npm available! 11.7.0 -> 11.11.1
npm notice Changelog: https://github.com/npm/cli/releases/tag/v11.11.1
npm notice To update run: npm install -g npm@11.11.1
npm notice
```