### PR TITLE
feat(all): universal `println` and `format`

### DIFF
--- a/docs/content/docs/contract-deployment.mdx
+++ b/docs/content/docs/contract-deployment.mdx
@@ -49,7 +49,7 @@ fun main() {
         counter: 0,    // Initial counter value
     });
 
-    println1("Deploying counter to {}", counter.address);
+    println("Deploying counter to {}", counter.address);
 
     // 3. Deploy the contract
     // This sends a transaction from the deployer wallet with the stateInit
@@ -60,8 +60,8 @@ fun main() {
         return;
     }
 
-    println1("Deployment complete: {}", counter.address);
-    println1("On-chain counter is {}", counter.currentCounter());
+    println("Deployment complete: {}", counter.address);
+    println("On-chain counter is {}", counter.currentCounter());
 }
 ```
 
@@ -93,7 +93,7 @@ fun main() {
     // Deploy
     minter.deploy(deployer.address, { value: ton("0.05") }).wait();
 
-    println1("Jetton deployed at {}", minter.address);
+    println("Jetton deployed at {}", minter.address);
 }
 ```
 

--- a/docs/content/docs/quickstart.mdx
+++ b/docs/content/docs/quickstart.mdx
@@ -164,8 +164,8 @@ In this guide, we will explore Acton's capabilities and develop a simple smart c
                 return;
             }
 
-            println1("Deployed counter to {}", counter.address);
-            println1("On-chain counter is {}", counter.currentCounter());
+            println("Deployed counter to {}", counter.address);
+            println("On-chain counter is {}", counter.currentCounter());
         }
         ```
 

--- a/docs/content/docs/scripting/blockchain-interaction.mdx
+++ b/docs/content/docs/scripting/blockchain-interaction.mdx
@@ -73,8 +73,8 @@ fun main() {
         return;
     }
 
-    println1("Deployed counter to {}", counter.address);
-    println1("On-chain counter is {}", counter.currentCounter());
+    println("Deployed counter to {}", counter.address);
+    println("On-chain counter is {}", counter.currentCounter());
 }
 ```
 
@@ -152,7 +152,7 @@ The `net.wallet()` function returns a wallet struct with an `address` field:
 ```tolk
 fun main() {
     val deployer = net.wallet("deployer");
-    println1("Wallet address: {}", deployer.address);
+    println("Wallet address: {}", deployer.address);
 }
 ```
 
@@ -201,7 +201,7 @@ fun main() {
     val deployResult = counter.deploy(deployer.address, ton("0.05"));
     deployResult.wait(); // Wait for deployment
 
-    println1("Counter deployed at {}", counter.address);
+    println("Counter deployed at {}", counter.address);
 
     // Send increase message
     val increaseResult = counter.sendIncrease(deployer.address, 5);
@@ -254,7 +254,7 @@ Scripts can read contract state using `net.runGetMethod()`:
 fun main() {
     val counterAddress = address("EQDt7LL...");
     val currentValue: int = net.runGetMethod(counterAddress, "currentCounter");
-    println1("Counter value: {}", currentValue);
+    println("Counter value: {}", currentValue);
 }
 ```
 

--- a/docs/content/docs/scripting/index.mdx
+++ b/docs/content/docs/scripting/index.mdx
@@ -53,7 +53,7 @@ fun main(libraryCode: cell, duration: int) {
 
     val toReserve = calculateGasFeeWithoutFlatPrice(MASTERCHAIN, gasConsumedForCalculation)
                     + calculateStorageFee(MASTERCHAIN, duration, libraryBits, libraryRefs);
-    println1("Storage fee: {:ton}", toReserve);
+    println("Storage fee: {:ton}", toReserve);
 }
 ```
 

--- a/docs/content/docs/scripting/passing-arguments.mdx
+++ b/docs/content/docs/scripting/passing-arguments.mdx
@@ -59,7 +59,7 @@ You can pass null values to work with optional types:
 import "@acton/io"
 
 fun main(value: int?) {
-    println1("Value: {}", value);
+    println("Value: {}", value);
 }
 ```
 
@@ -87,8 +87,8 @@ import "@acton/io"
 fun main(data: tuple) {
     val a: int = data.get(0)
     val b: int = data.get(1)
-    println1("First element: {}", a)
-    println1("Second element: {}", b)
+    println("First element: {}", a)
+    println("Second element: {}", b)
 }
 ```
 
@@ -118,8 +118,8 @@ struct Point {
 }
 
 fun main(p: Point) {
-    println1("Point x: {}", p.x)
-    println1("Point y: {}", p.y)
+    println("Point x: {}", p.x)
+    println("Point y: {}", p.y)
 }
 ```
 
@@ -138,7 +138,7 @@ To pass a string, you need to wrap it in double quotes both for the shell and fo
 import "@acton/io"
 
 fun main(name: slice) {
-    println1("Hello, {}", name.beginParse())
+    println("Hello, {}", name.beginParse())
 }
 ```
 
@@ -171,7 +171,7 @@ import "@acton/io"
 fun main(data: cell) {
     val s = data.beginParse()
     val value = s.loadUint(32)
-    println1("Value from cell: {}", value)
+    println("Value from cell: {}", value)
 }
 ```
 

--- a/docs/content/docs/setup-wallets.mdx
+++ b/docs/content/docs/setup-wallets.mdx
@@ -121,7 +121,7 @@ import "@acton/io"
 
 fun main() {
     val deployer = net.wallet("deployer");
-    println1("Deployer address: {}", deployer.address);
+    println("Deployer address: {}", deployer.address);
 
     // Use deployer.address for contract deployment
     // ...

--- a/docs/content/docs/standard_library/emulation/config.mdx
+++ b/docs/content/docs/standard_library/emulation/config.mdx
@@ -31,7 +31,7 @@ config.setGasPrices(simplePrices, MASTERCHAIN);
 
 // Access storage prices
 val storagePrices = config.getStoragePrices();
-println1("Bit price: {}", storagePrices);
+println("Bit price: {}", storagePrices);
 ```
 
 ## Definitions
@@ -179,7 +179,7 @@ Returns: [GlobalVersion](#globalversion) struct containing version number and ca
 Example:
 ```tolk
 val version = config.getGlobalVersion();
-println(format2("Network version: {}, capabilities: {}", version.version, version.capabilities));
+println("Network version: {}, capabilities: {}", version.version, version.capabilities);
 ```
 
 <SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/emulation/config.tolk#L135" />
@@ -265,7 +265,7 @@ Example:
 ```tolk
 val storagePrices = config.getStoragePrices();
 val initialPrices = storagePrices.getInitial();
-println1("Initial bit price: {}", initialPrices.bitPrice);
+println("Initial bit price: {}", initialPrices.bitPrice);
 ```
 
 <SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/emulation/config.tolk#L188" />
@@ -354,8 +354,8 @@ Example:
 ```tolk
 val storagePrices = config.getStoragePrices();
 val prices = storagePrices.get(1000000);
-println(format3("Bit price: {}, Cell price: {}, Masterchain bit price: {}",
-    prices.bitPrice, prices.cellPrice, prices.masterchainBitPrice));
+println("Bit price: {}, Cell price: {}, Masterchain bit price: {}",
+    prices.bitPrice, prices.cellPrice, prices.masterchainBitPrice);
 ```
 
 <SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/emulation/config.tolk#L271" />
@@ -465,7 +465,7 @@ Returns: [GasPrices](#gasprices) configuration union containing the gas pricing 
 Example:
 ```tolk
 val gasPrices = config.getGasPrices(BASECHAIN);
-println1("Gas limit basechain: {}", gasPrices);
+println("Gas limit basechain: {}", gasPrices);
 ```
 
 <SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/emulation/config.tolk#L348" />
@@ -569,8 +569,8 @@ Returns: [MsgForwardPrices](#msgforwardprices) configuration containing message 
 Example:
 ```tolk
 val msgPrices = config.getMsgForwardPrices(BASECHAIN);
-println(format3("Lump price: {}, Bit price: {}, Cell price: {}",
-    msgPrices.lumpPrice, msgPrices.bitPrice, msgPrices.cellPrice));
+println("Lump price: {}, Bit price: {}, Cell price: {}",
+    msgPrices.lumpPrice, msgPrices.bitPrice, msgPrices.cellPrice);
 ```
 
 <SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/emulation/config.tolk#L429" />

--- a/docs/content/docs/standard_library/emulation/network.mdx
+++ b/docs/content/docs/standard_library/emulation/network.mdx
@@ -699,7 +699,7 @@ fun main() {
    val result = counter.deploy(deployer.address, ton("0.05"));
    result.wait();
 
-   println1("Deployed counter to {}", counter.address);
+   println("Deployed counter to {}", counter.address);
 }
 ```
 
@@ -1013,7 +1013,7 @@ Example:
 ```tolk
 val state = net.getAccountState(contract.address);
 if (state != null) {
-    println1("Balance: {:ton}", state.storage.balance.grams);
+    println("Balance: {:ton}", state.storage.balance.grams);
 } else {
     println("Account not found");
 }
@@ -1035,7 +1035,7 @@ Example:
 ```tolk
 val storage_fee = net.getAccountStorageFee(contract.address, 86400); // 1 day
 if (storage_fee != null) {
-    println1("Daily storage fee: {:ton}", storage_fee);
+    println("Daily storage fee: {:ton}", storage_fee);
 }
 ```
 
@@ -1096,7 +1096,7 @@ Returns the current time in the emulated blockchain.
 Example:
 ```tolk
 val current_time = net.now();
-println1("Current emulation time: {}", current_time);
+println("Current emulation time: {}", current_time);
 ```
 
 <SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/emulation/network.tolk#L1048" />
@@ -1132,7 +1132,7 @@ Returns 0 if the address is not deployed.
 Example:
 ```tolk
 val balance = net.balance(address);
-println1("{:ton}", balance);
+println("{:ton}", balance);
 ```
 
 <SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/emulation/network.tolk#L1080" />
@@ -1191,7 +1191,7 @@ Example:
 ```tolk
 val shard = net.getShardAccount(addr);
 if (shard != null) {
-    println1("Last LT: {}", shard.lastTransLt);
+    println("Last LT: {}", shard.lastTransLt);
 }
 ```
 
@@ -1323,7 +1323,7 @@ val gasPrice = config.getGasPrices(BASECHAIN);
 val storagePrices = config.getStoragePrices();
 val globalVersion = config.getGlobalVersion();
 
-println(format1("Network version: {}", globalVersion.version));
+println("Network version: {}", globalVersion.version);
 ```
 
 <SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/emulation/network.tolk#L1282" />

--- a/docs/content/docs/standard_library/fmt.mdx
+++ b/docs/content/docs/standard_library/fmt.mdx
@@ -7,7 +7,8 @@ import { SourceCodeLink } from '@/components/SourceCodeLink';
 
 Module for string formatting.
 
-This module provides functions (`format1` to `format5`) for creating formatted strings.
+This module provides a universal `format` function for creating formatted strings.
+It accepts up to 5 typed arguments.
 
 Supported placeholders:
 - `{}`: default formatting
@@ -26,109 +27,30 @@ Format rules and edge cases:
 Examples:
 ```tolk
 // Simple string substitution
-val greeting = format1("Hello, {}!", "Tolk");
+val greeting = format("Hello, {}!", "Tolk");
 
 // Formatting numbers
-val hex = format1("Value in hex: 0x{:x}", 255); // "Value in hex: 0xff"
+val hex = format("Value in hex: 0x{:x}", 255); // "Value in hex: 0xff"
 
 // Formatting TON amounts
-val balance = format1("Balance: {:ton}", 500000000); // "Balance: 0.5 TON"
+val balance = format("Balance: {:ton}", 500000000); // "Balance: 0.5 TON"
 
 // Escaping braces
-val escaped = format1("Use {{}} to print braces", 0); // "Use {} to print braces"
+val escaped = format("Use {{}} to print braces", 0); // "Use {} to print braces"
 
 // Missing argument keeps placeholder as-is
-val partial = format1("{} {}", "left"); // "left {}"
+val partial = format("{} {}", "left"); // "left {}"
 
 // Multiple arguments
-val info = format3("User {} has {} items worth {:ton}", "Alice", 5, 1000000000);
+val info = format("User {} has {} items worth {:ton}", "Alice", 5, 1000000000);
 ```
 
 ## Definitions
 
-## `format1`
+## `format`
 
 ```tolk
-fun format1<T1>(fmt: string, arg1: T1): string
-```
-
-Formats a string with 1 argument.
-
-Uses the module-level format rules, including escaping (`{{`/`}}`), mismatch behavior,
-and runtime parser errors for invalid format strings.
-
-Example:
-```tolk
-val msg = format1("Hello {}", "world");
-println(msg);  // prints "Hello world"
-```
-
-Non-int fallback examples:
-```tolk
-format1("{:x}", "abc");   // "abc"
-format1("{:ton}", true);  // "true"
-```
-
-<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/fmt.tolk#L59" />
-
-## `format2`
-
-```tolk
-fun format2<T1, T2>(fmt: string, arg1: T1, arg2: T2): string
-```
-
-Formats a string with 2 arguments.
-
-Uses the same placeholder rules and edge-case behavior as [format1](#format1).
-
-Example:
-```tolk
-val msg = format2("{}: {}", "name", "John");
-println(msg);  // prints "name: John"
-```
-
-<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/fmt.tolk#L72" />
-
-## `format3`
-
-```tolk
-fun format3<T1, T2, T3>(fmt: string, arg1: T1, arg2: T2, arg3: T3): string
-```
-
-Formats a string with 3 arguments.
-
-Uses the same placeholder rules and edge-case behavior as [format1](#format1).
-
-Example:
-```tolk
-val msg = format3("{} + {} = {}", 2, 3, 5);
-println(msg);  // prints "2 + 3 = 5"
-```
-
-<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/fmt.tolk#L91" />
-
-## `format4`
-
-```tolk
-fun format4<T1, T2, T3, T4>(fmt: string, arg1: T1, arg2: T2, arg3: T3, arg4: T4): string
-```
-
-Formats a string with 4 arguments.
-
-Uses the same placeholder rules and edge-case behavior as [format1](#format1).
-
-Example:
-```tolk
-val msg = format4("{} {} {} {}", "a", "b", "c", "d");
-println(msg);  // prints "a b c d"
-```
-
-<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/fmt.tolk#L112" />
-
-## `format5`
-
-```tolk
-fun format5<T1, T2, T3, T4, T5>(
+fun format<T1 = void, T2 = void, T3 = void, T4 = void, T5 = void>(
     fmt: string,
     arg1: T1,
     arg2: T2,
@@ -138,15 +60,23 @@ fun format5<T1, T2, T3, T4, T5>(
 ): string
 ```
 
-Formats a string with 5 arguments.
+Formats a string with up to 5 arguments.
 
-Uses the same placeholder rules and edge-case behavior as [format1](#format1).
+Uses the module-level format rules, including escaping (`{{`/`}}`), mismatch behavior,
+and runtime parser errors for invalid format strings.
 
 Example:
 ```tolk
-val msg = format5("{} {} {} {} {}", 1, 2, 3, 4, 5);
-println(msg);  // prints "1 2 3 4 5"
+val a = format("Hello {}", "world");
+val b = format("{} + {} = {}", 2, 3, 5);
+val c = format("hello");
 ```
 
-<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/fmt.tolk#L135" />
+Non-int fallback examples:
+```tolk
+format("{:x}", "abc");   // "abc"
+format("{:ton}", true);  // "true"
+```
+
+<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/fmt.tolk#L61" />
 

--- a/docs/content/docs/standard_library/fs.mdx
+++ b/docs/content/docs/standard_library/fs.mdx
@@ -60,7 +60,7 @@ Example:
 ```tolk
 val content = fs.readFile("config.txt");
 if (content != null) {
-    println1("File content: {}", content);
+    println("File content: {}", content);
 } else {
     println("File not found");
 }

--- a/docs/content/docs/standard_library/io.mdx
+++ b/docs/content/docs/standard_library/io.mdx
@@ -20,8 +20,10 @@ val point = Point { x: 10, y: 20 };
 println(point); // Output: Point { x: 10, y: 20 }
 
 // Formatted output
-println1("Iteration: {}", 5);
-println2("Transfer {} to {}", amount, myAddress);
+println("Iteration: {}", 5);
+println("Transfer {} to {}", amount, myAddress);
+println("hello", "world");
+println(1, 2);
 
 // Error logging
 eprintln("Critical failure in setup!");
@@ -32,10 +34,22 @@ eprintln("Critical failure in setup!");
 ## `println`
 
 ```tolk
-fun println<T>(value: T): void
+fun println<T1, T2 = void, T3 = void, T4 = void, T5 = void, T6 = void>(
+    value1: T1,
+    value2: T2,
+    value3: T3,
+    value4: T4,
+    value5: T5,
+    value6: T6,
+): void
 ```
 
-Prints the given value to the standard output.
+Prints up to 6 values to the standard output.
+
+If the first argument is a `string`, `println` tries to interpret it as a format string.
+Placeholder-consumed arguments are rendered into that string, and any remaining arguments
+are appended separated by spaces. If the string is not a valid format string, it is printed
+literally and the remaining arguments are still appended separated by spaces.
 
 Example:
 ```tolk
@@ -46,114 +60,27 @@ println(Data {
     value: 10,
     is_set: true
 });
+
+println("Hello, 0x{:x}", 10);
+println("{} -> {}", "from", "to");
+println("value {}", 42);
+println(1, 2);
 ```
 
-<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/io.tolk#L39" />
-
-## `println1`
-
-```tolk
-fun println1<T>(fmt: string, value: T): void
-```
-
-Prints the given value to the standard output formatted according to format string.
-
-Example:
-```tolk
-println1("Hello, 0x{:x}", 10);
-```
-
-Format supports the following placeholders:
+Format supports the following placeholders when the first argument is a string:
 - `{}` - default formatter output
 - `{:x}` - formats an int as lowercase hexadecimal without `0x` prefix
 - `{:ton}` - formats an int amount in nanotons as `<value> TON`
 
 Notes:
 - Escape literal braces with `{{` and `}}`.
-- Invalid format strings fail at runtime with parser errors that include byte positions
-  (for example: unknown modifiers, unsupported placeholder payload, unclosed `{`,
-  unmatched `}`).
+- If the first string is an invalid format string, it is printed literally.
 - If placeholders outnumber arguments, unmatched placeholders stay in output as text.
-- If arguments outnumber placeholders, extra arguments are ignored.
+- If arguments outnumber placeholders, extra arguments are appended after the formatted text.
 - For non-int arguments, `{:x}` and `{:ton}` fall back to the same behavior as `{}`.
 - `{:ton}` uses floating-point conversion, so very large values can be rounded.
 
-<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/io.tolk#L64" />
-
-## `println2`
-
-```tolk
-fun println2<T1, T2>(fmt: string, value1: T1, value2: T2): void
-```
-
-Prints the given values to the standard output formatted according to format string.
-
-Uses the same placeholder rules and edge-case behavior as [println1](#println1).
-
-Example:
-```tolk
-println2("{} -> {}", "from", "to");
-```
-
-<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/io.tolk#L76" />
-
-## `println3`
-
-```tolk
-fun println3<T1, T2, T3>(fmt: string, value1: T1, value2: T2, value3: T3): void
-```
-
-Prints the given values to the standard output formatted according to format string.
-
-Uses the same placeholder rules and edge-case behavior as [println1](#println1).
-
-Example:
-```tolk
-println3("{} + {} = {}", 2, 3, 5);
-```
-
-<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/io.tolk#L88" />
-
-## `println4`
-
-```tolk
-fun println4<T1, T2, T3, T4>(fmt: string, value1: T1, value2: T2, value3: T3, value4: T4): void
-```
-
-Prints the given values to the standard output formatted according to format string.
-
-Uses the same placeholder rules and edge-case behavior as [println1](#println1).
-
-Example:
-```tolk
-println4("{} {} {} {}", "a", "b", "c", "d");
-```
-
-<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/io.tolk#L100" />
-
-## `println5`
-
-```tolk
-fun println5<T1, T2, T3, T4, T5>(
-    fmt: string,
-    value1: T1,
-    value2: T2,
-    value3: T3,
-    value4: T4,
-    value5: T5,
-): void
-```
-
-Prints the given values to the standard output formatted according to format string.
-
-Uses the same placeholder rules and edge-case behavior as [println1](#println1).
-
-Example:
-```tolk
-println5("{} {} {} {} {}", 1, 2, 3, 4, 5);
-```
-
-<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/io.tolk#L112" />
+<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/io.tolk#L63" />
 
 ## `eprintln`
 
@@ -168,5 +95,5 @@ Example:
 eprintln("Something went wrong");
 ```
 
-<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/io.tolk#L129" />
+<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/io.tolk#L93" />
 

--- a/docs/content/docs/standard_library/promts/prompts.mdx
+++ b/docs/content/docs/standard_library/promts/prompts.mdx
@@ -45,7 +45,7 @@ Non-interactive fallback:
 Example:
 ```tolk
 val name = prompt("What is your name?", "John");
-println(format1("Hello {}", name));
+println("Hello {}", name);
 ```
 
 <SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/promts/prompts.tolk#L37" />
@@ -67,7 +67,7 @@ Input and fallback behavior:
 Example:
 ```tolk
 val name = select("What is your name?", ["John", "Jane", "Jim"] as tuple);
-println(format1("Hello {}", name));
+println("Hello {}", name);
 ```
 
 <SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/promts/prompts.tolk#L54" />

--- a/docs/content/docs/standard_library/types/message.mdx
+++ b/docs/content/docs/standard_library/types/message.mdx
@@ -17,7 +17,7 @@ val action = outActions.getSendMessageAt(0);
 if (action != null) {
     val msg = action.loadMessage<Transfer>();
     val body = msg.loadBody();
-    println1("Transfer amount: {:ton}", body.amount);
+    println("Transfer amount: {:ton}", body.amount);
 }
 
 // Parsing a generic message to check opcode

--- a/docs/content/docs/standard_library/types/out_actions.mdx
+++ b/docs/content/docs/standard_library/types/out_actions.mdx
@@ -18,13 +18,13 @@ val actions = vm.outActions();
 // Check the first action
 val firstAction = actions.at(0);
 if (firstAction is OutActionSendMessage) {
-    println1("Sending message with mode: {}", firstAction.mode);
+    println("Sending message with mode: {}", firstAction.mode);
 }
 
 // Get specific message body
 val transfer = actions.getSendMessageBodyAt<Transfer>(0);
 if (transfer != null) {
-    println1("Transferred: {:ton}", transfer.amount);
+    println("Transferred: {:ton}", transfer.amount);
 }
 ```
 

--- a/docs/content/docs/standard_library/types/transaction.mdx
+++ b/docs/content/docs/standard_library/types/transaction.mdx
@@ -16,14 +16,14 @@ val tx = results.at(0).tx.load();
 
 // Check gas usage
 val gas = tx.getUsedGas();
-println1("Gas used: {}", gas);
+println("Gas used: {}", gas);
 
 // Inspect account status change
 val description = tx.description.load();
 if (description is TransOrd) {
     val compute = description.computePh;
     if (compute is TrComputeVm) {
-        println1("VM exit code: {}", compute.exitCode);
+        println("VM exit code: {}", compute.exitCode);
     }
 }
 ```

--- a/docs/content/docs/test-runner/writing-your-own-matchers.mdx
+++ b/docs/content/docs/test-runner/writing-your-own-matchers.mdx
@@ -82,7 +82,7 @@ import "@acton/fmt"
 fun Expectation<int>.toBeEven(self) {
     if (self.value % 2 != 0) {
         Assert.fail(
-            format1("Expected {} to be even", self.value),
+            format("Expected {} to be even", self.value),
             self.location
         );
     }
@@ -108,7 +108,7 @@ fun Expectation<address>.toHaveWorkchain(self, expectedWorkchain: int) {
     val actualWorkchain = self.value.getWorkchain();
     if (actualWorkchain != expectedWorkchain) {
         Assert.fail(
-            format2(
+            format(
                 "Expected address to have workchain {}, but got {}",
                 expectedWorkchain,
                 actualWorkchain
@@ -136,7 +136,7 @@ import "@acton/fmt"
 fun Expectation<slice>.toStartWith(self, prefix: slice) {
     if (!self.value.getFirstBits(prefix.remainingBitsCount()).bitsEqual(prefix)) {
         Assert.fail(
-            format2(
+            format(
                 "Expected slice '{}' to start with prefix '{}'",
                 self.value,
                 prefix
@@ -177,7 +177,7 @@ import "@acton/fmt"
 fun Expectation<User>.toBeActive(self) {
     if (!self.value.isActive) {
         Assert.fail(
-            format1("Expected user {} to be active", self.value.name),
+            format("Expected user {} to be active", self.value.name),
             self.location
         );
     }
@@ -202,7 +202,7 @@ The `Assert.fail()` function is particularly useful for providing custom error m
 fun Expectation<int>.toBePositive(self) {
     if (self.value <= 0) {
         Assert.fail(
-            format1("Expected {} to be a positive number", self.value),
+            format("Expected {} to be a positive number", self.value),
             self.location // Pass the location for better error reporting
         );
     }
@@ -227,7 +227,7 @@ Assert.fail("Value is not even");
 **Good:**
 ```tolk
 Assert.fail(
-    format1("Expected {} to be even, but it was odd.", self.value),
+    format("Expected {} to be even, but it was odd.", self.value),
     self.location
 );
 ```

--- a/lib/emulation/config.tolk
+++ b/lib/emulation/config.tolk
@@ -24,7 +24,7 @@
 ///
 /// // Access storage prices
 /// val storagePrices = config.getStoragePrices();
-/// println1("Bit price: {}", storagePrices);
+/// println("Bit price: {}", storagePrices);
 /// ```
 
 import "../testing/assert"
@@ -130,7 +130,7 @@ fun Config.setGlobalVersion(mutate self, version: GlobalVersion): void {
 /// Example:
 /// ```tolk
 /// val version = config.getGlobalVersion();
-/// println(format2("Network version: {}, capabilities: {}", version.version, version.capabilities));
+/// println("Network version: {}, capabilities: {}", version.version, version.capabilities);
 /// ```
 fun Config.getGlobalVersion(self): GlobalVersion {
     return GlobalVersion.fromCell(self.get(GLOBAL_VERSION_INDEX).loadValue());
@@ -183,7 +183,7 @@ const INITIAL_UNIXTIME_STORAGE_INDEX = 0
 /// ```tolk
 /// val storagePrices = config.getStoragePrices();
 /// val initialPrices = storagePrices.getInitial();
-/// println1("Initial bit price: {}", initialPrices.bitPrice);
+/// println("Initial bit price: {}", initialPrices.bitPrice);
 /// ```
 fun StoragePricesDict.getInitial(self): StoragePrices {
     val entry = self.get(INITIAL_UNIXTIME_STORAGE_INDEX);
@@ -265,8 +265,8 @@ fun Config.setStoragePrices(mutate self, prices: StoragePricesDict): void {
 /// ```tolk
 /// val storagePrices = config.getStoragePrices();
 /// val prices = storagePrices.get(1000000);
-/// println(format3("Bit price: {}, Cell price: {}, Masterchain bit price: {}",
-///     prices.bitPrice, prices.cellPrice, prices.masterchainBitPrice));
+/// println("Bit price: {}, Cell price: {}, Masterchain bit price: {}",
+///     prices.bitPrice, prices.cellPrice, prices.masterchainBitPrice);
 /// ```
 fun Config.getStoragePrices(self): StoragePricesDict {
     val rawDict = self.get(STORAGE_PRICES_INDEX).loadValue();
@@ -343,7 +343,7 @@ fun Config.setGasPrices(mutate self, prices: GasPrices, chainType: int): void {
 /// Example:
 /// ```tolk
 /// val gasPrices = config.getGasPrices(BASECHAIN);
-/// println1("Gas limit basechain: {}", gasPrices);
+/// println("Gas limit basechain: {}", gasPrices);
 /// ```
 fun Config.getGasPrices(self, chainType: int): GasPrices {
     val index = chainType == MASTERCHAIN
@@ -423,8 +423,8 @@ fun Config.setMsgForwardPrices(mutate self, prices: MsgForwardPrices, chainType:
 /// Example:
 /// ```tolk
 /// val msgPrices = config.getMsgForwardPrices(BASECHAIN);
-/// println(format3("Lump price: {}, Bit price: {}, Cell price: {}",
-///     msgPrices.lumpPrice, msgPrices.bitPrice, msgPrices.cellPrice));
+/// println("Lump price: {}, Bit price: {}, Cell price: {}",
+///     msgPrices.lumpPrice, msgPrices.bitPrice, msgPrices.cellPrice);
 /// ```
 fun Config.getMsgForwardPrices(self, chainType: int): MsgForwardPrices {
     val index = chainType == MASTERCHAIN

--- a/lib/emulation/network.tolk
+++ b/lib/emulation/network.tolk
@@ -131,7 +131,7 @@ fun OutMessages.at<Msg>(self, index: int): MessageRelaxed<Msg> {
             val opcodeTypeName = ffi.typeNameByOpcode(opcode);
 
             Assert.fail(
-                format4(
+                format(
                     "Out message is not a `{}` (opcode: 0x{:x}), but `{}` (opcode: 0x{:x})",
                     reflect.typeNameOf<Msg>(),
                     reflect.serializationPrefixOf<Msg>().0,
@@ -671,7 +671,7 @@ struct Wallet {
 ///    val result = counter.deploy(deployer.address, ton("0.05"));
 ///    result.wait();
 ///
-///    println1("Deployed counter to {}", counter.address);
+///    println("Deployed counter to {}", counter.address);
 /// }
 /// ```
 fun net.wallet(name: string): Wallet {
@@ -967,7 +967,7 @@ fun net.registerCodeCell(code: cell, name: string): void {
 /// ```tolk
 /// val state = net.getAccountState(contract.address);
 /// if (state != null) {
-///     println1("Balance: {:ton}", state.storage.balance.grams);
+///     println("Balance: {:ton}", state.storage.balance.grams);
 /// } else {
 ///     println("Account not found");
 /// }
@@ -989,7 +989,7 @@ fun net.getAccountState(addr: address): AccountInfo? {
 /// ```tolk
 /// val storage_fee = net.getAccountStorageFee(contract.address, 86400); // 1 day
 /// if (storage_fee != null) {
-///     println1("Daily storage fee: {:ton}", storage_fee);
+///     println("Daily storage fee: {:ton}", storage_fee);
 /// }
 /// ```
 fun net.getAccountStorageFee(addr: address, seconds: int): coins? {
@@ -1043,7 +1043,7 @@ fun net.setNow(now: uint32): void {
 /// Example:
 /// ```tolk
 /// val current_time = net.now();
-/// println1("Current emulation time: {}", current_time);
+/// println("Current emulation time: {}", current_time);
 /// ```
 fun net.now(): uint32 {
     return ffi.getNow();
@@ -1075,7 +1075,7 @@ fun net.topUp(to: address, amount: coins): void {
 /// Example:
 /// ```tolk
 /// val balance = net.balance(address);
-/// println1("{:ton}", balance);
+/// println("{:ton}", balance);
 /// ```
 fun net.balance(of: address): coins {
     val state = net.getAccountState(of);
@@ -1136,7 +1136,7 @@ fun net.setAccount(addr: address, acc: Account): void {
 /// ```tolk
 /// val shard = net.getShardAccount(addr);
 /// if (shard != null) {
-///     println1("Last LT: {}", shard.lastTransLt);
+///     println("Last LT: {}", shard.lastTransLt);
 /// }
 /// ```
 fun net.getShardAccount(addr: address): ShardAccount? {
@@ -1277,7 +1277,7 @@ fun net.setConfig(config: Config): bool {
 /// val storagePrices = config.getStoragePrices();
 /// val globalVersion = config.getGlobalVersion();
 ///
-/// println(format1("Network version: {}", globalVersion.version));
+/// println("Network version: {}", globalVersion.version);
 /// ```
 fun net.getConfig(): Config {
     return createMapFromLowLevelDict(ffi.getConfig());
@@ -1354,7 +1354,7 @@ fun impl.runGetMethodById<Ret, Args = tuple>(
     } catch (e) {
         if (e == 7) {
             Assert.fail(
-                format3(
+                format(
                     "Get method '{}' returned '{}' that cannot be deserialized to '{}'. Make sure you passed all parameters to the get method.",
                     name,
                     res,

--- a/lib/env.tolk
+++ b/lib/env.tolk
@@ -122,7 +122,7 @@ fun cell.__env(name: string): cell? {
 
 fun T.__env(name: string): T? {
     Assert.fail(
-        format1(
+        format(
             "env() supports only int, coins, bool, string, slice, address and cell types, but got {}",
             reflect.typeNameOf<T>(),
         ),

--- a/lib/fmt.tolk
+++ b/lib/fmt.tolk
@@ -1,6 +1,7 @@
 /// Module for string formatting.
 ///
-/// This module provides functions (`format1` to `format5`) for creating formatted strings.
+/// This module provides a universal `format` function for creating formatted strings.
+/// It accepts up to 5 typed arguments.
 ///
 /// Supported placeholders:
 /// - `{}`: default formatting
@@ -19,120 +20,45 @@
 /// Examples:
 /// ```tolk
 /// // Simple string substitution
-/// val greeting = format1("Hello, {}!", "Tolk");
+/// val greeting = format("Hello, {}!", "Tolk");
 ///
 /// // Formatting numbers
-/// val hex = format1("Value in hex: 0x{:x}", 255); // "Value in hex: 0xff"
+/// val hex = format("Value in hex: 0x{:x}", 255); // "Value in hex: 0xff"
 ///
 /// // Formatting TON amounts
-/// val balance = format1("Balance: {:ton}", 500000000); // "Balance: 0.5 TON"
+/// val balance = format("Balance: {:ton}", 500000000); // "Balance: 0.5 TON"
 ///
 /// // Escaping braces
-/// val escaped = format1("Use {{}} to print braces", 0); // "Use {} to print braces"
+/// val escaped = format("Use {{}} to print braces", 0); // "Use {} to print braces"
 ///
 /// // Missing argument keeps placeholder as-is
-/// val partial = format1("{} {}", "left"); // "left {}"
+/// val partial = format("{} {}", "left"); // "left {}"
 ///
 /// // Multiple arguments
-/// val info = format3("User {} has {} items worth {:ton}", "Alice", 5, 1000000000);
+/// val info = format("User {} has {} items worth {:ton}", "Alice", 5, 1000000000);
 /// ```
 
 import "@stdlib/reflection"
 import "ffi/ffi"
 
-/// Formats a string with 1 argument.
+/// Formats a string with up to 5 arguments.
 ///
 /// Uses the module-level format rules, including escaping (`{{`/`}}`), mismatch behavior,
 /// and runtime parser errors for invalid format strings.
 ///
 /// Example:
 /// ```tolk
-/// val msg = format1("Hello {}", "world");
-/// println(msg);  // prints "Hello world"
+/// val a = format("Hello {}", "world");
+/// val b = format("{} + {} = {}", 2, 3, 5);
+/// val c = format("hello");
 /// ```
 ///
 /// Non-int fallback examples:
 /// ```tolk
-/// format1("{:x}", "abc");   // "abc"
-/// format1("{:ton}", true);  // "true"
+/// format("{:x}", "abc");   // "abc"
+/// format("{:ton}", true);  // "true"
 /// ```
-fun format1<T1>(fmt: string, arg1: T1): string {
-    return ffi.format1(fmt, reflect.typeNameOfObject(arg1), arg1.toTuple());
-}
-
-/// Formats a string with 2 arguments.
-///
-/// Uses the same placeholder rules and edge-case behavior as [format1].
-///
-/// Example:
-/// ```tolk
-/// val msg = format2("{}: {}", "name", "John");
-/// println(msg);  // prints "name: John"
-/// ```
-fun format2<T1, T2>(fmt: string, arg1: T1, arg2: T2): string {
-    return ffi.format2(
-        fmt,
-        reflect.typeNameOfObject(arg1),
-        arg1.toTuple(),
-        reflect.typeNameOfObject(arg2),
-        arg2.toTuple(),
-    );
-}
-
-/// Formats a string with 3 arguments.
-///
-/// Uses the same placeholder rules and edge-case behavior as [format1].
-///
-/// Example:
-/// ```tolk
-/// val msg = format3("{} + {} = {}", 2, 3, 5);
-/// println(msg);  // prints "2 + 3 = 5"
-/// ```
-fun format3<T1, T2, T3>(fmt: string, arg1: T1, arg2: T2, arg3: T3): string {
-    return ffi.format3(
-        fmt,
-        reflect.typeNameOfObject(arg1),
-        arg1.toTuple(),
-        reflect.typeNameOfObject(arg2),
-        arg2.toTuple(),
-        reflect.typeNameOfObject(arg3),
-        arg3.toTuple(),
-    );
-}
-
-/// Formats a string with 4 arguments.
-///
-/// Uses the same placeholder rules and edge-case behavior as [format1].
-///
-/// Example:
-/// ```tolk
-/// val msg = format4("{} {} {} {}", "a", "b", "c", "d");
-/// println(msg);  // prints "a b c d"
-/// ```
-fun format4<T1, T2, T3, T4>(fmt: string, arg1: T1, arg2: T2, arg3: T3, arg4: T4): string {
-    return ffi.format4(
-        fmt,
-        reflect.typeNameOfObject(arg1),
-        arg1.toTuple(),
-        reflect.typeNameOfObject(arg2),
-        arg2.toTuple(),
-        reflect.typeNameOfObject(arg3),
-        arg3.toTuple(),
-        reflect.typeNameOfObject(arg4),
-        arg4.toTuple(),
-    );
-}
-
-/// Formats a string with 5 arguments.
-///
-/// Uses the same placeholder rules and edge-case behavior as [format1].
-///
-/// Example:
-/// ```tolk
-/// val msg = format5("{} {} {} {} {}", 1, 2, 3, 4, 5);
-/// println(msg);  // prints "1 2 3 4 5"
-/// ```
-fun format5<T1, T2, T3, T4, T5>(
+fun format<T1 = void, T2 = void, T3 = void, T4 = void, T5 = void>(
     fmt: string,
     arg1: T1,
     arg2: T2,
@@ -140,7 +66,7 @@ fun format5<T1, T2, T3, T4, T5>(
     arg4: T4,
     arg5: T5,
 ): string {
-    return ffi.format5(
+    return ffi.format(
         fmt,
         reflect.typeNameOfObject(arg1),
         arg1.toTuple(),
@@ -155,13 +81,5 @@ fun format5<T1, T2, T3, T4, T5>(
     );
 }
 
-fun ffi.format1(fmt: string, type1: string, arg1: tuple): string
+fun ffi.format(fmt: string, type1: string, arg1: tuple, type2: string, arg2: tuple, type3: string, arg3: tuple, type4: string, arg4: tuple, type5: string, arg5: tuple): string
     asm "200 EXTCALL"
-fun ffi.format2(fmt: string, type1: string, arg1: tuple, type2: string, arg2: tuple): string
-    asm "201 EXTCALL"
-fun ffi.format3(fmt: string, type1: string, arg1: tuple, type2: string, arg2: tuple, type3: string, arg3: tuple): string
-    asm "202 EXTCALL"
-fun ffi.format4(fmt: string, type1: string, arg1: tuple, type2: string, arg2: tuple, type3: string, arg3: tuple, type4: string, arg4: tuple): string
-    asm "203 EXTCALL"
-fun ffi.format5(fmt: string, type1: string, arg1: tuple, type2: string, arg2: tuple, type3: string, arg3: tuple, type4: string, arg4: tuple, type5: string, arg5: tuple): string
-    asm "204 EXTCALL"

--- a/lib/fs.tolk
+++ b/lib/fs.tolk
@@ -38,7 +38,7 @@ struct fs
 /// ```tolk
 /// val content = fs.readFile("config.txt");
 /// if (content != null) {
-///     println1("File content: {}", content);
+///     println("File content: {}", content);
 /// } else {
 ///     println("File not found");
 /// }

--- a/lib/io.tolk
+++ b/lib/io.tolk
@@ -13,18 +13,24 @@
 /// println(point); // Output: Point { x: 10, y: 20 }
 ///
 /// // Formatted output
-/// println1("Iteration: {}", 5);
-/// println2("Transfer {} to {}", amount, myAddress);
+/// println("Iteration: {}", 5);
+/// println("Transfer {} to {}", amount, myAddress);
+/// println("hello", "world");
+/// println(1, 2);
 ///
 /// // Error logging
 /// eprintln("Critical failure in setup!");
 /// ```
 
 import "@stdlib/reflection"
-import "fmt"
 import "ffi/ffi"
 
-/// Prints the given value to the standard output.
+/// Prints up to 6 values to the standard output.
+///
+/// If the first argument is a `string`, `println` tries to interpret it as a format string.
+/// Placeholder-consumed arguments are rendered into that string, and any remaining arguments
+/// are appended separated by spaces. If the string is not a valid format string, it is printed
+/// literally and the remaining arguments are still appended separated by spaces.
 ///
 /// Example:
 /// ```tolk
@@ -35,89 +41,47 @@ import "ffi/ffi"
 ///     value: 10,
 ///     is_set: true
 /// });
-/// ```
-fun println<T>(value: T): void {
-    ffi.println(reflect.typeNameOfObject(value), value.toTuple());
-}
-
-/// Prints the given value to the standard output formatted according to format string.
 ///
-/// Example:
-/// ```tolk
-/// println1("Hello, 0x{:x}", 10);
+/// println("Hello, 0x{:x}", 10);
+/// println("{} -> {}", "from", "to");
+/// println("value {}", 42);
+/// println(1, 2);
 /// ```
 ///
-/// Format supports the following placeholders:
+/// Format supports the following placeholders when the first argument is a string:
 /// - `{}` - default formatter output
 /// - `{:x}` - formats an int as lowercase hexadecimal without `0x` prefix
 /// - `{:ton}` - formats an int amount in nanotons as `<value> TON`
 ///
 /// Notes:
 /// - Escape literal braces with `{{` and `}}`.
-/// - Invalid format strings fail at runtime with parser errors that include byte positions
-///   (for example: unknown modifiers, unsupported placeholder payload, unclosed `{`,
-///   unmatched `}`).
+/// - If the first string is an invalid format string, it is printed literally.
 /// - If placeholders outnumber arguments, unmatched placeholders stay in output as text.
-/// - If arguments outnumber placeholders, extra arguments are ignored.
+/// - If arguments outnumber placeholders, extra arguments are appended after the formatted text.
 /// - For non-int arguments, `{:x}` and `{:ton}` fall back to the same behavior as `{}`.
 /// - `{:ton}` uses floating-point conversion, so very large values can be rounded.
-fun println1<T>(fmt: string, value: T): void {
-    println(format1(fmt, value));
-}
-
-/// Prints the given values to the standard output formatted according to format string.
-///
-/// Uses the same placeholder rules and edge-case behavior as [println1].
-///
-/// Example:
-/// ```tolk
-/// println2("{} -> {}", "from", "to");
-/// ```
-fun println2<T1, T2>(fmt: string, value1: T1, value2: T2): void {
-    println(format2(fmt, value1, value2));
-}
-
-/// Prints the given values to the standard output formatted according to format string.
-///
-/// Uses the same placeholder rules and edge-case behavior as [println1].
-///
-/// Example:
-/// ```tolk
-/// println3("{} + {} = {}", 2, 3, 5);
-/// ```
-fun println3<T1, T2, T3>(fmt: string, value1: T1, value2: T2, value3: T3): void {
-    println(format3(fmt, value1, value2, value3));
-}
-
-/// Prints the given values to the standard output formatted according to format string.
-///
-/// Uses the same placeholder rules and edge-case behavior as [println1].
-///
-/// Example:
-/// ```tolk
-/// println4("{} {} {} {}", "a", "b", "c", "d");
-/// ```
-fun println4<T1, T2, T3, T4>(fmt: string, value1: T1, value2: T2, value3: T3, value4: T4): void {
-    println(format4(fmt, value1, value2, value3, value4));
-}
-
-/// Prints the given values to the standard output formatted according to format string.
-///
-/// Uses the same placeholder rules and edge-case behavior as [println1].
-///
-/// Example:
-/// ```tolk
-/// println5("{} {} {} {} {}", 1, 2, 3, 4, 5);
-/// ```
-fun println5<T1, T2, T3, T4, T5>(
-    fmt: string,
+fun println<T1, T2 = void, T3 = void, T4 = void, T5 = void, T6 = void>(
     value1: T1,
     value2: T2,
     value3: T3,
     value4: T4,
     value5: T5,
+    value6: T6,
 ): void {
-    println(format5(fmt, value1, value2, value3, value4, value5));
+    ffi.println(
+        reflect.typeNameOfObject(value1),
+        value1.toTuple(),
+        reflect.typeNameOfObject(value2),
+        value2.toTuple(),
+        reflect.typeNameOfObject(value3),
+        value3.toTuple(),
+        reflect.typeNameOfObject(value4),
+        value4.toTuple(),
+        reflect.typeNameOfObject(value5),
+        value5.toTuple(),
+        reflect.typeNameOfObject(value6),
+        value6.toTuple(),
+    );
 }
 
 /// Prints the given slice string to the standard error output.
@@ -130,7 +94,7 @@ fun eprintln(str: string): void {
     ffi.eprintln(str);
 }
 
-fun ffi.println(typeName: string, str: tuple): void
+fun ffi.println(type1: string, arg1: tuple, type2: string, arg2: tuple, type3: string, arg3: tuple, type4: string, arg4: tuple, type5: string, arg5: tuple, type6: string, arg6: tuple): void
     asm "1 EXTCALL"
 fun ffi.eprintln(str: string): void
     asm "2 EXTCALL"

--- a/lib/promts/prompts.tolk
+++ b/lib/promts/prompts.tolk
@@ -32,7 +32,7 @@ import "../ffi/ffi"
 /// Example:
 /// ```tolk
 /// val name = prompt("What is your name?", "John");
-/// println(format1("Hello {}", name));
+/// println("Hello {}", name);
 /// ```
 fun prompt(message: string, placeholder: string = ""): string {
     return ffi.prompt(message, placeholder);
@@ -49,7 +49,7 @@ fun prompt(message: string, placeholder: string = ""): string {
 /// Example:
 /// ```tolk
 /// val name = select("What is your name?", ["John", "Jane", "Jim"] as tuple);
-/// println(format1("Hello {}", name));
+/// println("Hello {}", name);
 /// ```
 fun select(message: string, variants: tuple): string {
     return ffi.select(message, variants);

--- a/lib/testing/assert.tolk
+++ b/lib/testing/assert.tolk
@@ -277,7 +277,7 @@ fun ffi.assertConsumedLess(start: int, end: int, expected: int): void {
     val consumed = end - start - 26; // 26 gas cost of GASCONSUMED
     if (consumed > expected) {
         Assert.fail(
-            format2(
+            format(
                 "Gas consumption was expected to be less than or equal to {}, but {} was consumed",
                 expected,
                 consumed,

--- a/lib/testing/expect.tolk
+++ b/lib/testing/expect.tolk
@@ -172,7 +172,7 @@ fun Expectation<int>.toBeApproxEqAbs(self, expected: int, maxDelta: int): void {
     val realDelta = abs(self.value - expected);
     if (realDelta > maxDelta) {
         ffi.assertFail(
-            format4(
+            format(
                 "{} !~= {} (max delta: {}, real delta: {})",
                 self.value,
                 expected,
@@ -205,7 +205,7 @@ fun Expectation<int>.toBeApproxEqRel(self, expected: int, maxDelta: int): void {
     if (denominator == 0) {
         if (valueDelta > 0) {
             ffi.assertFail(
-                format3(
+                format(
                     "{} !~= {} (max delta: {}%, real delta: inf%)",
                     self.value,
                     expected,
@@ -221,7 +221,7 @@ fun Expectation<int>.toBeApproxEqRel(self, expected: int, maxDelta: int): void {
     val percent = mulDivFloor(valueDelta, 100, denominator);
     if (percent > maxDelta) {
         ffi.assertFail(
-            format4(
+            format(
                 "{} !~= {} (max delta: {}%, real delta: {}%)",
                 self.value,
                 expected,
@@ -530,7 +530,7 @@ fun Expectation<map<K, V>>.toContainKey(self, key: K): void {
     val result = self.value.get(key);
     if (!result.isFound) {
         Assert.fail(
-            format1(
+            format(
                 "expect(<actual>).toContainKey(<expected>): Key '{}' not found in the map",
                 key,
             ),
@@ -552,7 +552,7 @@ fun Expectation<map<K, V>>.toNotContainKey(self, key: K): void {
     val result = self.value.get(key);
     if (result.isFound) {
         Assert.fail(
-            format1(
+            format(
                 "expect(<actual>).toNotContainKey(<expected>): Key '{}' is found in the map",
                 key,
             ),
@@ -581,7 +581,7 @@ fun Expectation<map<K, V>>.toContainValue(self, value: V): void {
     }
 
     Assert.fail(
-        format1(
+        format(
             "expect(<actual>).toContainValue(<expected>): Value '{}' not found in the map",
             value,
         ),
@@ -604,7 +604,7 @@ fun Expectation<map<K, V>>.toNotContainValue(self, value: V): void {
         val mapValue = r.loadValue();
         if (mapValue == value) {
             Assert.fail(
-                format1(
+                format(
                     "expect(<actual>).toNotContainValue(<expected>): Value '{}' is found in the map",
                     value,
                 ),
@@ -664,7 +664,7 @@ fun Expectation<map<K, V>>.toHaveLength(self, length: int): void {
 }
 
 fun formatExpectLocation(loc: SourceLocation): string {
-    return format3("{}:{}:{}", loc.fileName, loc.lineNo, loc.charNo);
+    return format("{}:{}:{}", loc.fileName, loc.lineNo, loc.charNo);
 }
 
 /// Creates a new expectation for the given value.

--- a/lib/testing/fuzz.tolk
+++ b/lib/testing/fuzz.tolk
@@ -51,7 +51,7 @@ fun fuzz.bound<T>(
     val maxInt = maxValue as int;
     if (minInt > maxInt) {
         Assert.fail(
-            format2(
+            format(
                 "fuzz.bound(<value>, <min>, <max>): min {} must be less than or equal to max {}",
                 minInt,
                 maxInt,
@@ -84,5 +84,5 @@ fun fuzz.bound<T>(
 }
 
 fun formatFuzzLocation(loc: SourceLocation): string {
-    return format3("{}:{}:{}", loc.fileName, loc.lineNo, loc.charNo);
+    return format("{}:{}:{}", loc.fileName, loc.lineNo, loc.charNo);
 }

--- a/lib/testing/outlist_expect.tolk
+++ b/lib/testing/outlist_expect.tolk
@@ -67,12 +67,12 @@ fun Expectation<OutActionList>.toBeSendMessageAt<Msg>(self, index: int): void {
                 val opcodeTypeName = ffi.typeNameByOpcode(opcode);
 
                 Assert.fail(
-                    format4(
+                    format(
                         "Out action is a send message, but it cannot be load as a `{}` (opcode: 0x{:x}) since body has opcode 0x{:x}{}",
                         reflect.typeNameOf<Msg>(),
                         reflect.serializationPrefixOf<Msg>().0,
                         opcode,
-                        opcodeTypeName == null ? "" : format1(" ({})", opcodeTypeName),
+                        opcodeTypeName == null ? "" : format(" ({})", opcodeTypeName),
                     ),
                     self.location,
                 );
@@ -83,14 +83,14 @@ fun Expectation<OutActionList>.toBeSendMessageAt<Msg>(self, index: int): void {
         return;
     }
 
-    Assert.fail(format1("Out action at index {} is not a send message", index), self.location);
+    Assert.fail(format("Out action at index {} is not a send message", index), self.location);
 }
 
 struct expectImpl
 
 fun expectImpl.failToFindOutMsg<Msg>(exitCode: int, location: string): never {
     Assert.fail(
-        format2(
+        format(
             "Out action is a send message, but it cannot be load as a `{}` due to exit code {}",
             reflect.typeNameOf<Msg>(),
             exitCode,

--- a/lib/testing/transaction_expect.tolk
+++ b/lib/testing/transaction_expect.tolk
@@ -298,7 +298,7 @@ fun Expectation<SendResultList>.toEmitExternalMessage<Msg>(self): void {
     }
 
     Assert.fail(
-        format3(
+        format(
             "expect(<actual>).toEmitExternalMessage<{}>(): Cannot find external message {} (opcode: 0x{:x})",
             reflect.typeNameOf<Msg>(),
             reflect.typeNameOf<Msg>(),

--- a/lib/types/message.tolk
+++ b/lib/types/message.tolk
@@ -10,7 +10,7 @@
 /// if (action != null) {
 ///     val msg = action.loadMessage<Transfer>();
 ///     val body = msg.loadBody();
-///     println1("Transfer amount: {:ton}", body.amount);
+///     println("Transfer amount: {:ton}", body.amount);
 /// }
 ///
 /// // Parsing a generic message to check opcode

--- a/lib/types/out_actions.tolk
+++ b/lib/types/out_actions.tolk
@@ -11,13 +11,13 @@
 /// // Check the first action
 /// val firstAction = actions.at(0);
 /// if (firstAction is OutActionSendMessage) {
-///     println1("Sending message with mode: {}", firstAction.mode);
+///     println("Sending message with mode: {}", firstAction.mode);
 /// }
 ///
 /// // Get specific message body
 /// val transfer = actions.getSendMessageBodyAt<Transfer>(0);
 /// if (transfer != null) {
-///     println1("Transferred: {:ton}", transfer.amount);
+///     println("Transferred: {:ton}", transfer.amount);
 /// }
 /// ```
 
@@ -194,7 +194,7 @@ fun OutActionList.at(self, i: int): OutAction {
     try {
         return rawAction.load();
     } catch (e) {
-        Assert.fail(format2("Unknown out action at index {} (decode error code {})", i, e));
+        Assert.fail(format("Unknown out action at index {} (decode error code {})", i, e));
     }
 }
 

--- a/lib/types/transaction.tolk
+++ b/lib/types/transaction.tolk
@@ -9,14 +9,14 @@
 ///
 /// // Check gas usage
 /// val gas = tx.getUsedGas();
-/// println1("Gas used: {}", gas);
+/// println("Gas used: {}", gas);
 ///
 /// // Inspect account status change
 /// val description = tx.description.load();
 /// if (description is TransOrd) {
 ///     val compute = description.computePh;
 ///     if (compute is TrComputeVm) {
-///         println1("VM exit code: {}", compute.exitCode);
+///         println("VM exit code: {}", compute.exitCode);
 ///     }
 /// }
 /// ```

--- a/src/commands/new/templates/counter-app/contracts/scripts/deploy.tolk
+++ b/src/commands/new/templates/counter-app/contracts/scripts/deploy.tolk
@@ -15,6 +15,6 @@ fun main() {
         return;
     }
 
-    println1("Deployed counter to {}", counter.address);
-    println1("Counter value is {}", counter.currentCounter());
+    println("Deployed counter to {}", counter.address);
+    println("Counter value is {}", counter.currentCounter());
 }

--- a/src/commands/new/templates/counter/scripts/deploy.tolk
+++ b/src/commands/new/templates/counter/scripts/deploy.tolk
@@ -16,6 +16,6 @@ fun main() {
         return;
     }
 
-    println1("Deployed counter to {}", counter.address);
-    println1("Counter value is {}", counter.currentCounter());
+    println("Deployed counter to {}", counter.address);
+    println("Counter value is {}", counter.currentCounter());
 }

--- a/src/commands/new/templates/empty/scripts/deploy.tolk
+++ b/src/commands/new/templates/empty/scripts/deploy.tolk
@@ -13,6 +13,6 @@ fun main() {
         return;
     }
 
-    println1("Deployed starter contract to {}", contract.address);
-    println1("Owner is {}", contract.owner());
+    println("Deployed starter contract to {}", contract.address);
+    println("Owner is {}", contract.owner());
 }

--- a/src/commands/new/templates/jetton/scripts/deploy.tolk
+++ b/src/commands/new/templates/jetton/scripts/deploy.tolk
@@ -20,7 +20,7 @@ fun string.toSnakeString(self): cell {
 }
 
 fun buildOnchainMetadata(info: JettonInfo): cell {
-    println1("Deploying Jetton with {}", info);
+    println("Deploying Jetton with {}", info);
 
     var dict: map<uint256, cell> = [];
 
@@ -59,9 +59,9 @@ fun main() {
         return;
     }
 
-    println1("Deployed Jetton minter to {}", minter.address);
+    println("Deployed Jetton minter to {}", minter.address);
 
-    println1("Minting tokens: {}", supply);
+    println("Minting tokens: {}", supply);
     val mintRes = minter.sendMint(
         deployer.address,
         deployer.address,
@@ -73,6 +73,6 @@ fun main() {
         return;
     }
 
-    println2("Successfully minted and transferred {} tokens to {}", supply, deployer.address);
-    println1("Total supply is {}", minter.getTotalSupply());
+    println("Successfully minted and transferred {} tokens to {}", supply, deployer.address);
+    println("Total supply is {}", minter.getTotalSupply());
 }

--- a/src/ffi/io.rs
+++ b/src/ffi/io.rs
@@ -7,21 +7,53 @@ use num_traits::ToPrimitive;
 use std::io::{IsTerminal, stdin};
 use ton_emulator::{extension, register_ext_methods};
 use ton_executor::BaseExecutor;
+use tvmffi::from_stack::FromStack;
 use tvmffi::stack::{Tuple, TupleItem};
 
-extension!(println in (Context) with (s: TupleItem, type_name: String) using println_impl);
+extension!(println in (Context) with (arg6: TupleItem, type6: String, arg5: TupleItem, type5: String, arg4: TupleItem, type4: String, arg3: TupleItem, type3: String, arg2: TupleItem, type2: String, arg1: TupleItem, type1: String) using println_impl);
+#[allow(clippy::too_many_arguments)]
 fn println_impl(
     ctx: &mut Context,
     _stack: &mut Tuple,
-    arg: TupleItem,
-    type_name: String,
+    arg6: TupleItem,
+    type6: String,
+    arg5: TupleItem,
+    type5: String,
+    arg4: TupleItem,
+    type4: String,
+    arg3: TupleItem,
+    type3: String,
+    arg2: TupleItem,
+    type2: String,
+    arg1: TupleItem,
+    type1: String,
 ) -> anyhow::Result<()> {
-    let typed_arg = arg.unwrap_single().to_typed(&type_name);
-
-    let formatted = {
-        let formatter = FormatterContext::from_context(ctx);
-        formatter.format_with_color(&typed_arg)
+    let args = collect_non_void_args([
+        (type1, arg1),
+        (type2, arg2),
+        (type3, arg3),
+        (type4, arg4),
+        (type5, arg5),
+        (type6, arg6),
+    ]);
+    let formatter = FormatterContext::from_context(ctx);
+    let (mut formatted, tail) = if let Some((type_name, arg)) = args.first()
+        && type_name == "string"
+        && let Ok(fmt) = String::from_item(arg.clone().unwrap_single())
+        && let Ok((rendered, consumed)) = format_args(&formatter, &fmt, &args[1..])
+    {
+        (rendered, &args[1 + consumed..])
+    } else {
+        (String::new(), args.as_slice())
     };
+
+    for (type_name, arg) in tail {
+        if !formatted.is_empty() {
+            formatted.push(' ');
+        }
+        let typed_arg = arg.unwrap_single().to_typed(type_name);
+        formatted.push_str(&formatter.format_with_color(&typed_arg));
+    }
 
     if ctx.io.capture_output {
         ctx.io.stdout_buffer.push_str(&formatted);
@@ -43,79 +75,9 @@ fn eprintln_impl(ctx: &mut Context, _stack: &mut Tuple, s: String) -> anyhow::Re
     Ok(())
 }
 
-extension!(format1 in (Context) with (arg1: TupleItem, type1: String, fmt: String) using format1_impl);
-fn format1_impl(
-    ctx: &mut Context,
-    stack: &mut Tuple,
-    arg1: TupleItem,
-    type1: String,
-    fmt: String,
-) -> anyhow::Result<()> {
-    let args = vec![(type1, arg1)];
-    let result = format_args(ctx, fmt, args)?;
-    stack.push_string(&result);
-    Ok(())
-}
-
-extension!(format2 in (Context) with (arg2: TupleItem, type2: String, arg1: TupleItem, type1: String, fmt: String) using format2_impl);
-fn format2_impl(
-    ctx: &mut Context,
-    stack: &mut Tuple,
-    arg2: TupleItem,
-    type2: String,
-    arg1: TupleItem,
-    type1: String,
-    fmt: String,
-) -> anyhow::Result<()> {
-    let args = vec![(type1, arg1), (type2, arg2)];
-    let result = format_args(ctx, fmt, args)?;
-    stack.push_string(&result);
-    Ok(())
-}
-
-extension!(format3 in (Context) with (arg3: TupleItem, type3: String, arg2: TupleItem, type2: String, arg1: TupleItem, type1: String, fmt: String) using format3_impl);
+extension!(format in (Context) with (arg5: TupleItem, type5: String, arg4: TupleItem, type4: String, arg3: TupleItem, type3: String, arg2: TupleItem, type2: String, arg1: TupleItem, type1: String, fmt: String) using format_impl);
 #[allow(clippy::too_many_arguments)]
-fn format3_impl(
-    ctx: &mut Context,
-    stack: &mut Tuple,
-    arg3: TupleItem,
-    type3: String,
-    arg2: TupleItem,
-    type2: String,
-    arg1: TupleItem,
-    type1: String,
-    fmt: String,
-) -> anyhow::Result<()> {
-    let args = vec![(type1, arg1), (type2, arg2), (type3, arg3)];
-    let result = format_args(ctx, fmt, args)?;
-    stack.push_string(&result);
-    Ok(())
-}
-
-extension!(format4 in (Context) with (arg4: TupleItem, type4: String, arg3: TupleItem, type3: String, arg2: TupleItem, type2: String, arg1: TupleItem, type1: String, fmt: String) using format4_impl);
-#[allow(clippy::too_many_arguments)]
-fn format4_impl(
-    ctx: &mut Context,
-    stack: &mut Tuple,
-    arg4: TupleItem,
-    type4: String,
-    arg3: TupleItem,
-    type3: String,
-    arg2: TupleItem,
-    type2: String,
-    arg1: TupleItem,
-    type1: String,
-    fmt: String,
-) -> anyhow::Result<()> {
-    let args = vec![(type1, arg1), (type2, arg2), (type3, arg3), (type4, arg4)];
-    let result = format_args(ctx, fmt, args)?;
-    stack.push_string(&result);
-    Ok(())
-}
-
-extension!(format5 in (Context) with (arg5: TupleItem, type5: String, arg4: TupleItem, type4: String, arg3: TupleItem, type3: String, arg2: TupleItem, type2: String, arg1: TupleItem, type1: String, fmt: String) using format5_impl);
-#[allow(clippy::too_many_arguments)]
-fn format5_impl(
+fn format_impl(
     ctx: &mut Context,
     stack: &mut Tuple,
     arg5: TupleItem,
@@ -130,14 +92,15 @@ fn format5_impl(
     type1: String,
     fmt: String,
 ) -> anyhow::Result<()> {
-    let args = vec![
+    let args = collect_non_void_args([
         (type1, arg1),
         (type2, arg2),
         (type3, arg3),
         (type4, arg4),
         (type5, arg5),
-    ];
-    let result = format_args(ctx, fmt, args)?;
+    ]);
+    let formatter = FormatterContext::from_context(ctx);
+    let (result, _) = format_args(&formatter, &fmt, &args)?;
     stack.push_string(&result);
     Ok(())
 }
@@ -277,23 +240,37 @@ fn format_single_arg(
     }
 }
 
+fn collect_non_void_args<const N: usize>(
+    args: [(String, TupleItem); N],
+) -> Vec<(String, TupleItem)> {
+    let mut collected = Vec::with_capacity(N);
+    for (type_name, arg) in args {
+        if type_name == "void" {
+            break;
+        }
+        collected.push((type_name, arg));
+    }
+    collected
+}
+
 fn format_args(
-    ctx: &mut Context,
-    fmt: String,
-    args: Vec<(String, TupleItem)>,
-) -> anyhow::Result<String> {
-    let tokens = parse_format(&fmt)?;
+    formatter: &FormatterContext<'_>,
+    fmt: &str,
+    args: &[(String, TupleItem)],
+) -> anyhow::Result<(String, usize)> {
+    let tokens = parse_format(fmt)?;
     let mut out = String::with_capacity(fmt.len());
-    let mut args_iter = args.into_iter();
-    let formatter = FormatterContext::from_context(ctx);
+    let mut args_iter = args.iter().cloned();
+    let mut consumed = 0;
 
     for token in tokens {
         match token {
             FormatToken::Literal(text) => out.push_str(&text),
             FormatToken::Placeholder(kind) => {
                 if let Some((type_name, arg)) = args_iter.next() {
-                    let formatted = format_single_arg(&formatter, kind, &type_name, arg);
+                    let formatted = format_single_arg(formatter, kind, &type_name, arg);
                     out.push_str(&formatted);
+                    consumed += 1;
                 } else {
                     out.push_str(placeholder_repr(kind));
                 }
@@ -301,7 +278,7 @@ fn format_args(
         }
     }
 
-    Ok(out)
+    Ok((out, consumed))
 }
 
 extension!(prompt in (Context) with (placeholder: String, message: String) using prompt_impl);
@@ -368,13 +345,9 @@ fn confirm_impl(
 
 pub fn register_extensions<T: BaseExecutor>(executor: &mut T, ctx: &mut Context) {
     register_ext_methods!(executor, ctx, {
-        1 => println : 2,
+        1 => println : 12,
         2 => eprintln : 1,
-        200 => format1 : 3,
-        201 => format2 : 5,
-        202 => format3 : 7,
-        203 => format4 : 9,
-        204 => format5 : 11,
+        200 => format : 11,
         205 => prompt : 2,
         206 => select : 2,
         207 => confirm : 3,

--- a/tests/acton-stdlib/fmt.test.tolk
+++ b/tests/acton-stdlib/fmt.test.tolk
@@ -36,14 +36,14 @@ struct VeryNested1 {
 }
 
 get fun `test-format-struct-with-single-field`() {
-    expect(format1("{}", SingleInt { a: 100 })).toEqual("""SingleInt {
+    expect(format("{}", SingleInt { a: 100 })).toEqual("""SingleInt {
     a: 100
 }""");
 }
 
 get fun `test-format-struct-with-two-fields`() {
     expect(
-        format1(
+        format(
             "{}",
             DoubleInt {
                 a: 100,
@@ -58,7 +58,7 @@ get fun `test-format-struct-with-two-fields`() {
 
 get fun `test-format-struct-with-nested-single-int`() {
     expect(
-        format1(
+        format(
             "{}",
             DoubleIntAndNestedSingleInt {
                 a: 100,
@@ -77,7 +77,7 @@ get fun `test-format-struct-with-nested-single-int`() {
 
 get fun `test-format-struct-with-nested-double-int`() {
     expect(
-        format1("{}", DoubleIntAndNestedDoubleInt {}),
+        format("{}", DoubleIntAndNestedDoubleInt {}),
     ).toEqual("""DoubleIntAndNestedDoubleInt {
     a: 3,
     b: 4,
@@ -89,7 +89,7 @@ get fun `test-format-struct-with-nested-double-int`() {
 }
 
 get fun `test-format-struct-with-very-nested-`() {
-    val formatted = format1("{}", VeryNested {});
+    val formatted = format("{}", VeryNested {});
     expect(
         formatted,
     ).toEqual("""VeryNested {
@@ -122,7 +122,7 @@ get fun `test-format-message`() {
         loaded.info.createdLt = 0;
         loaded.info.createdAt = 0;
         expect(
-            format1("{}", loaded),
+            format("{}", loaded),
         ).toEqual("""MessageRelaxedGeneric {
     info: IntMsgInfoRelaxed {
         ihrDisabled: true,
@@ -146,11 +146,27 @@ get fun `test-format-message`() {
 }
 
 get fun `test-format-multiple-arguments-and-modifiers`() {
-    expect(format2("{} {:x}", "hex", 255)).toEqual("hex ff");
-    expect(format3("{} {} {:ton}", "value", 7, ton("1.5"))).toEqual("value 7 1.5 TON");
-    expect(format4("{{{}}} {} {} {}", 1, 2, 3, 4)).toEqual("{1} 2 3 4");
+    expect(format("{} {:x}", "hex", 255)).toEqual("hex ff");
+    expect(format("{} {} {:ton}", "value", 7, ton("1.5"))).toEqual("value 7 1.5 TON");
+    expect(format("{{{}}} {} {} {}", 1, 2, 3, 4)).toEqual("{1} 2 3 4");
     expect(
-        format5(
+        format(
+            "{} {} {} {} {}",
+            1,
+            2,
+            3,
+            4,
+            5,
+        ),
+    ).toEqual("1 2 3 4 5");
+}
+
+get fun `test-format-with-optional-arguments`() {
+    expect(format("hello")).toEqual("hello");
+    expect(format("value = {}", 42)).toEqual("value = 42");
+    expect(format("pair {} {}", 0, 0)).toEqual("pair 0 0");
+    expect(
+        format(
             "{} {} {} {} {}",
             1,
             2,

--- a/tests/debugging/real_test.rs
+++ b/tests/debugging/real_test.rs
@@ -175,10 +175,10 @@ fun main() {
     val (counter, deployer) = setupTest();
 
     val counterRes = net.runGetMethod<int, tuple>(counter.address, "currentCounter");
-    println(format1("Counter: {}", counterRes));
+    println("Counter: {}", counterRes);
 
     val info = net.getAccountState(counter.address)!;
-    println(format1("Balance: {:ton}", info.storage.balance.grams));
+    println("Balance: {:ton}", info.storage.balance.grams);
 
     val res = counter.sendIncrease(deployer.address, 100);
     println(res);

--- a/tests/debugging/snapshots/counter/test_real_counter_step_in.trace.txt
+++ b/tests/debugging/snapshots/counter/test_real_counter_step_in.trace.txt
@@ -7,7 +7,7 @@ Step 1 (before):
                                        ^^^^^^^^^^^
      71| 
      72|     val counterRes = net.runGetMethod<int, tuple>(counter.address, "currentCounter");
-     73|     println(format1("Counter: {}", counterRes));
+     73|     println("Counter: {}", counterRes);
 
 Step 2 (step_in):
   Code:
@@ -239,7 +239,7 @@ Step 18 (step_over):
                  ^^^^^^^^^^^^^^^^^^^
      71| 
      72|     val counterRes = net.runGetMethod<int, tuple>(counter.address, "currentCounter");
-     73|     println(format1("Counter: {}", counterRes));
+     73|     println("Counter: {}", counterRes);
 
 Step 19 (step_over):
   Code:
@@ -248,7 +248,7 @@ Step 19 (step_over):
      71| 
      72|     val counterRes = net.runGetMethod<int, tuple>(counter.address, "currentCounter");
                                                                             ^^^^^^^^^^^^^^^^
-     73|     println(format1("Counter: {}", counterRes));
+     73|     println("Counter: {}", counterRes);
      74| 
      75|     val info = net.getAccountState(counter.address)!;
   Variables:
@@ -260,11 +260,11 @@ Step 20 (step_over):
      70|     val (counter, deployer) = setupTest();
      71| 
      72|     val counterRes = net.runGetMethod<int, tuple>(counter.address, "currentCounter");
-     73|     println(format1("Counter: {}", counterRes));
-                             ^^^^^^^^^^^^^
+     73|     println("Counter: {}", counterRes);
+                     ^^^^^^^^^^^^^
      74| 
      75|     val info = net.getAccountState(counter.address)!;
-     76|     println(format1("Balance: {:ton}", info.storage.balance.grams));
+     76|     println("Balance: {:ton}", info.storage.balance.grams);
   Variables:
     counter = Counter
     deployer = Treasury
@@ -273,11 +273,11 @@ Step 20 (step_over):
 Step 21 (step_over):
   Code:
      72|     val counterRes = net.runGetMethod<int, tuple>(counter.address, "currentCounter");
-     73|     println(format1("Counter: {}", counterRes));
+     73|     println("Counter: {}", counterRes);
      74| 
      75|     val info = net.getAccountState(counter.address)!;
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-     76|     println(format1("Balance: {:ton}", info.storage.balance.grams));
+     76|     println("Balance: {:ton}", info.storage.balance.grams);
      77| 
      78|     val res = counter.sendIncrease(deployer.address, 100);
   Variables:
@@ -287,11 +287,11 @@ Step 21 (step_over):
 
 Step 22 (step_over):
   Code:
-     73|     println(format1("Counter: {}", counterRes));
+     73|     println("Counter: {}", counterRes);
      74| 
      75|     val info = net.getAccountState(counter.address)!;
-     76|     println(format1("Balance: {:ton}", info.storage.balance.grams));
-                             ^^^^^^^^^^^^^^^^^
+     76|     println("Balance: {:ton}", info.storage.balance.grams);
+                     ^^^^^^^^^^^^^^^^^
      77| 
      78|     val res = counter.sendIncrease(deployer.address, 100);
      79|     println(res);
@@ -304,7 +304,7 @@ Step 22 (step_over):
 Step 23 (step_over):
   Code:
      75|     val info = net.getAccountState(counter.address)!;
-     76|     println(format1("Balance: {:ton}", info.storage.balance.grams));
+     76|     println("Balance: {:ton}", info.storage.balance.grams);
      77| 
      78|     val res = counter.sendIncrease(deployer.address, 100);
                                ^^^^^^^^^^^^
@@ -319,7 +319,7 @@ Step 23 (step_over):
 
 Step 24 (step_over):
   Code:
-     76|     println(format1("Balance: {:ton}", info.storage.balance.grams));
+     76|     println("Balance: {:ton}", info.storage.balance.grams);
      77| 
      78|     val res = counter.sendIncrease(deployer.address, 100);
      79|     println(res);

--- a/tests/debugging/snapshots/counter/test_real_counter_tests.trace.txt
+++ b/tests/debugging/snapshots/counter/test_real_counter_tests.trace.txt
@@ -7,7 +7,7 @@ Step 1 (before):
                                        ^^^^^^^^^^^
      71| 
      72|     val counterRes = net.runGetMethod<int, tuple>(counter.address, "currentCounter");
-     73|     println(format1("Counter: {}", counterRes));
+     73|     println("Counter: {}", counterRes);
 
 Step 2 (step_over):
   Code:
@@ -16,7 +16,7 @@ Step 2 (step_over):
      71| 
      72|     val counterRes = net.runGetMethod<int, tuple>(counter.address, "currentCounter");
                                                                             ^^^^^^^^^^^^^^^^
-     73|     println(format1("Counter: {}", counterRes));
+     73|     println("Counter: {}", counterRes);
      74| 
      75|     val info = net.getAccountState(counter.address)!;
   Variables:
@@ -28,11 +28,11 @@ Step 3 (step_over):
      70|     val (counter, deployer) = setupTest();
      71| 
      72|     val counterRes = net.runGetMethod<int, tuple>(counter.address, "currentCounter");
-     73|     println(format1("Counter: {}", counterRes));
-                             ^^^^^^^^^^^^^
+     73|     println("Counter: {}", counterRes);
+                     ^^^^^^^^^^^^^
      74| 
      75|     val info = net.getAccountState(counter.address)!;
-     76|     println(format1("Balance: {:ton}", info.storage.balance.grams));
+     76|     println("Balance: {:ton}", info.storage.balance.grams);
   Variables:
     counter = Counter
     deployer = Treasury
@@ -41,11 +41,11 @@ Step 3 (step_over):
 Step 4 (step_over):
   Code:
      72|     val counterRes = net.runGetMethod<int, tuple>(counter.address, "currentCounter");
-     73|     println(format1("Counter: {}", counterRes));
+     73|     println("Counter: {}", counterRes);
      74| 
      75|     val info = net.getAccountState(counter.address)!;
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-     76|     println(format1("Balance: {:ton}", info.storage.balance.grams));
+     76|     println("Balance: {:ton}", info.storage.balance.grams);
      77| 
      78|     val res = counter.sendIncrease(deployer.address, 100);
   Variables:
@@ -55,11 +55,11 @@ Step 4 (step_over):
 
 Step 5 (step_over):
   Code:
-     73|     println(format1("Counter: {}", counterRes));
+     73|     println("Counter: {}", counterRes);
      74| 
      75|     val info = net.getAccountState(counter.address)!;
-     76|     println(format1("Balance: {:ton}", info.storage.balance.grams));
-                             ^^^^^^^^^^^^^^^^^
+     76|     println("Balance: {:ton}", info.storage.balance.grams);
+                     ^^^^^^^^^^^^^^^^^
      77| 
      78|     val res = counter.sendIncrease(deployer.address, 100);
      79|     println(res);
@@ -72,7 +72,7 @@ Step 5 (step_over):
 Step 6 (step_over):
   Code:
      75|     val info = net.getAccountState(counter.address)!;
-     76|     println(format1("Balance: {:ton}", info.storage.balance.grams));
+     76|     println("Balance: {:ton}", info.storage.balance.grams);
      77| 
      78|     val res = counter.sendIncrease(deployer.address, 100);
                                ^^^^^^^^^^^^
@@ -87,7 +87,7 @@ Step 6 (step_over):
 
 Step 7 (step_over):
   Code:
-     76|     println(format1("Balance: {:ton}", info.storage.balance.grams));
+     76|     println("Balance: {:ton}", info.storage.balance.grams);
      77| 
      78|     val res = counter.sendIncrease(deployer.address, 100);
      79|     println(res);

--- a/tests/integration/litenode_tests.rs
+++ b/tests/integration/litenode_tests.rs
@@ -62,7 +62,7 @@ fun main() {
     });
     net.send(wallet.address, deployDeployer);
 
-    println1("DEPLOYER_CONTRACT={}", deployerAddress);
+    println("DEPLOYER_CONTRACT={}", deployerAddress);
 }
 "#;
 
@@ -131,7 +131,7 @@ fun main() {
     });
     net.send(wallet.address, deployGetter);
 
-    println1("GETTER_CONTRACT={}", getterAddress);
+    println("GETTER_CONTRACT={}", getterAddress);
 }
 "#;
 
@@ -243,8 +243,8 @@ fun main() {
     });
     net.send(wallet.address, deployWorkerViaManagerMsg);
 
-    println1("MANAGER_CONTRACT={}", managerAddress);
-    println1("WORKER_CONTRACT={}", workerAddress);
+    println("MANAGER_CONTRACT={}", managerAddress);
+    println("WORKER_CONTRACT={}", workerAddress);
 }
 "#;
 
@@ -279,8 +279,8 @@ fun main() {
     });
     net.send(wallet.address, triggerDestroyMsg);
 
-    println1("MANAGER_CONTRACT={}", managerAddress);
-    println1("WORKER_CONTRACT={}", workerAddress);
+    println("MANAGER_CONTRACT={}", managerAddress);
+    println("WORKER_CONTRACT={}", workerAddress);
 }
 "#;
 

--- a/tests/integration/rpc_tests.rs
+++ b/tests/integration/rpc_tests.rs
@@ -26,7 +26,7 @@ import "../../lib/io"
 
 fun main() {
     val wallet = net.wallet("deployer");
-    println1("DEPLOYER_ADDRESS={}", wallet.address);
+    println("DEPLOYER_ADDRESS={}", wallet.address);
 }
 "#;
 const DEPLOY_COUNTER_SCRIPT: &str = r#"
@@ -58,7 +58,7 @@ fun main() {
     });
     net.send(wallet.address, deployCounter);
 
-    println1("COUNTER_ADDRESS={}", counterAddress);
+    println("COUNTER_ADDRESS={}", counterAddress);
 }
 "#;
 

--- a/tests/integration/script_tests.rs
+++ b/tests/integration/script_tests.rs
@@ -413,9 +413,9 @@ fn test_script_with_tensor_args_and_struct() {
             }
 
             fun main(a: Abc) {
-                println1("a: {}", a.a);
-                println1("b: {}", a.b);
-                println1("c: {}", a.c);
+                println("a: {}", a.a);
+                println("b: {}", a.b);
+                println("c: {}", a.c);
             }
 
         "#,
@@ -448,9 +448,9 @@ fn test_script_with_args_and_struct() {
             }
 
             fun main(a: Abc) {
-                println1("a: {}", a.a);
-                println1("b: {}", a.b);
-                println1("c: {}", a.c);
+                println("a: {}", a.a);
+                println("b: {}", a.b);
+                println("c: {}", a.c);
             }
 
         "#,
@@ -479,7 +479,7 @@ fn test_script_with_null_arg() {
             import "../../lib/io"
 
             fun main(a: int?) {
-                println1("a: {}", a);
+                println("a: {}", a);
             }
 
         "#,
@@ -513,7 +513,7 @@ fn test_script_with_cell_arg() {
 
             fun main(a: cell) {
                 var slice = a.beginParse();
-                println1("a: {}", slice.loadUint(32));
+                println("a: {}", slice.loadUint(32));
             }
 
         "#,
@@ -543,7 +543,7 @@ fn test_script_with_slice_arg() {
             import "../../lib/io"
 
             fun main(a: slice) {
-                println1("a: {}", a.loadUint(32));
+                println("a: {}", a.loadUint(32));
             }
 
         "#,
@@ -574,7 +574,7 @@ fn test_script_with_string_arg() {
             import "../../lib/io"
 
             fun main(a: slice) {
-                println1("a: {}", a);
+                println("a: {}", a);
             }
 
         "#,
@@ -600,7 +600,7 @@ fn test_script_with_long_string_arg() {
             import "../../lib/io"
 
             fun main(a: slice) {
-                println1("a: {}", a);
+                println("a: {}", a);
             }
 
         "#,
@@ -626,7 +626,7 @@ fn test_script_with_invalid_arg() {
             import "../../lib/io"
 
             fun main(a: int) {
-                println1("a: {}", a);
+                println("a: {}", a);
             }
 
         "#,
@@ -661,7 +661,7 @@ fn test_script_to_calculate_storage_fee() {
 
                 val toReserve = calculateGasFeeWithoutFlatPrice(MASTERCHAIN, gasConsumedForCalculation)
                     + calculateStorageFee(MASTERCHAIN, duration, libraryBits, libraryRefs);
-                println1("{:ton}", toReserve);
+                println("{:ton}", toReserve);
             }
         "#,
         )
@@ -1122,10 +1122,10 @@ fn test_script_multi_arg_println_helpers_snapshot() {
             import "../../lib/io"
 
             fun main() {
-                println2("{} + {}", "left", "right");
-                println3("hex={:x} ton={:ton} label={}", 255, 2500000000, "ok");
-                println4("{} {} {} {}", "a", "b", "c", "d");
-                println5("{} {} {} {} {}", 1, 2, 3, 4, 5);
+                println("{} + {}", "left", "right");
+                println("hex={:x} ton={:ton} label={}", 255, 2500000000, "ok");
+                println("{} {} {} {}", "a", "b", "c", "d");
+                println("{} {} {} {} {}", 1, 2, 3, 4, 5);
             }
         "#,
         )
@@ -1272,7 +1272,7 @@ fn test_script_broadcast_with_nonexistent_wallet_with_wallets() {
                 println("Attempting to deploy with nonexistent wallet");
                 // This should fail because wallet "nonexistent" is not defined
                 val wallet = net.wallet("nonexistent");
-                println1("Wallet found: {}", wallet.address);
+                println("Wallet found: {}", wallet.address);
             }
         "#,
         )
@@ -1326,7 +1326,7 @@ fn test_script_broadcast_with_nonexistent_wallet_no_config() {
                 println("Attempting to deploy with nonexistent wallet");
                 // This should fail because wallet "nonexistent" is not defined
                 val wallet = net.wallet("nonexistent");
-                println1("Wallet found: {}", wallet.address);
+                println("Wallet found: {}", wallet.address);
             }
         "#,
         )
@@ -1370,7 +1370,7 @@ fn test_script_broadcast_with_nonexistent_wallet_empty_config() {
                 println("Attempting to deploy with nonexistent wallet");
                 // This should fail because wallet "nonexistent" is not defined
                 val wallet = net.wallet("nonexistent");
-                println1("Wallet found: {}", wallet.address);
+                println("Wallet found: {}", wallet.address);
             }
         "#,
         )
@@ -1621,7 +1621,7 @@ fun main() {
         return;
     }
 
-    println1("COUNTER_ADDRESS={}", counterAddress);
+    println("COUNTER_ADDRESS={}", counterAddress);
 }
 "#,
         )
@@ -1651,7 +1651,7 @@ import "../../lib/io"
 
 fun main() {{
     val counter: int = net.runGetMethod(address("{counter_address}"), "currentCounter");
-    println1("On-chain counter: {{}}", counter);
+    println("On-chain counter: {{}}", counter);
 }}
 "#
         ),
@@ -1902,28 +1902,28 @@ fn test_script_env_vars() {
             fun main() {
                 val i = env<int>("TEST_INT");
                 if (i != null) {
-                    println1("int: {}", i);
+                    println("int: {}", i);
                 }
 
                 val b = env<bool>("TEST_BOOL");
                 if (b != null) {
-                    println1("bool: {}", b);
+                    println("bool: {}", b);
                 }
 
                 val s = env<string>("TEST_SLICE");
                 if (s != null) {
-                    println1("slice: {}", s);
+                    println("slice: {}", s);
                 }
 
                 val a = env<address>("TEST_ADDRESS");
                 if (a != null) {
-                    println1("address: {}", a);
+                    println("address: {}", a);
                 }
 
                 val c = env<cell>("TEST_CELL");
                 if (c != null) {
                     var slice = c.beginParse();
-                    println1("cell: {}", slice.loadUint(32));
+                    println("cell: {}", slice.loadUint(32));
                 }
             }
         "#,
@@ -1967,33 +1967,33 @@ fn test_script_env_vars_extended() {
             fun main() {
                 val i_hex = env<int>("TEST_INT_HEX");
                 if (i_hex != null) {
-                    println1("int_hex: {}", i_hex);
+                    println("int_hex: {}", i_hex);
                 }
 
                 val b_1 = env<bool>("TEST_BOOL_1");
                 if (b_1 != null) {
-                    println1("bool_1: {}", b_1);
+                    println("bool_1: {}", b_1);
                 }
 
                 val b_false = env<bool>("TEST_BOOL_FALSE");
                 if (b_false != null) {
-                    println1("bool_false: {}", b_false);
+                    println("bool_false: {}", b_false);
                 }
 
                 val b_0 = env<bool>("TEST_BOOL_0");
                 if (b_0 != null) {
-                    println1("bool_0: {}", b_0);
+                    println("bool_0: {}", b_0);
                 }
 
                 val a_raw = env<address>("TEST_ADDRESS_RAW");
                 if (a_raw != null) {
-                    println1("address_raw: {}", a_raw);
+                    println("address_raw: {}", a_raw);
                 }
 
                 val c_b64 = env<cell>("TEST_CELL_B64");
                 if (c_b64 != null) {
                     var slice = c_b64.beginParse();
-                    println1("cell_b64: {}", slice.loadUint(32));
+                    println("cell_b64: {}", slice.loadUint(32));
                 }
             }
         "#,
@@ -2039,11 +2039,11 @@ fn test_script_env_vars_support_coins() {
             fun main() {
                 val amount = env<coins>("TEST_COINS");
                 if (amount != null) {
-                    println1("coins: {:ton}", amount);
+                    println("coins: {:ton}", amount);
                 }
 
                 val fallback = envOr<coins>("TEST_COINS_MISSING", ton("0.75"));
-                println1("coins_default: {:ton}", fallback);
+                println("coins_default: {:ton}", fallback);
             }
         "#,
         )
@@ -2071,16 +2071,16 @@ fn test_script_env_or_vars() {
 
             fun main() {
                 val i = envOr<int>("TEST_INT", 42);
-                println1("int: {}", i);
+                println("int: {}", i);
 
                 val b = envOr<bool>("TEST_BOOL", false);
-                println1("bool: {}", b);
+                println("bool: {}", b);
 
                 val s = envOr<string>("TEST_SLICE", "default");
-                println1("string: {}", s);
+                println("string: {}", s);
 
                 val a = envOr<address>("TEST_ADDRESS", address("EQBvDB_H7FFBs0nF4ap_DBdcOrwY_rMIpNVVOR6SWYFHByMJ"));
-                println1("address: {}", a);
+                println("address: {}", a);
             }
         "#,
         )

--- a/tests/integration/snapshots/test-runner/println_and_println1_support_hex_and_ton_formatters/println2_to_println5_support_multi_argument_formatters.stdout.txt
+++ b/tests/integration/snapshots/test-runner/println_and_println1_support_hex_and_ton_formatters/println2_to_println5_support_multi_argument_formatters.stdout.txt
@@ -20,5 +20,10 @@ See [ACTON_DOCS_URL]/build-system/configuration-reference/#contracts-section for
        hex=ff ton=2.5 TON label=ok
        a b c d
        1 2 3 4 5
+       hello world
+       str 1 2
+       value 42! 100
+       1 2
+       broken { 1 2
 
  ✓ 1 passed in 1 file

--- a/tests/integration/snapshots/test_basic_fixture_with_gas_limit.stdout.txt
+++ b/tests/integration/snapshots/test_basic_fixture_with_gas_limit.stdout.txt
@@ -9,7 +9,7 @@
 
  > tests/counter.test.tolk (2 tests)
   ✗ should-increase-counter [TIME]
-    └─ Gas limit exceeded: used 149525, limit 100
+    └─ Gas limit exceeded: used 156041, limit 100
   ✓ should-reset-counter [TIME]
 
  ✓ 1 passed, ✗ 1 failed in 1 file

--- a/tests/integration/test_runner/api_fmt_env_tests.rs
+++ b/tests/integration/test_runner/api_fmt_env_tests.rs
@@ -11,7 +11,7 @@ fn fmt_supports_mixed_hex_ton_and_plain_placeholders() {
             import "../../lib/testing/expect"
 
             get fun `test-fmt-mixed-placeholders`() {
-                val rendered = format3("hex={:x} ton={:ton} label={}", 255, 1500000000, "ok");
+                val rendered = format("hex={:x} ton={:ton} label={}", 255, 1500000000, "ok");
                 expect(rendered).toEqual("hex=ff ton=1.5 TON label=ok");
             }
         "#,
@@ -37,7 +37,7 @@ fn fmt_plain_and_hex_placeholders_should_follow_argument_order_bug() {
             import "../../lib/testing/expect"
 
             get fun `test-fmt-placeholder-order`() {
-                val rendered = format2("{} {:x}", 255, 16);
+                val rendered = format("{} {:x}", 255, 16);
                 expect(rendered).toEqual("255 10");
             }
         "#,
@@ -63,10 +63,10 @@ fn fmt_fallback_for_non_int_specs_and_ignores_extra_args() {
             import "../../lib/testing/expect"
 
             get fun `test-fmt-fallback-and-extra-args`() {
-                val fallback = format2("{:x} {:ton}", "abc", "tonlike");
+                val fallback = format("{:x} {:ton}", "abc", "tonlike");
                 expect(fallback).toEqual("abc tonlike");
 
-                val extra = format2("{}", 255, 16);
+                val extra = format("{}", 255, 16);
                 expect(extra).toEqual("255");
             }
         "#,

--- a/tests/integration/test_runner/dynamic_format1_strings_break_store_string_and_treasury_bug_tests.rs
+++ b/tests/integration/test_runner/dynamic_format1_strings_break_store_string_and_treasury_bug_tests.rs
@@ -38,7 +38,7 @@ get fun `test-bz-literal-store-string-works`() {
 }
 
 get fun `test-bz-format1-store-string-not-a-cell`() {
-    val dynamic = format1("hello {}", "world");
+    val dynamic = format("hello {}", "world");
     val stored = beginCell().storeString(dynamic).endCell();
     println(stored);
 }
@@ -58,7 +58,7 @@ get fun `test-bz-static-treasury-name-works`() {
 }
 
 get fun `test-bz-format1-treasury-name-not-a-cell`() {
-    val treasuryName = format1("bz_dynamic_{}", 1);
+    val treasuryName = format("bz_dynamic_{}", 1);
     val treasury = net.treasury(treasuryName);
     println(treasury.address);
 }

--- a/tests/integration/test_runner/env_parses_int_bool_address_and_cell_in_supported_formats_tests.rs
+++ b/tests/integration/test_runner/env_parses_int_bool_address_and_cell_in_supported_formats_tests.rs
@@ -199,8 +199,8 @@ fn env_parses_user_friendly_address_form() {
                 val parsed = env<address>("Z_ENV_ADDRESS_FRIENDLY");
                 expect(parsed).toBeNotNull();
 
-                val renderedParsed = format1("{}", parsed!);
-                val renderedExpected = format1("{}", address("0:0000000000000000000000000000000000000000000000000000000000000000"));
+                val renderedParsed = format("{}", parsed!);
+                val renderedExpected = format("{}", address("0:0000000000000000000000000000000000000000000000000000000000000000"));
                 expect(renderedParsed).toEqual(renderedExpected);
             }
         "#,

--- a/tests/integration/test_runner/format1_and_format2_support_plain_hex_and_ton_specifiers_tests.rs
+++ b/tests/integration/test_runner/format1_and_format2_support_plain_hex_and_ton_specifiers_tests.rs
@@ -29,13 +29,13 @@ fn format1_and_format2_support_plain_hex_and_ton_specifiers() {
         "y-stdlib-format1-format2-specifiers",
         r#"
 get fun `test-y-stdlib-format1-format2-specifiers`() {
-    val plain = format1("hello {}", "world");
+    val plain = format("hello {}", "world");
     expect(plain).toEqual("hello world");
 
-    val hex = format1("0x{:x}", 255);
+    val hex = format("0x{:x}", 255);
     expect(hex).toEqual("0xff");
 
-    val ton = format2("{} {:ton}", "balance", 1500000000);
+    val ton = format("{} {:ton}", "balance", 1500000000);
     expect(ton).toEqual("balance 1.5 TON");
 }
 "#,
@@ -49,10 +49,10 @@ fn format3_and_format4_support_mixed_plain_hex_and_ton() {
         "y-stdlib-format3-format4-mixed-specifiers",
         r#"
 get fun `test-y-stdlib-format3-format4-mixed-specifiers`() {
-    val formatted3 = format3("hex={:x} ton={:ton} label={}", 255, 2500000000, "ok");
+    val formatted3 = format("hex={:x} ton={:ton} label={}", 255, 2500000000, "ok");
     expect(formatted3).toEqual("hex=ff ton=2.5 TON label=ok");
 
-    val formatted4 = format4("a={} b={:x} c={:ton} d={}", "left", 16, 1230000000, "right");
+    val formatted4 = format("a={} b={:x} c={:ton} d={}", "left", 16, 1230000000, "right");
     expect(formatted4).toEqual("a=left b=10 c=1.23 TON d=right");
 }
 "#,
@@ -66,7 +66,7 @@ fn format5_should_respect_placeholder_order_for_plain_hex_and_ton_bug() {
         "y-stdlib-format5-placeholder-order-bug",
         r#"
 get fun `test-y-stdlib-format5-placeholder-order-bug`() {
-    val rendered = format5("{} | {:x} | {:ton} | {} | {}", 255, 16, 1500000000, "left", "right");
+    val rendered = format("{} | {:x} | {:ton} | {} | {}", 255, 16, 1500000000, "left", "right");
     expect(rendered).toEqual("255 | 10 | 1.5 TON | left | right");
 }
 "#,

--- a/tests/integration/test_runner/format2_plain_placeholders_use_default_formatter_for_int_and_bool_tests.rs
+++ b/tests/integration/test_runner/format2_plain_placeholders_use_default_formatter_for_int_and_bool_tests.rs
@@ -29,7 +29,7 @@ fn format2_plain_placeholders_use_default_formatter_for_int_and_bool() {
         "bs-stdlib-format2-default-formatter",
         r#"
 get fun `test-bs-stdlib-format2-default-formatter`() {
-    val rendered = format2("left={} right={}", -42, true);
+    val rendered = format("left={} right={}", -42, true);
     expect(rendered).toEqual("left=-42 right=true");
 }
 "#,
@@ -43,7 +43,7 @@ fn format2_escaped_braces_around_placeholder_should_collapse_bug() {
         "bs-stdlib-format2-escaped-braces-bug",
         r#"
 get fun `test-bs-stdlib-format2-escaped-braces-bug`() {
-    val rendered = format2("open={{{}}} close={}", "inner", "done");
+    val rendered = format("open={{{}}} close={}", "inner", "done");
     expect(rendered).toEqual("open={inner} close=done");
 }
 "#,

--- a/tests/integration/test_runner/format3_mixed_placeholders_should_follow_template_order_bug_tests.rs
+++ b/tests/integration/test_runner/format3_mixed_placeholders_should_follow_template_order_bug_tests.rs
@@ -29,7 +29,7 @@ fn format3_mixed_placeholders_should_follow_template_order_bug() {
         "ea-stdlib-format3-mixed-placeholder-order-bug",
         r#"
 get fun `test-ea-stdlib-format3-mixed-placeholder-order-bug`() {
-    val rendered = format3("{} | {:x} | {:ton}", 255, 16, 1500000000);
+    val rendered = format("{} | {:x} | {:ton}", 255, 16, 1500000000);
     expect(rendered).toEqual("255 | 10 | 1.5 TON");
 }
 "#,
@@ -43,7 +43,7 @@ fn format3_escaped_braces_around_placeholder_should_collapse_bug() {
         "ea-stdlib-format3-escaped-braces-bug",
         r#"
 get fun `test-ea-stdlib-format3-escaped-braces-bug`() {
-    val rendered = format3("wrap={{{}}} hex={:x} ton={:ton}", "inner", 255, 2500000000);
+    val rendered = format("wrap={{{}}} hex={:x} ton={:ton}", "inner", 255, 2500000000);
     expect(rendered).toEqual("wrap={inner} hex=ff ton=2.5 TON");
 }
 "#,

--- a/tests/integration/test_runner/format4_ignores_extra_arguments_when_template_has_only_two_placeholders_tests.rs
+++ b/tests/integration/test_runner/format4_ignores_extra_arguments_when_template_has_only_two_placeholders_tests.rs
@@ -46,7 +46,7 @@ fn format4_ignores_extra_arguments_when_template_has_only_two_placeholders() {
         "eb-stdlib-format4-extra-args-ignored",
         r#"
 get fun `test-eb-stdlib-format4-extra-args-ignored`() {
-    val rendered = format4("{}: {:ton}", "alpha", 2500000000, "unused", 255);
+    val rendered = format("{}: {:ton}", "alpha", 2500000000, "unused", 255);
     expect(rendered).toEqual("alpha: 2.5 TON");
 }
 "#,
@@ -60,7 +60,7 @@ fn format4_leaves_unmatched_placeholder_when_template_has_five_slots() {
         "eb-stdlib-format4-missing-placeholder-slot",
         r#"
 get fun `test-eb-stdlib-format4-missing-placeholder-slot`() {
-    val rendered = format4("a={} b={} c={} d={} e={}", 1, 2, 3, 4);
+    val rendered = format("a={} b={} c={} d={} e={}", 1, 2, 3, 4);
     expect(rendered).toEqual("a=1 b=2 c=3 d=4 e={}");
 }
 "#,
@@ -74,7 +74,7 @@ fn format1_rejects_unknown_modifier_in_placeholder() {
         "eb-stdlib-format1-unknown-modifier",
         r#"
 get fun `test-eb-stdlib-format1-unknown-modifier`() {
-    format1("value={:hex}", 255);
+    format("value={:hex}", 255);
 }
 "#,
         "integration/snapshots/test-runner/format4_ignores_extra_arguments_when_template_has_only_two_placeholders/format1_rejects_unknown_modifier_in_placeholder.stdout.txt",
@@ -88,7 +88,7 @@ fn format1_rejects_empty_modifier_in_placeholder() {
         "eb-stdlib-format1-empty-modifier",
         r#"
 get fun `test-eb-stdlib-format1-empty-modifier`() {
-    format1("value={:}", 255);
+    format("value={:}", 255);
 }
 "#,
         "integration/snapshots/test-runner/format4_ignores_extra_arguments_when_template_has_only_two_placeholders/format1_rejects_empty_modifier_in_placeholder.stdout.txt",
@@ -102,7 +102,7 @@ fn format1_rejects_unsupported_placeholder_payload() {
         "eb-stdlib-format1-unsupported-placeholder-payload",
         r#"
 get fun `test-eb-stdlib-format1-unsupported-placeholder-payload`() {
-    format1("value={name}", 255);
+    format("value={name}", 255);
 }
 "#,
         "integration/snapshots/test-runner/format4_ignores_extra_arguments_when_template_has_only_two_placeholders/format1_rejects_unsupported_placeholder_payload.stdout.txt",
@@ -116,7 +116,7 @@ fn format1_rejects_unclosed_open_brace() {
         "eb-stdlib-format1-unclosed-open-brace",
         r#"
 get fun `test-eb-stdlib-format1-unclosed-open-brace`() {
-    format1("value={", 255);
+    format("value={", 255);
 }
 "#,
         "integration/snapshots/test-runner/format4_ignores_extra_arguments_when_template_has_only_two_placeholders/format1_rejects_unclosed_open_brace.stdout.txt",
@@ -130,7 +130,7 @@ fn format1_rejects_unmatched_closing_brace() {
         "eb-stdlib-format1-unmatched-closing-brace",
         r#"
 get fun `test-eb-stdlib-format1-unmatched-closing-brace`() {
-    format1("value=}", 255);
+    format("value=}", 255);
 }
 "#,
         "integration/snapshots/test-runner/format4_ignores_extra_arguments_when_template_has_only_two_placeholders/format1_rejects_unmatched_closing_brace.stdout.txt",
@@ -144,7 +144,7 @@ fn format2_escaped_braces_are_treated_as_literals() {
         "eb-stdlib-format2-escaped-braces-literals",
         r#"
 get fun `test-eb-stdlib-format2-escaped-braces-literals`() {
-    val rendered = format2("literal={{}} value={}", 42, 999);
+    val rendered = format("literal={{}} value={}", 42, 999);
     expect(rendered).toEqual("literal={} value=42");
 }
 "#,
@@ -158,7 +158,7 @@ fn format1_supports_utf8_literals_with_plain_placeholder() {
         "eb-stdlib-format1-utf8-literal-placeholder",
         r#"
 get fun `test-eb-stdlib-format1-utf8-literal-placeholder`() {
-    val rendered = format1("привет🙂 {}", 7);
+    val rendered = format("привет🙂 {}", 7);
     expect(rendered).toEqual("привет🙂 7");
 }
 "#,
@@ -172,7 +172,7 @@ fn format1_escaped_braces_without_placeholders_render_as_literals() {
         "eb-stdlib-format1-escaped-only-literals",
         r#"
 get fun `test-eb-stdlib-format1-escaped-only-literals`() {
-    val rendered = format1("{{}} and }}{{", 42);
+    val rendered = format("{{}} and }}{{", 42);
     expect(rendered).toEqual("{} and }{");
 }
 "#,
@@ -186,7 +186,7 @@ fn format1_rejects_invalid_modifier_payload() {
         "eb-stdlib-format1-invalid-modifier-payload",
         r#"
 get fun `test-eb-stdlib-format1-invalid-modifier-payload`() {
-    format1("value={:x:}", 255);
+    format("value={:x:}", 255);
 }
 "#,
         "integration/snapshots/test-runner/format4_ignores_extra_arguments_when_template_has_only_two_placeholders/format1_rejects_invalid_modifier_payload.stdout.txt",

--- a/tests/integration/test_runner/format5_mixed_specifiers_should_follow_placeholder_order_bug_tests.rs
+++ b/tests/integration/test_runner/format5_mixed_specifiers_should_follow_placeholder_order_bug_tests.rs
@@ -31,7 +31,7 @@ fn format5_mixed_specifiers_should_follow_placeholder_order_bug() {
         "br-stdlib-format5-placeholder-order-bug",
         r#"
 get fun `test-br-stdlib-format5-placeholder-order-bug`() {
-    val rendered = format5("{} | {:ton} | {:x} | {} | {}", 255, 1500000000, 16, "left", "right");
+    val rendered = format("{} | {:ton} | {:x} | {} | {}", 255, 1500000000, 16, "left", "right");
     expect(rendered).toEqual("255 | 1.5 TON | 10 | left | right");
 }
 "#,
@@ -46,7 +46,7 @@ fn format5_mixed_specifiers_should_follow_placeholder_order_in_fixture_project_b
     let source = wrap_fmt_test_source(
         r#"
 get fun `test-br-stdlib-format5-placeholder-order-fixture-bug`() {
-    val rendered = format5("{:ton} | {} | {:x} | {} | {}", 1500000000, 2000000000, 16, "mid", "end");
+    val rendered = format("{:ton} | {} | {:x} | {} | {}", 1500000000, 2000000000, 16, "mid", "end");
     expect(rendered).toEqual("1.5 TON | 2000000000 | 10 | mid | end");
 }
 "#,

--- a/tests/integration/test_runner/keeps_stdout_and_stderr_separated_when_stderr_happens_first_tests.rs
+++ b/tests/integration/test_runner/keeps_stdout_and_stderr_separated_when_stderr_happens_first_tests.rs
@@ -52,7 +52,7 @@ get fun `test-at-stdlib-interleaved-stdout-order`() {
     eprintln("stderr-1");
     println("stdout-2");
     eprintln("stderr-2");
-    println1("stdout-3={}", 333);
+    println("stdout-3={}", 333);
     eprintln("stderr-3");
     println("stdout-4");
 }

--- a/tests/integration/test_runner/println1_formats_negative_hex_and_ton_values_tests.rs
+++ b/tests/integration/test_runner/println1_formats_negative_hex_and_ton_values_tests.rs
@@ -31,10 +31,10 @@ fn println1_formats_negative_hex_and_ton_values() {
         "as-stdlib-println1-negative-formatters",
         r#"
 get fun `test-as-stdlib-println1-negative-formatters`() {
-    println1("hex_neg_one={:x}", -1);
-    println1("hex_neg_255={:x}", -255);
-    println1("ton_neg_nano={:ton}", -1);
-    println1("ton_neg_one_and_half={:ton}", -1500000000);
+    println("hex_neg_one={:x}", -1);
+    println("hex_neg_255={:x}", -255);
+    println("ton_neg_nano={:ton}", -1);
+    println("ton_neg_one_and_half={:ton}", -1500000000);
 }
 "#,
         "integration/snapshots/test-runner/println1_formats_negative_hex_and_ton_values/println1_formats_negative_hex_and_ton_values.stdout.txt",
@@ -47,10 +47,10 @@ fn println1_formats_edge_hex_and_ton_values() {
         "as-stdlib-println1-edge-formatters",
         r#"
 get fun `test-as-stdlib-println1-edge-formatters`() {
-    println1("hex_zero={:x}", 0);
-    println1("hex_i64_max={:x}", 9223372036854775807);
-    println1("ton_zero={:ton}", 0);
-    println1("ton_i64_max={:ton}", 9223372036854775807);
+    println("hex_zero={:x}", 0);
+    println("hex_i64_max={:x}", 9223372036854775807);
+    println("ton_zero={:ton}", 0);
+    println("ton_i64_max={:ton}", 9223372036854775807);
 }
 "#,
         "integration/snapshots/test-runner/println1_formats_negative_hex_and_ton_values/println1_formats_edge_hex_and_ton_values.stdout.txt",

--- a/tests/integration/test_runner/println_and_println1_support_hex_and_ton_formatters_tests.rs
+++ b/tests/integration/test_runner/println_and_println1_support_hex_and_ton_formatters_tests.rs
@@ -32,9 +32,9 @@ fn println_and_println1_support_hex_and_ton_formatters() {
         r#"
         get fun `test-println-and-println1-formatters`() {
             println(17);
-            println1("hex={:x}", 48879);
-            println1("ton={:ton}", 1000000000);
-            println1("plain={}", "ok");
+            println("hex={:x}", 48879);
+            println("ton={:ton}", 1000000000);
+            println("plain={}", "ok");
         }
         "#,
         "integration/snapshots/test-runner/println_and_println1_support_hex_and_ton_formatters/println_and_println1_support_hex_and_ton_formatters.stdout.txt",
@@ -47,10 +47,15 @@ fn println2_to_println5_support_multi_argument_formatters() {
         "v-stdlib-println2-to-println5-formatters",
         r#"
         get fun `test-println2-to-println5-formatters`() {
-            println2("{} + {}", "left", "right");
-            println3("hex={:x} ton={:ton} label={}", 255, 2500000000, "ok");
-            println4("{} {} {} {}", "a", "b", "c", "d");
-            println5("{} {} {} {} {}", 1, 2, 3, 4, 5);
+            println("{} + {}", "left", "right");
+            println("hex={:x} ton={:ton} label={}", 255, 2500000000, "ok");
+            println("{} {} {} {}", "a", "b", "c", "d");
+            println("{} {} {} {} {}", 1, 2, 3, 4, 5);
+            println("hello", "world");
+            println("str", 1, 2);
+            println("value {}!", 42, 100);
+            println(1, 2);
+            println("broken {", 1, 2);
         }
         "#,
         "integration/snapshots/test-runner/println_and_println1_support_hex_and_ton_formatters/println2_to_println5_support_multi_argument_formatters.stdout.txt",

--- a/tests/integration/test_runner/println_formats_nested_tuple_and_struct_values_tests.rs
+++ b/tests/integration/test_runner/println_formats_nested_tuple_and_struct_values_tests.rs
@@ -94,7 +94,7 @@ get fun `test-ar-stdlib-println1-nested-tuple-and-struct-values`() {
         ([29, 31], Point { x: 37, y: 41 }),
     );
 
-    println1("nested={}", nested);
+    println("nested={}", nested);
 }
 "#,
         "integration/snapshots/test-runner/println_formats_nested_tuple_and_struct_values/println1_formats_nested_tuple_and_struct_values_via_placeholder_pipeline.stdout.txt",

--- a/tests/integration/test_runner/set_time_and_logical_time_update_c7_slots_tests.rs
+++ b/tests/integration/test_runner/set_time_and_logical_time_update_c7_slots_tests.rs
@@ -181,8 +181,8 @@ get fun `test-aj-stdlib-vm-convert-address-valid`() {
     val fromRaw = vm.convertAddress(raw);
     val fromFriendly = vm.convertAddress(friendly);
 
-    val renderedRaw = format1("{}", fromRaw);
-    val renderedFriendly = format1("{}", fromFriendly);
+    val renderedRaw = format("{}", fromRaw);
+    val renderedFriendly = format("{}", fromFriendly);
 
     expect(renderedRaw).toEqual(renderedFriendly);
     expect(renderedRaw).toEqual("kQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHTW");

--- a/tests/integration/test_tests.rs
+++ b/tests/integration/test_tests.rs
@@ -67,7 +67,7 @@ fn test_unknown_get_method_call() {
                 val (counter, deployer) = setupTest();
 
                 val counterRes = net.runGetMethod<int, tuple>(counter.address, "currentCounter999");
-                println(format1("Counter: {}", counterRes));
+                println("Counter: {}", counterRes);
             }
         "#)
             .as_str(),
@@ -93,7 +93,7 @@ fn test_unknown_get_method_call_with_backtrace_full() {
                 val (counter, deployer) = setupTest();
 
                 val counterRes = net.runGetMethod<int, tuple>(counter.address, "currentCounter999");
-                println(format1("Counter: {}", counterRes));
+                println("Counter: {}", counterRes);
             }
         "#)
             .as_str(),
@@ -123,7 +123,7 @@ fn test_get_method_call_return_type_mismatch() {
                 val (counter, deployer) = setupTest();
 
                 val counterRes = net.runGetMethod<address, tuple>(counter.address, "getCell");
-                println(format1("Counter: {}", counterRes));
+                println("Counter: {}", counterRes);
             }
         "#)
             .as_str(),
@@ -151,7 +151,7 @@ fn test_no_arg_get_method_call() {
                 val (counter, deployer) = setupTest();
 
                 val counterRes = net.runGetMethod<int, tuple>(counter.address, "currentCounter2");
-                println(format1("Counter: {}", counterRes));
+                println("Counter: {}", counterRes);
             }
         "#)
             .as_str(),
@@ -177,7 +177,7 @@ fn test_no_arg_get_method_call_2() {
                 val (counter, deployer) = setupTest();
 
                 val counterRes = net.runGetMethod<int, tuple>(counter.address, "currentCounter3");
-                println(format1("Counter: {}", counterRes));
+                println("Counter: {}", counterRes);
             }
         "#)
             .as_str(),
@@ -203,7 +203,7 @@ fn test_no_arg_get_method_call_2_with_backtrace_full() {
                 val (counter, deployer) = setupTest();
 
                 val counterRes = net.runGetMethod<int, tuple>(counter.address, "currentCounter3");
-                println(format1("Counter: {}", counterRes));
+                println("Counter: {}", counterRes);
             }
         "#)
             .as_str(),
@@ -232,7 +232,7 @@ fn test_get_method_call_shows_exit_code_variant() {
                 val (counter, deployer) = setupTest();
 
                 val counterRes = net.runGetMethod<int, tuple>(counter.address, "currentCounterFail");
-                println(format1("Counter: {}", counterRes));
+                println("Counter: {}", counterRes);
             }
         "#)
             .as_str(),
@@ -260,7 +260,7 @@ fn test_get_method_call_shows_backtrace_with_full_mode() {
                 val (counter, deployer) = setupTest();
 
                 val counterRes = net.runGetMethod<int, tuple>(counter.address, "currentCounterFail");
-                println(format1("Counter: {}", counterRes));
+                println("Counter: {}", counterRes);
             }
         "#)
                 .as_str(),
@@ -293,7 +293,7 @@ fn test_get_method_call_shows_backtrace_with_full_mode_from_config() {
                 val (counter, deployer) = setupTest();
 
                 val counterRes = net.runGetMethod<int, tuple>(counter.address, "currentCounterFail");
-                println(format1("Counter: {}", counterRes));
+                println("Counter: {}", counterRes);
             }
         "#)
                 .as_str(),


### PR DESCRIPTION
Drop println1/println2/etc. and format1/format2/etc. They become universal:

```
// just a value
println("hello");

// or multiple ones
println(1, 2, 3);

// or with format string
println("value = {}", 42);
println("{} + {} = {}", 2, 3, 5);
```

Same for `format`:
```
val s1 = format("value = {}", 42);
val s2 = format("{} + {} = {}", 2, 3, 5);
```

This is possible thanks to latest features in Tolk.