### PR TITLE
chore(ci): split the release into the build and the release creation

### DIFF
--- a/.github/workflows/build-release-binaries.yml
+++ b/.github/workflows/build-release-binaries.yml
@@ -14,6 +14,7 @@ concurrency:
 jobs:
   build-linux:
     name: Build Linux (${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
     strategy:
       matrix:
         include:
@@ -23,7 +24,6 @@ jobs:
           - runner: ubicloud-standard-4-arm-ubuntu-2204
             os: linux
             arch: aarch64
-    runs-on: ${{ matrix.runner }}
 
     permissions:
       contents: read
@@ -86,23 +86,25 @@ jobs:
           ./target/release-size/acton --help
 
       - name: Prepare Acton archive
-        if: github.event_name == 'push'
         env:
           ARCHIVE_NAME: acton-${{ matrix.os }}-${{ matrix.arch }}.tar.gz
         run: |
           mkdir -p dist
           tar -czf "dist/${ARCHIVE_NAME}" -C target/release-size acton
+          shasum -a 256 "dist/${ARCHIVE_NAME}" > "dist/${ARCHIVE_NAME}.sha256"
 
       - name: Upload Acton archive as artifact
-        if: github.event_name == 'push'
         uses: actions/upload-artifact@v7
         with:
           name: acton-${{ matrix.os }}-${{ matrix.arch }}
-          path: dist/acton-${{ matrix.os }}-${{ matrix.arch }}.tar.gz
+          path: |
+            dist/acton-${{ matrix.os }}-${{ matrix.arch }}.tar.gz
+            dist/acton-${{ matrix.os }}-${{ matrix.arch }}.tar.gz.sha256
           retention-days: 1
 
   build-macos:
     name: Build macOS (${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
     strategy:
       matrix:
         include:
@@ -112,7 +114,6 @@ jobs:
           - runner: macos-15
             os: macos
             arch: aarch64
-    runs-on: ${{ matrix.runner }}
 
     permissions:
       contents: read
@@ -165,17 +166,18 @@ jobs:
           ./target/release-size/acton --help
 
       - name: Prepare Acton archive
-        if: github.event_name == 'push'
         env:
           ARCHIVE_NAME: acton-${{ matrix.os }}-${{ matrix.arch }}.tar.gz
         run: |
           mkdir -p dist
           tar -czf "dist/${ARCHIVE_NAME}" -C target/release-size acton
+          shasum -a 256 "dist/${ARCHIVE_NAME}" > "dist/${ARCHIVE_NAME}.sha256"
 
       - name: Upload Acton archive as artifact
-        if: github.event_name == 'push'
         uses: actions/upload-artifact@v7
         with:
           name: acton-${{ matrix.os }}-${{ matrix.arch }}
-          path: dist/acton-${{ matrix.os }}-${{ matrix.arch }}.tar.gz
+          path: |
+            dist/acton-${{ matrix.os }}-${{ matrix.arch }}.tar.gz
+            dist/acton-${{ matrix.os }}-${{ matrix.arch }}.tar.gz.sha256
           retention-days: 1

--- a/.github/workflows/build-release-binaries.yml
+++ b/.github/workflows/build-release-binaries.yml
@@ -24,6 +24,8 @@ jobs:
           - runner: ubicloud-standard-4-arm-ubuntu-2204
             os: linux
             arch: aarch64
+    env:
+      TARGET_NAME: ${{ matrix.os }}-${{ matrix.arch }}
 
     permissions:
       contents: read
@@ -59,14 +61,14 @@ jobs:
       - name: Download TON objects archive
         env:
           GH_TOKEN: ${{ github.token }}
-          ARCHIVE_NAME: ton-objs-${{ matrix.os }}-${{ matrix.arch }}.tar.gz
         run: |
+          archive_name="ton-objs-${TARGET_NAME}.tar.gz"
           mkdir -p objs
           gh release download trunk-objs \
             --repo "${GITHUB_REPOSITORY}" \
-            --pattern "${ARCHIVE_NAME}" \
+            --pattern "${archive_name}" \
             --dir "${RUNNER_TEMP}"
-          tar -C objs -xzf "${RUNNER_TEMP}/${ARCHIVE_NAME}"
+          tar -C objs -xzf "${RUNNER_TEMP}/${archive_name}"
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@ecf28ddc73e819eb6fa29df6b34ef8921c743461 # v2.1.3
@@ -86,22 +88,21 @@ jobs:
           ./target/release-size/acton --help
 
       - name: Prepare Acton archive
-        env:
-          ARTIFACTS_DIR: acton-${{ matrix.os }}-${{ matrix.arch }}
-          ARCHIVE_NAME: acton-${{ matrix.os }}-${{ matrix.arch }}.tar.gz
         run: |
-          mkdir -p "${ARTIFACTS_DIR}"
-          cp "target/release-size/acton" "${ARTIFACTS_DIR}/acton"
-          tar -czf "${ARCHIVE_NAME}" -C "${ARTIFACTS_DIR}" .
-          shasum -a 256 "${ARCHIVE_NAME}" > "${ARCHIVE_NAME}.sha256"
+          artifacts_dir="acton-${TARGET_NAME}"
+          archive_name="${artifacts_dir}.tar.gz"
+          mkdir -p "${artifacts_dir}"
+          cp "target/release-size/acton" "${artifacts_dir}/acton"
+          tar -czvf "${archive_name}" -C "${artifacts_dir}" .
+          shasum -a 256 "${archive_name}" > "${archive_name}.sha256"
 
       - name: Upload Acton archive as artifact
         uses: actions/upload-artifact@v7
         with:
-          name: artifacts-${{ matrix.os }}-${{ matrix.arch }}
+          name: artifacts-${{ env.TARGET_NAME }}
           path: |
-            acton-${{ matrix.os }}-${{ matrix.arch }}.tar.gz
-            acton-${{ matrix.os }}-${{ matrix.arch }}.tar.gz.sha256
+            acton-${{ env.TARGET_NAME }}.tar.gz
+            acton-${{ env.TARGET_NAME }}.tar.gz.sha256
           retention-days: 1
 
   build-macos:
@@ -116,6 +117,8 @@ jobs:
           - runner: macos-15
             os: macos
             arch: aarch64
+    env:
+      TARGET_NAME: ${{ matrix.os }}-${{ matrix.arch }}
 
     permissions:
       contents: read
@@ -144,14 +147,14 @@ jobs:
       - name: Download TON objects archive
         env:
           GH_TOKEN: ${{ github.token }}
-          ARCHIVE_NAME: ton-objs-${{ matrix.os }}-${{ matrix.arch }}.tar.gz
         run: |
+          archive_name="ton-objs-${TARGET_NAME}.tar.gz"
           mkdir -p objs
           gh release download trunk-objs \
             --repo "${GITHUB_REPOSITORY}" \
-            --pattern "${ARCHIVE_NAME}" \
+            --pattern "${archive_name}" \
             --dir "${RUNNER_TEMP}"
-          tar -C objs -xzf "${RUNNER_TEMP}/${ARCHIVE_NAME}"
+          tar -C objs -xzf "${RUNNER_TEMP}/${archive_name}"
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@ecf28ddc73e819eb6fa29df6b34ef8921c743461 # v2.1.3
@@ -168,20 +171,19 @@ jobs:
           ./target/release-size/acton --help
 
       - name: Prepare Acton archive
-        env:
-          ARTIFACTS_DIR: acton-${{ matrix.os }}-${{ matrix.arch }}
-          ARCHIVE_NAME: acton-${{ matrix.os }}-${{ matrix.arch }}.tar.gz
         run: |
-          mkdir -p "${ARTIFACTS_DIR}"
-          cp "target/release-size/acton" "${ARTIFACTS_DIR}/acton"
-          tar -czf "${ARCHIVE_NAME}" -C "${ARTIFACTS_DIR}" .
-          shasum -a 256 "${ARCHIVE_NAME}" > "${ARCHIVE_NAME}.sha256"
+          artifacts_dir="acton-${TARGET_NAME}"
+          archive_name="${artifacts_dir}.tar.gz"
+          mkdir -p "${artifacts_dir}"
+          cp "target/release-size/acton" "${artifacts_dir}/acton"
+          tar -czvf "${archive_name}" -C "${artifacts_dir}" .
+          shasum -a 256 "${archive_name}" > "${archive_name}.sha256"
 
       - name: Upload Acton archive as artifact
         uses: actions/upload-artifact@v7
         with:
-          name: artifacts-${{ matrix.os }}-${{ matrix.arch }}
+          name: artifacts-${{ env.TARGET_NAME }}
           path: |
-            acton-${{ matrix.os }}-${{ matrix.arch }}.tar.gz
-            acton-${{ matrix.os }}-${{ matrix.arch }}.tar.gz.sha256
+            acton-${{ env.TARGET_NAME }}.tar.gz
+            acton-${{ env.TARGET_NAME }}.tar.gz.sha256
           retention-days: 1

--- a/.github/workflows/build-release-binaries.yml
+++ b/.github/workflows/build-release-binaries.yml
@@ -1,0 +1,181 @@
+name: "Build release binaries"
+
+on:
+  workflow_call:
+    inputs:
+      plan:
+        required: false
+        type: string
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-linux:
+    name: Build Linux (${{ matrix.arch }})
+    strategy:
+      matrix:
+        include:
+          - runner: ubicloud-standard-4-ubuntu-2204
+            os: linux
+            arch: x86_64
+          - runner: ubicloud-standard-4-arm-ubuntu-2204
+            os: linux
+            arch: aarch64
+    runs-on: ${{ matrix.runner }}
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Check out Acton repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Cache Cargo
+        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
+        with:
+          key: ${{ matrix.runner }}
+          save-if: false
+          lookup-only: true
+
+      - name: Install Rust
+        run: rustup toolchain install
+
+      - name: Installing additional Rust components
+        uses: taiki-e/install-action@d6e286fa45544157a02d45a43742857ebbc25d12 # v2.68.16
+        with:
+          tool: just
+
+      - name: Install LLVM and Clang (don't cache)
+        run: |
+          wget https://apt.llvm.org/llvm.sh
+          chmod +x llvm.sh
+          sudo ./llvm.sh 16 clang
+          rm llvm.sh
+
+      - name: Download TON objects archive
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ARCHIVE_NAME: ton-objs-${{ matrix.os }}-${{ matrix.arch }}.tar.gz
+        run: |
+          mkdir -p dist objs
+          gh release download trunk-objs \
+            --repo "${GITHUB_REPOSITORY}" \
+            --pattern "${ARCHIVE_NAME}" \
+            --dir dist
+          tar -C objs -xzf "dist/${ARCHIVE_NAME}"
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@ecf28ddc73e819eb6fa29df6b34ef8921c743461 # v2.1.3
+        with:
+          no-cache: true
+
+      - name: Build acton binary
+        env:
+          CC: clang-16
+          CXX: clang++-16
+        run: |
+          just build-ui
+          cargo build --profile release-size --bin acton
+
+      - name: Test acton binary
+        run: |
+          ./target/release-size/acton --help
+
+      - name: Prepare Acton archive
+        if: github.event_name == 'push'
+        env:
+          ARCHIVE_NAME: acton-${{ matrix.os }}-${{ matrix.arch }}.tar.gz
+        run: |
+          mkdir -p dist
+          tar -czf "dist/${ARCHIVE_NAME}" -C target/release-size acton
+
+      - name: Upload Acton archive as artifact
+        if: github.event_name == 'push'
+        uses: actions/upload-artifact@v7
+        with:
+          name: acton-${{ matrix.os }}-${{ matrix.arch }}
+          path: dist/acton-${{ matrix.os }}-${{ matrix.arch }}.tar.gz
+          retention-days: 1
+
+  build-macos:
+    name: Build macOS (${{ matrix.arch }})
+    strategy:
+      matrix:
+        include:
+          - runner: macos-15-intel
+            os: macos
+            arch: x86_64
+          - runner: macos-15
+            os: macos
+            arch: aarch64
+    runs-on: ${{ matrix.runner }}
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Check out Acton repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Cache Cargo
+        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
+        with:
+          key: ${{ matrix.runner }}
+          save-if: false
+          lookup-only: true
+
+      - name: Install Rust
+        run: rustup toolchain install
+
+      - name: Installing additional Rust components
+        uses: taiki-e/install-action@d6e286fa45544157a02d45a43742857ebbc25d12 # v2.68.16
+        with:
+          tool: just
+
+      - name: Download TON objects archive
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ARCHIVE_NAME: ton-objs-${{ matrix.os }}-${{ matrix.arch }}.tar.gz
+        run: |
+          mkdir -p dist objs
+          gh release download trunk-objs \
+            --repo "${GITHUB_REPOSITORY}" \
+            --pattern "${ARCHIVE_NAME}" \
+            --dir dist
+          tar -C objs -xzf "dist/${ARCHIVE_NAME}"
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@ecf28ddc73e819eb6fa29df6b34ef8921c743461 # v2.1.3
+        with:
+          no-cache: true
+
+      - name: Build acton binary
+        run: |
+          just build-ui
+          cargo build --profile release-size --bin acton
+
+      - name: Test acton binary
+        run: |
+          ./target/release-size/acton --help
+
+      - name: Prepare Acton archive
+        if: github.event_name == 'push'
+        env:
+          ARCHIVE_NAME: acton-${{ matrix.os }}-${{ matrix.arch }}.tar.gz
+        run: |
+          mkdir -p dist
+          tar -czf "dist/${ARCHIVE_NAME}" -C target/release-size acton
+
+      - name: Upload Acton archive as artifact
+        if: github.event_name == 'push'
+        uses: actions/upload-artifact@v7
+        with:
+          name: acton-${{ matrix.os }}-${{ matrix.arch }}
+          path: dist/acton-${{ matrix.os }}-${{ matrix.arch }}.tar.gz
+          retention-days: 1

--- a/.github/workflows/build-release-binaries.yml
+++ b/.github/workflows/build-release-binaries.yml
@@ -104,8 +104,10 @@ jobs:
             acton-${{ env.TARGET_NAME }}.tar.gz
             acton-${{ env.TARGET_NAME }}.tar.gz.sha256
           retention-days: 1
+          if-no-files-found: error
 
   build-macos:
+    if: fales
     name: Build macOS (${{ matrix.arch }})
     runs-on: ${{ matrix.runner }}
     strategy:
@@ -187,3 +189,4 @@ jobs:
             acton-${{ env.TARGET_NAME }}.tar.gz
             acton-${{ env.TARGET_NAME }}.tar.gz.sha256
           retention-days: 1
+          if-no-files-found: error

--- a/.github/workflows/build-release-binaries.yml
+++ b/.github/workflows/build-release-binaries.yml
@@ -62,13 +62,13 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          archive_name="ton-objs-${TARGET_NAME}.tar.gz"
+          ARCHIVE_NAME="ton-objs-${TARGET_NAME}.tar.gz"
           mkdir -p objs
           gh release download trunk-objs \
             --repo "${GITHUB_REPOSITORY}" \
-            --pattern "${archive_name}" \
+            --pattern "${ARCHIVE_NAME}" \
             --dir "${RUNNER_TEMP}"
-          tar -C objs -xzf "${RUNNER_TEMP}/${archive_name}"
+          tar -C objs -xzf "${RUNNER_TEMP}/${ARCHIVE_NAME}"
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@ecf28ddc73e819eb6fa29df6b34ef8921c743461 # v2.1.3
@@ -88,13 +88,17 @@ jobs:
           ./target/release-size/acton --help
 
       - name: Prepare Acton archive
+        # language=Bash
         run: |
-          artifacts_dir="acton-${TARGET_NAME}"
-          archive_name="${artifacts_dir}.tar.gz"
-          mkdir -p "${artifacts_dir}"
-          cp "target/release-size/acton" "${artifacts_dir}/acton"
-          tar -czvf "${archive_name}" -C "${artifacts_dir}" .
-          shasum -a 256 "${archive_name}" > "${archive_name}.sha256"
+          set -euo pipefail
+
+          ARTIFACTS_DIR="acton-${TARGET_NAME}"
+          ARCHIVE_NAME="${ARTIFACTS_DIR}.tar.gz"
+
+          mkdir -p "${ARTIFACTS_DIR}"
+          cp "target/release-size/acton" "${ARTIFACTS_DIR}/acton"
+          tar -czvf "${ARCHIVE_NAME}" -C "${ARTIFACTS_DIR}" .
+          shasum -a 256 "${ARCHIVE_NAME}" > "${ARCHIVE_NAME}.sha256"
 
       - name: Upload Acton archive as artifact
         uses: actions/upload-artifact@v7
@@ -118,7 +122,6 @@ jobs:
           - runner: macos-15
             os: macos
             arch: aarch64
-    if: false
     env:
       TARGET_NAME: ${{ matrix.os }}-${{ matrix.arch }}
 
@@ -150,13 +153,13 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          archive_name="ton-objs-${TARGET_NAME}.tar.gz"
+          ARCHIVE_NAME="ton-objs-${TARGET_NAME}.tar.gz"
           mkdir -p objs
           gh release download trunk-objs \
             --repo "${GITHUB_REPOSITORY}" \
-            --pattern "${archive_name}" \
+            --pattern "${ARCHIVE_NAME}" \
             --dir "${RUNNER_TEMP}"
-          tar -C objs -xzf "${RUNNER_TEMP}/${archive_name}"
+          tar -C objs -xzf "${RUNNER_TEMP}/${ARCHIVE_NAME}"
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@ecf28ddc73e819eb6fa29df6b34ef8921c743461 # v2.1.3
@@ -173,13 +176,17 @@ jobs:
           ./target/release-size/acton --help
 
       - name: Prepare Acton archive
+        # language=Bash
         run: |
-          artifacts_dir="acton-${TARGET_NAME}"
-          archive_name="${artifacts_dir}.tar.gz"
-          mkdir -p "${artifacts_dir}"
-          cp "target/release-size/acton" "${artifacts_dir}/acton"
-          tar -czvf "${archive_name}" -C "${artifacts_dir}" .
-          shasum -a 256 "${archive_name}" > "${archive_name}.sha256"
+          set -euo pipefail
+
+          ARTIFACTS_DIR="acton-${TARGET_NAME}"
+          ARCHIVE_NAME="${ARTIFACTS_DIR}.tar.gz"
+
+          mkdir -p "${ARTIFACTS_DIR}"
+          cp "target/release-size/acton" "${ARTIFACTS_DIR}/acton"
+          tar -czvf "${ARCHIVE_NAME}" -C "${ARTIFACTS_DIR}" .
+          shasum -a 256 "${ARCHIVE_NAME}" > "${ARCHIVE_NAME}.sha256"
 
       - name: Upload Acton archive as artifact
         uses: actions/upload-artifact@v7

--- a/.github/workflows/build-release-binaries.yml
+++ b/.github/workflows/build-release-binaries.yml
@@ -98,7 +98,7 @@ jobs:
       - name: Upload Acton archive as artifact
         uses: actions/upload-artifact@v7
         with:
-          name: acton-${{ matrix.os }}-${{ matrix.arch }}
+          name: artifacts-${{ matrix.os }}-${{ matrix.arch }}
           path: |
             acton-${{ matrix.os }}-${{ matrix.arch }}.tar.gz
             acton-${{ matrix.os }}-${{ matrix.arch }}.tar.gz.sha256
@@ -180,7 +180,7 @@ jobs:
       - name: Upload Acton archive as artifact
         uses: actions/upload-artifact@v7
         with:
-          name: acton-${{ matrix.os }}-${{ matrix.arch }}
+          name: artifacts-${{ matrix.os }}-${{ matrix.arch }}
           path: |
             acton-${{ matrix.os }}-${{ matrix.arch }}.tar.gz
             acton-${{ matrix.os }}-${{ matrix.arch }}.tar.gz.sha256

--- a/.github/workflows/build-release-binaries.yml
+++ b/.github/workflows/build-release-binaries.yml
@@ -107,7 +107,6 @@ jobs:
           if-no-files-found: error
 
   build-macos:
-    if: fales
     name: Build macOS (${{ matrix.arch }})
     runs-on: ${{ matrix.runner }}
     strategy:
@@ -119,6 +118,7 @@ jobs:
           - runner: macos-15
             os: macos
             arch: aarch64
+    if: false
     env:
       TARGET_NAME: ${{ matrix.os }}-${{ matrix.arch }}
 

--- a/.github/workflows/build-release-binaries.yml
+++ b/.github/workflows/build-release-binaries.yml
@@ -61,12 +61,12 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           ARCHIVE_NAME: ton-objs-${{ matrix.os }}-${{ matrix.arch }}.tar.gz
         run: |
-          mkdir -p dist objs
+          mkdir -p objs
           gh release download trunk-objs \
             --repo "${GITHUB_REPOSITORY}" \
             --pattern "${ARCHIVE_NAME}" \
-            --dir dist
-          tar -C objs -xzf "dist/${ARCHIVE_NAME}"
+            --dir "${RUNNER_TEMP}"
+          tar -C objs -xzf "${RUNNER_TEMP}/${ARCHIVE_NAME}"
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@ecf28ddc73e819eb6fa29df6b34ef8921c743461 # v2.1.3
@@ -87,19 +87,21 @@ jobs:
 
       - name: Prepare Acton archive
         env:
+          ARTIFACTS_DIR: acton-${{ matrix.os }}-${{ matrix.arch }}
           ARCHIVE_NAME: acton-${{ matrix.os }}-${{ matrix.arch }}.tar.gz
         run: |
-          mkdir -p dist
-          tar -czf "dist/${ARCHIVE_NAME}" -C target/release-size acton
-          shasum -a 256 "dist/${ARCHIVE_NAME}" > "dist/${ARCHIVE_NAME}.sha256"
+          mkdir -p "${ARTIFACTS_DIR}"
+          cp "target/release-size/acton" "${ARTIFACTS_DIR}/acton"
+          tar -czf "${ARCHIVE_NAME}" -C "${ARTIFACTS_DIR}" .
+          shasum -a 256 "${ARCHIVE_NAME}" > "${ARCHIVE_NAME}.sha256"
 
       - name: Upload Acton archive as artifact
         uses: actions/upload-artifact@v7
         with:
           name: acton-${{ matrix.os }}-${{ matrix.arch }}
           path: |
-            dist/acton-${{ matrix.os }}-${{ matrix.arch }}.tar.gz
-            dist/acton-${{ matrix.os }}-${{ matrix.arch }}.tar.gz.sha256
+            acton-${{ matrix.os }}-${{ matrix.arch }}.tar.gz
+            acton-${{ matrix.os }}-${{ matrix.arch }}.tar.gz.sha256
           retention-days: 1
 
   build-macos:
@@ -144,12 +146,12 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           ARCHIVE_NAME: ton-objs-${{ matrix.os }}-${{ matrix.arch }}.tar.gz
         run: |
-          mkdir -p dist objs
+          mkdir -p objs
           gh release download trunk-objs \
             --repo "${GITHUB_REPOSITORY}" \
             --pattern "${ARCHIVE_NAME}" \
-            --dir dist
-          tar -C objs -xzf "dist/${ARCHIVE_NAME}"
+            --dir "${RUNNER_TEMP}"
+          tar -C objs -xzf "${RUNNER_TEMP}/${ARCHIVE_NAME}"
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@ecf28ddc73e819eb6fa29df6b34ef8921c743461 # v2.1.3
@@ -167,17 +169,19 @@ jobs:
 
       - name: Prepare Acton archive
         env:
+          ARTIFACTS_DIR: acton-${{ matrix.os }}-${{ matrix.arch }}
           ARCHIVE_NAME: acton-${{ matrix.os }}-${{ matrix.arch }}.tar.gz
         run: |
-          mkdir -p dist
-          tar -czf "dist/${ARCHIVE_NAME}" -C target/release-size acton
-          shasum -a 256 "dist/${ARCHIVE_NAME}" > "dist/${ARCHIVE_NAME}.sha256"
+          mkdir -p "${ARTIFACTS_DIR}"
+          cp "target/release-size/acton" "${ARTIFACTS_DIR}/acton"
+          tar -czf "${ARCHIVE_NAME}" -C "${ARTIFACTS_DIR}" .
+          shasum -a 256 "${ARCHIVE_NAME}" > "${ARCHIVE_NAME}.sha256"
 
       - name: Upload Acton archive as artifact
         uses: actions/upload-artifact@v7
         with:
           name: acton-${{ matrix.os }}-${{ matrix.arch }}
           path: |
-            dist/acton-${{ matrix.os }}-${{ matrix.arch }}.tar.gz
-            dist/acton-${{ matrix.os }}-${{ matrix.arch }}.tar.gz.sha256
+            acton-${{ matrix.os }}-${{ matrix.arch }}.tar.gz
+            acton-${{ matrix.os }}-${{ matrix.arch }}.tar.gz.sha256
           retention-days: 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,6 +78,10 @@ jobs:
 
   build-release-binaries:
     needs: [ check-versions ]
+
+    permissions:
+      contents: read
+
     uses: ./.github/workflows/build-release-binaries.yml
 
   create-release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ env:
 jobs:
   check-versions:
     name: Check Release Versions
-    runs-on: ubuntu-latest
+    runs-on: ubicloud-standard-2
 
     permissions:
       contents: read
@@ -86,7 +86,7 @@ jobs:
 
   create-release:
     needs: [ build-release-binaries ]
-    runs-on: ubuntu-latest
+    runs-on: ubicloud-standard-2
     if: github.event_name == 'push'
 
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: release-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 permissions: { }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ env:
 jobs:
   check-versions:
     name: Check Release Versions
-    runs-on: ubicloud-standard-2
+    runs-on: ubuntu-latest
 
     permissions:
       contents: read
@@ -76,181 +76,13 @@ jobs:
           echo "All versions match ${tag_version}"
           exit 0
 
-  build-linux:
-    name: Build Linux (${{ matrix.arch }})
+  build-release-binaries:
     needs: [ check-versions ]
-    strategy:
-      matrix:
-        include:
-          - runner: ubicloud-standard-4-ubuntu-2204
-            os: linux
-            arch: x86_64
-          - runner: ubicloud-standard-4-arm-ubuntu-2204
-            os: linux
-            arch: aarch64
-    runs-on: ${{ matrix.runner }}
-    if: true
-
-    permissions:
-      contents: read
-
-    steps:
-      - name: Check out Acton repository
-        uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-
-      - name: Cache Cargo
-        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
-        with:
-          key: ${{ matrix.runner }}
-          save-if: false
-          lookup-only: true
-
-      - name: Install Rust
-        run: rustup toolchain install
-
-      - name: Installing additional Rust components
-        uses: taiki-e/install-action@d6e286fa45544157a02d45a43742857ebbc25d12 # v2.68.16
-        with:
-          tool: just
-
-      - name: Install LLVM and Clang (don't cache)
-        run: |
-          wget https://apt.llvm.org/llvm.sh
-          chmod +x llvm.sh
-          sudo ./llvm.sh 16 clang
-          rm llvm.sh
-
-      - name: Download TON objects archive
-        env:
-          GH_TOKEN: ${{ github.token }}
-          ARCHIVE_NAME: ton-objs-${{ matrix.os }}-${{ matrix.arch }}.tar.gz
-        run: |
-          mkdir -p dist objs
-          gh release download trunk-objs \
-            --repo "${GITHUB_REPOSITORY}" \
-            --pattern "${ARCHIVE_NAME}" \
-            --dir dist
-          tar -C objs -xzf "dist/${ARCHIVE_NAME}"
-
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@ecf28ddc73e819eb6fa29df6b34ef8921c743461 # v2.1.3
-        with:
-          no-cache: true
-
-      - name: Build acton binary
-        env:
-          CC: clang-16
-          CXX: clang++-16
-        run: |
-          just build-ui
-          cargo build --profile release-size --bin acton
-
-      - name: Test acton binary
-        run: |
-          ./target/release-size/acton --help
-
-      - name: Prepare Acton archive
-        if: github.event_name == 'push'
-        env:
-          ARCHIVE_NAME: acton-${{ matrix.os }}-${{ matrix.arch }}.tar.gz
-        run: |
-          mkdir -p dist
-          tar -czf "dist/${ARCHIVE_NAME}" -C target/release-size acton
-
-      - name: Upload Acton archive as artifact
-        if: github.event_name == 'push'
-        uses: actions/upload-artifact@v7
-        with:
-          name: acton-${{ matrix.os }}-${{ matrix.arch }}
-          path: dist/acton-${{ matrix.os }}-${{ matrix.arch }}.tar.gz
-          retention-days: 1
-
-  build-macos:
-    name: Build macOS (${{ matrix.arch }})
-    needs: [ check-versions ]
-    strategy:
-      matrix:
-        include:
-          - runner: macos-15-intel
-            os: macos
-            arch: x86_64
-          - runner: macos-15
-            os: macos
-            arch: aarch64
-    runs-on: ${{ matrix.runner }}
-    if: true
-
-    permissions:
-      contents: read
-
-    steps:
-      - name: Check out Acton repository
-        uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-
-      - name: Cache Cargo
-        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
-        with:
-          key: ${{ matrix.runner }}
-          save-if: false
-          lookup-only: true
-
-      - name: Install Rust
-        run: rustup toolchain install
-
-      - name: Installing additional Rust components
-        uses: taiki-e/install-action@d6e286fa45544157a02d45a43742857ebbc25d12 # v2.68.16
-        with:
-          tool: just
-
-      - name: Download TON objects archive
-        env:
-          GH_TOKEN: ${{ github.token }}
-          ARCHIVE_NAME: ton-objs-${{ matrix.os }}-${{ matrix.arch }}.tar.gz
-        run: |
-          mkdir -p dist objs
-          gh release download trunk-objs \
-            --repo "${GITHUB_REPOSITORY}" \
-            --pattern "${ARCHIVE_NAME}" \
-            --dir dist
-          tar -C objs -xzf "dist/${ARCHIVE_NAME}"
-
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@ecf28ddc73e819eb6fa29df6b34ef8921c743461 # v2.1.3
-        with:
-          no-cache: true
-
-      - name: Build acton binary
-        run: |
-          just build-ui
-          cargo build --profile release-size --bin acton
-
-      - name: Test acton binary
-        run: |
-          ./target/release-size/acton --help
-
-      - name: Prepare Acton archive
-        if: github.event_name == 'push'
-        env:
-          ARCHIVE_NAME: acton-${{ matrix.os }}-${{ matrix.arch }}.tar.gz
-        run: |
-          mkdir -p dist
-          tar -czf "dist/${ARCHIVE_NAME}" -C target/release-size acton
-
-      - name: Upload Acton archive as artifact
-        if: github.event_name == 'push'
-        uses: actions/upload-artifact@v7
-        with:
-          name: acton-${{ matrix.os }}-${{ matrix.arch }}
-          path: dist/acton-${{ matrix.os }}-${{ matrix.arch }}.tar.gz
-          retention-days: 1
+    uses: ./.github/workflows/build-release-binaries.yml
 
   create-release:
-    needs: [ build-linux, build-macos ]
-    runs-on: ubicloud-standard-2
+    needs: [ build-release-binaries ]
+    runs-on: ubuntu-latest
     if: github.event_name == 'push'
 
     permissions:
@@ -260,7 +92,7 @@ jobs:
       - name: Download Acton release archives
         uses: actions/download-artifact@v8
         with:
-          pattern: acton-*
+          pattern: artifacts-*
           path: dist/
           merge-multiple: true
 
@@ -278,7 +110,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ github.ref_name }}
         run: |
-          gh release create "${RELEASE_TAG}" dist/*.tar.gz \
+          gh release create "${RELEASE_TAG}" dist/* \
             --repo "${GITHUB_REPOSITORY}" \
             --title "${RELEASE_TAG}" \
             --latest \
@@ -299,7 +131,7 @@ jobs:
           EOF
           )
 
-          gh release create "${RELEASE_TAG}" dist/*.tar.gz \
+          gh release create "${RELEASE_TAG}" dist/* \
             --repo "${PUBLIC_ACTON_REPOSITORY}" \
             --title "${RELEASE_TAG}" \
             --latest \


### PR DESCRIPTION
This is required for `cargo-dist` to ensure that the diff is minimal and does not break current processes