### PR TITLE
chore(docs): unify code style in Tolk snippets throughout the docs

### DIFF
--- a/crates/tolk-linter/src/rules/dfa/divide_before_multiply/mod.rs
+++ b/crates/tolk-linter/src/rules/dfa/divide_before_multiply/mod.rs
@@ -16,14 +16,14 @@ pub mod analysis;
 /// ### Example
 /// ```tolk
 /// fun main(a: int, b: int, c: int): int {
-///   return a / b * c;
+///     return a / b * c;
 /// }
 /// ```
 ///
 /// Use instead:
 /// ```tolk
 /// fun main(a: int, b: int, c: int): int {
-///   return a * c / b;
+///     return a * c / b;
 /// }
 /// ```
 ///

--- a/crates/tolk-linter/src/rules/dfa/random_requires_initialization/mod.rs
+++ b/crates/tolk-linter/src/rules/dfa/random_requires_initialization/mod.rs
@@ -18,15 +18,15 @@ pub mod analysis;
 /// ### Example
 /// ```tolk
 /// fun main() {
-///   val x = random.uint256();
+///     val x = random.uint256();
 /// }
 /// ```
 ///
 /// Use instead:
 /// ```tolk
 /// fun main() {
-///   random.initializeBy(123);
-///   val x = random.uint256();
+///     random.initializeBy(123);
+///     val x = random.uint256();
 /// }
 /// ```
 ///

--- a/crates/tolk-linter/src/rules/dfa/unauthorized_access/mod.rs
+++ b/crates/tolk-linter/src/rules/dfa/unauthorized_access/mod.rs
@@ -18,17 +18,17 @@ pub mod analysis;
 /// ### Example
 /// ```tolk
 /// fun onInternalMessage(in: InMessage) {
-///   val storage = lazy Storage.fromCell(contract.getData());
-///   storage.save();
+///     val storage = lazy Storage.fromCell(contract.getData());
+///     storage.save();
 /// }
 /// ```
 ///
 /// Use instead:
 /// ```tolk
 /// fun onInternalMessage(in: InMessage) {
-///   val storage = lazy Storage.fromCell(contract.getData());
-///   assert (in.senderAddress == storage.adminAddress) throw ERR_UNAUTHORIZED;
-///   storage.save();
+///     val storage = lazy Storage.fromCell(contract.getData());
+///     assert (in.senderAddress == storage.adminAddress) throw ERR_UNAUTHORIZED;
+///     storage.save();
 /// }
 /// ```
 #[derive(ViolationMetadata)]

--- a/docs/content/docs/contract-deployment.mdx
+++ b/docs/content/docs/contract-deployment.mdx
@@ -44,7 +44,7 @@ fun main() {
 
     // 2. Prepare the contract
     // We create the contract instance locally with its initial state
-    val counter = Counter.fromStorage(Storage {
+    val counter = Counter.fromStorage({
         id: 123,       // Unique ID to randomize address
         counter: 0,    // Initial counter value
     });
@@ -84,7 +84,7 @@ fun main() {
     });
 
     val minter = JettonMinter.fromStorage({
-        totalSupply: 1000000000,
+        totalSupply: 1_000_000_000,
         adminAddress: deployer.address,
         content: content,
         jettonWalletCode: build("JettonWallet"),

--- a/docs/content/docs/linting/rules/e017-unauthorized-access.mdx
+++ b/docs/content/docs/linting/rules/e017-unauthorized-access.mdx
@@ -23,17 +23,17 @@ arbitrary inbound senders to mutate contract storage.
 ### Example
 ```tolk
 fun onInternalMessage(in: InMessage) {
-  val storage = lazy Storage.fromCell(contract.getData());
-  storage.save();
+    val storage = lazy Storage.fromCell(contract.getData());
+    storage.save();
 }
 ```
 
 Use instead:
 ```tolk
 fun onInternalMessage(in: InMessage) {
-  val storage = lazy Storage.fromCell(contract.getData());
-  assert (in.senderAddress == storage.adminAddress) throw ERR_UNAUTHORIZED;
-  storage.save();
+    val storage = lazy Storage.fromCell(contract.getData());
+    assert (in.senderAddress == storage.adminAddress) throw ERR_UNAUTHORIZED;
+    storage.save();
 }
 ```
 

--- a/docs/content/docs/linting/rules/e024-random-requires-initialization.mdx
+++ b/docs/content/docs/linting/rules/e024-random-requires-initialization.mdx
@@ -23,15 +23,15 @@ or invalid randomness behavior.
 ### Example
 ```tolk
 fun main() {
-  val x = random.uint256();
+    val x = random.uint256();
 }
 ```
 
 Use instead:
 ```tolk
 fun main() {
-  random.initializeBy(123);
-  val x = random.uint256();
+    random.initializeBy(123);
+    val x = random.uint256();
 }
 ```
 

--- a/docs/content/docs/linting/rules/e025-divide-before-multiply.mdx
+++ b/docs/content/docs/linting/rules/e025-divide-before-multiply.mdx
@@ -22,14 +22,14 @@ and can produce unintended results in subsequent multiplication.
 ### Example
 ```tolk
 fun main(a: int, b: int, c: int): int {
-  return a / b * c;
+    return a / b * c;
 }
 ```
 
 Use instead:
 ```tolk
 fun main(a: int, b: int, c: int): int {
-  return a * c / b;
+    return a * c / b;
 }
 ```
 

--- a/docs/content/docs/quickstart.mdx
+++ b/docs/content/docs/quickstart.mdx
@@ -158,7 +158,10 @@ In this guide, we will explore Acton's capabilities and develop a simple smart c
         fun main() {
             val deployer = net.wallet("deployer");
 
-            val counter = Counter.fromStorage(Storage { id: 0, counter: 0 });
+            val counter = Counter.fromStorage({
+                id: 0,
+                counter: 0,
+            });
             val res = counter.deploy(deployer.address, { value: ton("0.005") });
             if (!res.wait()) {
                 return;

--- a/docs/content/docs/scripting/blockchain-interaction.mdx
+++ b/docs/content/docs/scripting/blockchain-interaction.mdx
@@ -63,7 +63,7 @@ import "@wrappers/Counter"
 
 fun main() {
     val deployer = net.wallet("deployer");
-    val counter = Counter.fromStorage(Storage {
+    val counter = Counter.fromStorage({
         id: 8,
         counter: 0,
     });
@@ -81,6 +81,7 @@ fun main() {
 The `counter_wrapper.tolk` file provides a convenient wrapper around the counter contract:
 
 ```tolk collapse={2-3, 10-17, 30-42} title="counter_wrapper.tolk"
+// todo update snippet to actual wrapper
 import "@acton/build/build"
 import "@acton/emulation/network"
 
@@ -97,7 +98,7 @@ fun Counter.fromStorage(storage: Storage): Counter {
         data: storage.toCell(),
     };
     val address = AutoDeployAddress { stateInit: init }.calculateAddress();
-    return Counter { address, init }
+    return Counter { address, init };
 }
 
 fun Counter.deploy(self, deployer: address, value: coins) {
@@ -122,7 +123,7 @@ fun Counter.sendIncrease(self, from: address, increaseBy: int) {
 }
 
 fun Counter.getCounter(self): int {
-    return net.runGetMethod(self.address, "currentCounter")
+    return net.runGetMethod(self.address, "currentCounter");
 }
 ```
 
@@ -197,7 +198,10 @@ fun main() {
     val deployer = net.wallet("deployer");
 
     // Deploy counter
-    val counter = Counter.fromStorage(Storage { id: 8, counter: 0 });
+    val counter = Counter.fromStorage({
+        id: 8,
+        counter: 0,
+    });
     val deployResult = counter.deploy(deployer.address, ton("0.05"));
     deployResult.wait(); // Wait for deployment
 
@@ -253,7 +257,7 @@ Scripts can read contract state using `net.runGetMethod()`:
 ```tolk
 fun main() {
     val counterAddress = address("EQDt7LL...");
-    val currentValue: int = net.runGetMethod(counterAddress, "currentCounter");
+    val currentValue = net.runGetMethod<int>(counterAddress, "currentCounter");
     println("Counter value: {}", currentValue);
 }
 ```

--- a/docs/content/docs/scripting/passing-arguments.mdx
+++ b/docs/content/docs/scripting/passing-arguments.mdx
@@ -17,8 +17,7 @@ For example, consider a script that adds two numbers:
 import "@acton/io"
 
 fun main(a: int, b: int) {
-    println("The sum is:")
-    println(a + b)
+    println("The sum is: {}", a + b);
 }
 ```
 
@@ -85,10 +84,10 @@ You can pass tuples by enclosing the values in `[ ... ]` or `( ... )`.
 import "@acton/io"
 
 fun main(data: tuple) {
-    val a: int = data.get(0)
-    val b: int = data.get(1)
-    println("First element: {}", a)
-    println("Second element: {}", b)
+    val a: int = data.get(0);
+    val b: int = data.get(1);
+    println("First element: {}", a);
+    println("Second element: {}", b);
 }
 ```
 
@@ -118,8 +117,8 @@ struct Point {
 }
 
 fun main(p: Point) {
-    println("Point x: {}", p.x)
-    println("Point y: {}", p.y)
+    println("Point x: {}", p.x);
+    println("Point y: {}", p.y);
 }
 ```
 
@@ -169,9 +168,9 @@ You can also pass raw cells and slices using the `C{...}` and `CS{...}` syntax, 
 import "@acton/io"
 
 fun main(data: cell) {
-    val s = data.beginParse()
-    val value = s.loadUint(32)
-    println("Value from cell: {}", value)
+    val s = data.beginParse();
+    val value = s.loadUint(32);
+    println("Value from cell: {}", value);
 }
 ```
 

--- a/docs/content/docs/standard_library/emulation/config.mdx
+++ b/docs/content/docs/standard_library/emulation/config.mdx
@@ -19,15 +19,15 @@ Examples:
 ```tolk
 // Set custom gas prices
 var config = net.blockchainConfig();
-val gasPrice = GasPricesSimple {
+val gasPrices = GasPricesSimple {
     gasPrice: 1000,
-    gasLimit: 1000000,
+    gasLimit: 1_000_000,
     gasCredit: 10000,
-    blockGasLimit: 10000000,
-    freezeDueLimit: 1000000000,
-    deleteDueLimit: 5000000000
+    blockGasLimit: 10_000_000,
+    freezeDueLimit: 1_000_000_000,
+    deleteDueLimit: 5_000_000_000
 };
-config.setGasPrices(simplePrices, MASTERCHAIN);
+config.setGasPrices(gasPrices, MASTERCHAIN);
 
 // Access storage prices
 val storagePrices = config.getStoragePrices();
@@ -322,8 +322,8 @@ Parameters:
 Example:
 ```tolk
 var pricesDict = StoragePricesDict.fromMap(createEmptyMap<uint32, StoragePrices>());
-pricesDict.set(1000000, StoragePrices {
-    initialUnixTime: 1000000,
+pricesDict.set(1_000_000, StoragePrices {
+    initialUnixTime: 1_000_000,
     bitPrice: 1,
     cellPrice: 1000,
     masterchainBitPrice: 1,
@@ -353,7 +353,7 @@ Returns: [StoragePricesDict](#storagepricesdict) containing storage price config
 Example:
 ```tolk
 val storagePrices = config.getStoragePrices();
-val prices = storagePrices.get(1000000);
+val prices = storagePrices.get(1_000_000);
 println("Bit price: {}, Cell price: {}, Masterchain bit price: {}",
     prices.bitPrice, prices.cellPrice, prices.masterchainBitPrice);
 ```

--- a/docs/content/docs/standard_library/emulation/network.mdx
+++ b/docs/content/docs/standard_library/emulation/network.mdx
@@ -521,14 +521,14 @@ This method is useful for bounce testing where you want to simulate a bounced me
 
 Example:
 ```tolk
-val bounced_msg = createMessage({
+val bouncedMsg = createMessage({
     bounce: false,
     value: ton("0.95"),
-    dest: deployer_jetton_wallet.address,
+    dest: deployer.address,
     body: beginCell().storeUint(0xFFFFFFFF, 32).storeSlice(body.toCell().beginParse()).endCell(),
 }).bounced();
 
-net.sendSingle(not_deployer_jetton_wallet.address, bounced_msg);
+net.sendSingle(notDeployer.address, bouncedMsg);
 ```
 
 See [net.send](#netsend) if you need to send a message and process out messages.
@@ -613,14 +613,14 @@ This is useful for testing single messages with [net.sendSingle](#netsendsingle)
 
 Example:
 ```tolk
-val bounced_msg = createMessage({
+val bouncedMsg = createMessage({
     bounce: false,
     value: ton("0.95"),
-    dest: deployer_jetton_wallet.address,
+    dest: deployer.address,
     body: beginCell().storeUint(0xFFFFFFFF, 32).storeSlice(body.toCell().beginParse()).endCell(),
 }).bounced();
 
-net.sendSingle(not_deployer_jetton_wallet.address, bounced_msg);
+net.sendSingle(notDeployer.address, bouncedMsg);
 ```
 
 <SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/emulation/network.tolk#L599" />
@@ -690,16 +690,16 @@ Example:
 ```tolk
 /// Script that deploys a counter contract using a wallet to real blockchain.
 fun main() {
-   val deployer = net.wallet("deployer");
-   val counter = Counter.fromStorage(Storage {
-       id: 8,
-       counter: 0,
-   });
+    val deployer = net.wallet("deployer");
+    val counter = Counter.fromStorage({
+        id: 8,
+        counter: 0,
+    });
 
-   val result = counter.deploy(deployer.address, ton("0.05"));
-   result.wait();
+    val result = counter.deploy(deployer.address, ton("0.05"));
+    result.wait();
 
-   println("Deployed counter to {}", counter.address);
+    println("Deployed counter to {}", counter.address);
 }
 ```
 
@@ -898,7 +898,7 @@ If get method returns a tensor, specify tuple as a first type argument:
 get fun get_all_data(): (int, slice) { ... }
 ```
 ```tolk
-val data: tuple = net.runGetMethod(wallet.address, "get_all_data");
+val data = net.runGetMethod<tuple>(wallet.address, "get_all_data");
 val first = data.get(0) as int;
 val second = data.get(1) as int;
 ```
@@ -940,12 +940,12 @@ Example:
 ```tolk
 fun JettonWallet.getJettonBalance(self): coins {
     if (!net.isDeployed(self.address)) {
-        return 0 // return 0 if contract is not deployed
+        return 0; // return 0 if contract is not deployed
     }
 
     // and if deployed, actually run get method
-    val result: JettonWalletDataReply = net.runGetMethod(self.address, "get_wallet_data");
-    return result.jettonBalance
+    val result = net.runGetMethod<JettonWalletDataReply>(self.address, "get_wallet_data");
+    return result.jettonBalance;
 }
 ```
 
@@ -1020,7 +1020,7 @@ This allows test runner to show the name instead of the address in the test outp
 Example:
 ```tolk
 val address = net.randomAddress("random_user");
-val masterchain_address = net.randomAddress("random_user", -1);
+val masterchainAddress = net.randomAddress("random_user", -1);
 ```
 
 <SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/emulation/network.tolk#L953" />
@@ -1100,9 +1100,9 @@ Returns `null` if the contract with given address is not deployed.
 
 Example:
 ```tolk
-val storage_fee = net.getAccountStorageFee(contract.address, 86400); // 1 day
-if (storage_fee != null) {
-    println("Daily storage fee: {:ton}", storage_fee);
+val storageFee = net.getAccountStorageFee(contract.address, 86400); // 1 day
+if (storageFee != null) {
+    println("Daily storage fee: {:ton}", storageFee);
 }
 ```
 
@@ -1144,8 +1144,8 @@ This is useful for testing time-dependent contracts.
 
 Example:
 ```tolk
-val future_time = net.now() + 1000; // 1000 seconds from now
-net.setNow(future_time);
+val futureTime = net.now() + 1000; // 1000 seconds from now
+net.setNow(futureTime);
 ```
 
 <SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/emulation/network.tolk#L1083" />
@@ -1162,8 +1162,8 @@ Returns the current time in the emulated blockchain.
 
 Example:
 ```tolk
-val current_time = net.now();
-println("Current emulation time: {}", current_time);
+val currentTime = net.now();
+println("Current emulation time: {}", currentTime);
 ```
 
 <SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/emulation/network.tolk#L1099" />

--- a/docs/content/docs/standard_library/fmt.mdx
+++ b/docs/content/docs/standard_library/fmt.mdx
@@ -33,7 +33,7 @@ val greeting = format("Hello, {}!", "Tolk");
 val hex = format("Value in hex: 0x{:x}", 255); // "Value in hex: 0xff"
 
 // Formatting TON amounts
-val balance = format("Balance: {:ton}", 500000000); // "Balance: 0.5 TON"
+val balance = format("Balance: {:ton}", 500_000_000); // "Balance: 0.5 TON"
 
 // Escaping braces
 val escaped = format("Use {{}} to print braces", 0); // "Use {} to print braces"
@@ -42,7 +42,7 @@ val escaped = format("Use {{}} to print braces", 0); // "Use {} to print braces"
 val partial = format("{} {}", "left"); // "left {}"
 
 // Multiple arguments
-val info = format("User {} has {} items worth {:ton}", "Alice", 5, 1000000000);
+val info = format("User {} has {} items worth {:ton}", "Alice", 5, 1_000_000_000);
 ```
 
 ## Definitions

--- a/docs/content/docs/standard_library/io.mdx
+++ b/docs/content/docs/standard_library/io.mdx
@@ -58,7 +58,7 @@ println("Hello, world!");
 println((1, 2, 3));
 println(Data {
     value: 10,
-    is_set: true
+    isSet: true
 });
 
 println("Hello, 0x{:x}", 10);

--- a/docs/content/docs/standard_library/testing/assert.mdx
+++ b/docs/content/docs/standard_library/testing/assert.mdx
@@ -140,7 +140,7 @@ The fixed `26` gas measurement overhead is subtracted before the `<= expected` c
 Example:
 ```tolk
 get fun `test gas consumption`() {
-    val result = Assert.consumesLessThan(fun do_something() {
+    val result = Assert.consumesLessThan(fun() {
         // do something that consumes gas
         return 42;
     }, 100);
@@ -168,7 +168,7 @@ Uses the same gas accounting as `consumesLessThan`: `end - start - 26 <= expecte
 Example:
 ```tolk
 get fun `test gas consumption`() {
-    val result = Assert.consumesLessThan1(fun do_something(a: int) {
+    val result = Assert.consumesLessThan1(fun(a: int) {
         // do something that consumes gas
         return a + 1;
     }, 100, 100);
@@ -200,7 +200,7 @@ Uses the same gas accounting as `consumesLessThan`: `end - start - 26 <= expecte
 Example:
 ```tolk
 get fun `test gas consumption`() {
-    val result = Assert.consumesLessThan2(fun do_something(a: int, b: int) {
+    val result = Assert.consumesLessThan2(fun(a: int, b: int) {
         // do something that consumes gas
         return a + b;
     }, 10, 20, 100);
@@ -234,7 +234,7 @@ Uses the same gas accounting as `consumesLessThan`: `end - start - 26 <= expecte
 Example:
 ```tolk
 get fun `test gas consumption`() {
-    val result = Assert.consumesLessThan3(fun do_something(a: int, b: int, c: int) {
+    val result = Assert.consumesLessThan3(fun(a: int, b: int, c: int) {
         // do something that consumes gas
         return a + b + c;
     }, 10, 20, 30, 100);

--- a/docs/content/docs/standard_library/testing/outlist_expect.mdx
+++ b/docs/content/docs/standard_library/testing/outlist_expect.mdx
@@ -42,8 +42,8 @@ Indexing is reverse-chronological (same as `OutActionList.at`): index `0` is the
 
 Example:
 ```tolk
-val out_actions = vm.outActions();
-expect(out_actions).toBeSendMessageAt<IncreaseCounter>(0);
+val outActions = vm.outActions();
+expect(outActions).toBeSendMessageAt<IncreaseCounter>(0);
 ```
 
 Note that you should provide the message type as a generic parameter.

--- a/docs/content/docs/standard_library/types/message.mdx
+++ b/docs/content/docs/standard_library/types/message.mdx
@@ -46,8 +46,8 @@ later manually (for example to load the opcode).
 
 Example:
 ```tolk
-val out_actions = vm.outActions();
-val action = out_actions.at(0);
+val outActions = vm.outActions();
+val action = outActions.at(0);
 if (action is OutActionSendMessage) {
     val message = action.loadGenericMessage();
     val opcode = message.loadOpcode();
@@ -75,8 +75,8 @@ If [skipBounce](#messagerelaxedgenericloadopcode) is true, the `0xFFFFFFFF` pref
 
 Example:
 ```tolk
-val out_actions = vm.outActions();
-val action = out_actions.at(0);
+val outActions = vm.outActions();
+val action = outActions.at(0);
 if (action is OutActionSendMessage) {
     val message = action.loadGenericMessage();
     val opcode = message.loadOpcode(true);
@@ -135,8 +135,8 @@ If actual message body has a different type, loading will fail with exit code 63
 
 Example:
 ```tolk
-val out_actions = vm.outActions();
-val action = out_actions.at(0);
+val outActions = vm.outActions();
+val action = outActions.at(0);
 if (action is OutActionSendMessage) {
     val message = action.loadMessage<IncreaseCounter>();
     val body = message.loadBody();
@@ -162,8 +162,8 @@ Note that if message type mismatch, loading will fail with exit code 63.
 
 Example:
 ```tolk
-val out_actions = vm.outActions();
-val action = out_actions.at(0);
+val outActions = vm.outActions();
+val action = outActions.at(0);
 if (action is OutActionSendMessage) {
     val message = action.loadMessage<IncreaseCounter>();
     val body = message.loadBody();

--- a/docs/content/docs/standard_library/types/out_actions.mdx
+++ b/docs/content/docs/standard_library/types/out_actions.mdx
@@ -80,8 +80,8 @@ If you want to access the body of the message, use [OutActionSendMessage.loadBod
 
 Example:
 ```tolk
-val out_actions = vm.outActions();
-val action = out_actions.at(0);
+val outActions = vm.outActions();
+val action = outActions.at(0);
 if (action is OutActionSendMessage) {
     val message = action.loadMessage<IncreaseCounter>();
     val body = message.loadBody();
@@ -103,8 +103,8 @@ Note that you should provide the message type as a generic parameter.
 
 Example:
 ```tolk
-val out_actions = vm.outActions();
-val action = out_actions.at(0);
+val outActions = vm.outActions();
+val action = outActions.at(0);
 if (action is OutActionSendMessage) {
     val body = action.loadBody<IncreaseCounter>();
     println(body.increaseBy);
@@ -125,8 +125,8 @@ Instead it loads the message with body as a slice. Use this method if don't know
 
 Example:
 ```tolk
-val out_actions = vm.outActions();
-val action = out_actions.at(0);
+val outActions = vm.outActions();
+val action = outActions.at(0);
 if (action is OutActionSendMessage) {
     val message = action.loadGenericMessage();
     val opcode = message.loadOpcode();
@@ -272,8 +272,8 @@ Fails with [Assert.fail](../../testing/assert/#assertfail) if the stored tuple e
 
 Example:
 ```tolk
-val out_actions = vm.outActions();
-val action = out_actions.at(0);
+val outActions = vm.outActions();
+val action = outActions.at(0);
 println(action.kind());
 ```
 
@@ -291,8 +291,8 @@ If the action is not a send message, returns null.
 
 Example:
 ```tolk
-val out_actions = vm.outActions();
-val action = out_actions.getSendMessageAt(0);
+val outActions = vm.outActions();
+val action = outActions.getSendMessageAt(0);
 if (action != null) {
     println(action.mode);
 }
@@ -316,8 +316,8 @@ If the action is a send message but `Msg` does not match actual body type, this 
 
 Example:
 ```tolk
-val out_actions = vm.outActions();
-val body = out_actions.getSendMessageBodyAt<IncreaseCounter>(0);
+val outActions = vm.outActions();
+val body = outActions.getSendMessageBodyAt<IncreaseCounter>(0);
 if (body != null) {
     println(body.increaseBy);
 }
@@ -345,8 +345,8 @@ Returns the out actions from the control register C5 at that moment.
 
 Example:
 ```tolk
-val out_actions = vm.outActions();
-println(out_actions.size());
+val outActions = vm.outActions();
+println(outActions.size());
 ```
 
 <SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/types/out_actions.tolk#L261" />
@@ -364,8 +364,8 @@ Fails with [Assert.fail](../../testing/assert/#assertfail) if list node layout i
 
 Example:
 ```tolk
-val out_actions = vm.parseOutActions(vm.getC5());
-println(out_actions.size());
+val outActions = vm.parseOutActions(vm.getC5());
+println(outActions.size());
 ```
 
 <SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/types/out_actions.tolk#L275" />

--- a/docs/content/docs/standard_library/vm/vm.mdx
+++ b/docs/content/docs/standard_library/vm/vm.mdx
@@ -13,7 +13,7 @@ It allows reading and writing to control registers (C5, C7) and configuring exec
 Examples:
 ```tolk
 // Mock time
-vm.setTime(1700000000);
+vm.setTime(1_700_000_000);
 
 // Register a mock library
 vm.registerLibrary(myLibCell);

--- a/docs/content/docs/test-runner/cookbook.mdx
+++ b/docs/content/docs/test-runner/cookbook.mdx
@@ -22,7 +22,7 @@ get fun `test mint`() {
         dest: address,
         body: ChangeMinterAdmin {
             queryId: 0,
-            newAdminAddress: new_owner,
+            newAdminAddress: newOwner,
         },
     });
     val result = net.send(from, msg);
@@ -45,7 +45,7 @@ fun JettonMinter.getJettonData(self): JettonDataReply {
 
 ```tolk
 fun JettonMinter.getWalletAddress(self, owner: address): address {
-    return net.runGetMethod(self.address, "get_wallet_address", owner)
+    return net.runGetMethod(self.address, "get_wallet_address", owner);
 }
 ```
 
@@ -73,8 +73,8 @@ get fun `test mint`() {
 ```tolk
 get fun `test mint`() {
     // ...
-    expect(mint_result).toHaveSuccessfulTx({
-        rom: minter.address,
+    expect(mintResult).toHaveSuccessfulTx({
+        from: minter.address,
         to: wallet.address,
     });
 }
@@ -85,8 +85,8 @@ get fun `test mint`() {
 ```tolk
 get fun `test mint`() {
     // ...
-    expect(mint_result).toHaveSuccessfulTx<MintNewJettons>({
-        rom: minter.address,
+    expect(mintResult).toHaveSuccessfulTx<MintNewJettons>({
+        from: minter.address,
         to: wallet.address,
     });
 }
@@ -113,8 +113,8 @@ get fun `test mint`() {
 ```tolk
 get fun `test mint`() {
     // ...
-    expect(send_result).toHaveBouncedTx({
-        from: deployer_jetton_wallet.address,
+    expect(sendResult).toHaveBouncedTx({
+        from: deployerJettonWallet.address,
         to: deployer.address,
     });
 }
@@ -125,10 +125,10 @@ get fun `test mint`() {
 ```tolk
 get fun `test mint`() {
     // ...
-    expect(mint_result).toHaveFailedTx({
-        from: not_deployer.address,
+    expect(mintResult).toHaveFailedTx({
+        from: notDeployer.address,
         to: minter.address,
-        exit_code: ERR_NOT_FROM_ADMIN,
+        exitCode: ERR_NOT_FROM_ADMIN,
     });
 }
 ```
@@ -138,9 +138,9 @@ get fun `test mint`() {
 ```tolk
 get fun `test mint`() {
     // ...
-    expect(send_result).toNotHaveTx({
-        from: not_deployer_jetton_wallet.address,
-        to: not_deployer.address
+    expect(sendResult).toNotHaveTx({
+        from: notDeployerJettonWallet.address,
+        to: notDeployer.address
     });
 }
 ```
@@ -159,7 +159,7 @@ get fun `test something`() {
 ```tolk
 get fun `test something`() {
     // ...
-    expect(send_result.at(0)).toConsumeLessThan(1500);
+    expect(sendResult.at(0)).toConsumeLessThan(1500);
 }
 ```
 
@@ -168,9 +168,9 @@ get fun `test something`() {
 ```tolk
 get fun `test something`() {
     // ...
-    val out_actions = send_result.at(0).allOutActions();
-    val first = out_actions.at(0);
-    println(first.kind())
+    val outActions = sendResult.at(0).allOutActions();
+    val first = outActions.at(0);
+    println(first.kind());
 }
 ```
 
@@ -187,12 +187,11 @@ get fun `test something`() {
 ```tolk
 fun JettonWallet.getJettonBalance(self): coins {
     if (!net.isDeployed(self.address)) {
-        return 0
+        return 0;
     }
 
-    val result: JettonWalletDataReply =
-        net.runGetMethod(self.address, "get_wallet_data");
-    return result.jettonBalance
+    val result = net.runGetMethod<JettonWalletDataReply>(self.address, "get_wallet_data");
+    return result.jettonBalance;
 }
 ```
 

--- a/docs/content/docs/test-runner/generating-wrappers.mdx
+++ b/docs/content/docs/test-runner/generating-wrappers.mdx
@@ -32,24 +32,27 @@ import "wrappers/Counter"
 // ... other imports
 
 /// Initializes the test environment, creating a fresh instance of the contract.
-/// Returns the contract wrapper and two treasury accounts (`deployer` and `not_deployer`).
+/// Returns the contract wrapper and two treasury accounts (`deployer` and `notDeployer`).
 fun setupTest() {
     // Create a treasury account for deployment (typically the owner)
     val deployer = net.treasury("deployer");
     // Create another treasury account for testing interactions from other users
-    val not_deployer = net.treasury("not_deployer");
+    val notDeployer = net.treasury("not_deployer");
 
     // Initialize and deploy the contract with default values
-    val contract = Counter.fromStorage({ id: 0, counter: 0 });
+    val contract = Counter.fromStorage({
+        id: 0,
+        counter: 0,
+    });
     val res = contract.deploy(deployer.address, { value: ton("1") });
     expect(res).toHaveSuccessfulDeploy({ to: contract.address });
 
-    return (contract, deployer, not_deployer)
+    return (contract, deployer, notDeployer);
 }
 
 /// Example test case demonstrating the basic flow
 get fun `test basic flow`() {
-    val (contract, deployer, not_deployer) = setupTest();
+    val (contract, deployer, notDeployer) = setupTest();
 
     // TODO: Implement your test logic here
     // Example:

--- a/docs/content/docs/test-runner/world-state-snapshots.mdx
+++ b/docs/content/docs/test-runner/world-state-snapshots.mdx
@@ -24,7 +24,7 @@ get fun `test save snapshot`() {
     val target = net.randomAddress("snapshot-target");
 
     net.topUp(target, ton("3"));
-    net.setNow(1700023001);
+    net.setNow(1_700_023_001);
 
     expect(net.saveSnapshot("fixtures/world-state.json")).toBeTrue();
 }
@@ -40,7 +40,7 @@ get fun `test load snapshot`() {
     val target = net.randomAddress("snapshot-target");
 
     expect(net.loadSnapshot("fixtures/world-state.json")).toBeTrue();
-    expect(net.now()).toEqual(1700023001);
+    expect(net.now()).toEqual(1_700_023_001);
     expect(net.balance(target)).toEqual(ton("3"));
 }
 ```

--- a/docs/content/docs/test-runner/your-first-integration-test-in-tolk.mdx
+++ b/docs/content/docs/test-runner/your-first-integration-test-in-tolk.mdx
@@ -114,7 +114,7 @@ fun Counter.fromStorage(storage: Storage): Counter {
         data: storage.toCell(),
     };
     val address = AutoDeployAddress { stateInit: init }.calculateAddress();
-    return Counter { address, init }
+    return Counter { address, init };
 }
 ```
 
@@ -128,7 +128,10 @@ Now let's write our first test in which we will deploy the contract.
 
 ```tolk
 get fun `test should deploy`() {
-    val counter = Counter.fromStorage({ id: 0, counter: 0 });
+    val counter = Counter.fromStorage({
+        id: 0,
+        counter: 0,
+    });
 
     val deployer = net.treasury("deployer");
     val msg = createMessage({
@@ -177,7 +180,10 @@ The complete test code looks like this:
 
 ````tolk
 get fun `test should deploy`() {
-    val counter = Counter.fromStorage({ id: 0, counter: 0 });
+    val counter = Counter.fromStorage({
+        id: 0,
+        counter: 0,
+    });
 
     val deployer = net.treasury("deployer");
     val msg = createMessage({
@@ -202,7 +208,10 @@ For our `Counter` tests, we need both `counter` and `deployer` contracts. Let's 
 
 ```tolk
 fun setupTest() {
-    val counter = Counter.fromStorage({ id: 0, counter: 0 });
+    val counter = Counter.fromStorage({
+        id: 0,
+        counter: 0,
+    });
 
     val deployer = net.treasury("deployer");
     val msg = createMessage({
@@ -215,7 +224,7 @@ fun setupTest() {
     val res = net.send(deployer.address, msg);
     expect(res).toHaveSuccessfulDeploy({ to: counter.address });
 
-    return (counter, deployer)
+    return (counter, deployer);
 }
 ```
 
@@ -272,7 +281,7 @@ To call a getter method on the desired contract, just call the `net.runGetMethod
 
 ```tolk
 fun Counter.getCounter(self): int {
-    return net.runGetMethod(self.address, "currentCounter")
+    return net.runGetMethod(self.address, "currentCounter");
 }
 ```
 

--- a/lib/emulation/config.tolk
+++ b/lib/emulation/config.tolk
@@ -12,15 +12,15 @@
 /// ```tolk
 /// // Set custom gas prices
 /// var config = net.blockchainConfig();
-/// val gasPrice = GasPricesSimple {
+/// val gasPrices = GasPricesSimple {
 ///     gasPrice: 1000,
-///     gasLimit: 1000000,
+///     gasLimit: 1_000_000,
 ///     gasCredit: 10000,
-///     blockGasLimit: 10000000,
-///     freezeDueLimit: 1000000000,
-///     deleteDueLimit: 5000000000
+///     blockGasLimit: 10_000_000,
+///     freezeDueLimit: 1_000_000_000,
+///     deleteDueLimit: 5_000_000_000
 /// };
-/// config.setGasPrices(simplePrices, MASTERCHAIN);
+/// config.setGasPrices(gasPrices, MASTERCHAIN);
 ///
 /// // Access storage prices
 /// val storagePrices = config.getStoragePrices();
@@ -235,8 +235,8 @@ fun StoragePricesDict.setInitial(mutate self, prices: StoragePrices): void {
 /// Example:
 /// ```tolk
 /// var pricesDict = StoragePricesDict.fromMap(createEmptyMap<uint32, StoragePrices>());
-/// pricesDict.set(1000000, StoragePrices {
-///     initialUnixTime: 1000000,
+/// pricesDict.set(1_000_000, StoragePrices {
+///     initialUnixTime: 1_000_000,
 ///     bitPrice: 1,
 ///     cellPrice: 1000,
 ///     masterchainBitPrice: 1,
@@ -264,7 +264,7 @@ fun Config.setStoragePrices(mutate self, prices: StoragePricesDict): void {
 /// Example:
 /// ```tolk
 /// val storagePrices = config.getStoragePrices();
-/// val prices = storagePrices.get(1000000);
+/// val prices = storagePrices.get(1_000_000);
 /// println("Bit price: {}, Cell price: {}, Masterchain bit price: {}",
 ///     prices.bitPrice, prices.cellPrice, prices.masterchainBitPrice);
 /// ```

--- a/lib/emulation/network.tolk
+++ b/lib/emulation/network.tolk
@@ -484,14 +484,14 @@ fun net.sendIter(from: address, message: OutMessage): TxCursor {
 ///
 /// Example:
 /// ```tolk
-/// val bounced_msg = createMessage({
+/// val bouncedMsg = createMessage({
 ///     bounce: false,
 ///     value: ton("0.95"),
-///     dest: deployer_jetton_wallet.address,
+///     dest: deployer.address,
 ///     body: beginCell().storeUint(0xFFFFFFFF, 32).storeSlice(body.toCell().beginParse()).endCell(),
 /// }).bounced();
 ///
-/// net.sendSingle(not_deployer_jetton_wallet.address, bounced_msg);
+/// net.sendSingle(notDeployer.address, bouncedMsg);
 /// ```
 ///
 /// See [net.send] if you need to send a message and process out messages.
@@ -587,14 +587,14 @@ fun net.runTickTock(onAccount: address, isTock: bool): SendResultList {
 ///
 /// Example:
 /// ```tolk
-/// val bounced_msg = createMessage({
+/// val bouncedMsg = createMessage({
 ///     bounce: false,
 ///     value: ton("0.95"),
-///     dest: deployer_jetton_wallet.address,
+///     dest: deployer.address,
 ///     body: beginCell().storeUint(0xFFFFFFFF, 32).storeSlice(body.toCell().beginParse()).endCell(),
 /// }).bounced();
 ///
-/// net.sendSingle(not_deployer_jetton_wallet.address, bounced_msg);
+/// net.sendSingle(notDeployer.address, bouncedMsg);
 /// ```
 fun OutMessage.bounced(self): OutMessage {
     var msg = (self.messageCell as Cell<MessageRelaxedGeneric>).load();
@@ -663,16 +663,16 @@ struct Wallet {
 /// ```tolk
 /// /// Script that deploys a counter contract using a wallet to real blockchain.
 /// fun main() {
-///    val deployer = net.wallet("deployer");
-///    val counter = Counter.fromStorage(Storage {
-///        id: 8,
-///        counter: 0,
-///    });
+///     val deployer = net.wallet("deployer");
+///     val counter = Counter.fromStorage({
+///         id: 8,
+///         counter: 0,
+///     });
 ///
-///    val result = counter.deploy(deployer.address, ton("0.05"));
-///    result.wait();
+///     val result = counter.deploy(deployer.address, ton("0.05"));
+///     result.wait();
 ///
-///    println("Deployed counter to {}", counter.address);
+///     println("Deployed counter to {}", counter.address);
 /// }
 /// ```
 fun net.wallet(name: string): Wallet {
@@ -844,7 +844,7 @@ fun net.disableBroadcast(): void {
 /// get fun get_all_data(): (int, slice) { ... }
 /// ```
 /// ```tolk
-/// val data: tuple = net.runGetMethod(wallet.address, "get_all_data");
+/// val data = net.runGetMethod<tuple>(wallet.address, "get_all_data");
 /// val first = data.get(0) as int;
 /// val second = data.get(1) as int;
 /// ```
@@ -877,12 +877,12 @@ fun net.runGetMethodById<Ret, Args = tuple>(addr: address, id: int, args: Args? 
 /// ```tolk
 /// fun JettonWallet.getJettonBalance(self): coins {
 ///     if (!net.isDeployed(self.address)) {
-///         return 0 // return 0 if contract is not deployed
+///         return 0; // return 0 if contract is not deployed
 ///     }
 ///
 ///     // and if deployed, actually run get method
-///     val result: JettonWalletDataReply = net.runGetMethod(self.address, "get_wallet_data");
-///     return result.jettonBalance
+///     val result = net.runGetMethod<JettonWalletDataReply>(self.address, "get_wallet_data");
+///     return result.jettonBalance;
 /// }
 /// ```
 fun net.isDeployed(addr: address): bool {
@@ -948,7 +948,7 @@ fun net.waitForTransaction(
 /// Example:
 /// ```tolk
 /// val address = net.randomAddress("random_user");
-/// val masterchain_address = net.randomAddress("random_user", -1);
+/// val masterchainAddress = net.randomAddress("random_user", -1);
 /// ```
 fun net.randomAddress(name: string? = null, wc: int = 0): address {
     var builder = beginCell();
@@ -1038,9 +1038,9 @@ fun net.getAccountState(addr: address): AccountInfo? {
 ///
 /// Example:
 /// ```tolk
-/// val storage_fee = net.getAccountStorageFee(contract.address, 86400); // 1 day
-/// if (storage_fee != null) {
-///     println("Daily storage fee: {:ton}", storage_fee);
+/// val storageFee = net.getAccountStorageFee(contract.address, 86400); // 1 day
+/// if (storageFee != null) {
+///     println("Daily storage fee: {:ton}", storageFee);
 /// }
 /// ```
 fun net.getAccountStorageFee(addr: address, seconds: int): coins? {
@@ -1077,8 +1077,8 @@ fun net.fetchAndRegisterLibrary(hash: string): bool {
 ///
 /// Example:
 /// ```tolk
-/// val future_time = net.now() + 1000; // 1000 seconds from now
-/// net.setNow(future_time);
+/// val futureTime = net.now() + 1000; // 1000 seconds from now
+/// net.setNow(futureTime);
 /// ```
 fun net.setNow(now: uint32): void {
     // Update C7[0][3] (unixtime) FIRST so blockchain.now() stays in sync
@@ -1093,8 +1093,8 @@ fun net.setNow(now: uint32): void {
 ///
 /// Example:
 /// ```tolk
-/// val current_time = net.now();
-/// println("Current emulation time: {}", current_time);
+/// val currentTime = net.now();
+/// println("Current emulation time: {}", currentTime);
 /// ```
 fun net.now(): uint32 {
     return ffi.getNow();

--- a/lib/fmt.tolk
+++ b/lib/fmt.tolk
@@ -26,7 +26,7 @@
 /// val hex = format("Value in hex: 0x{:x}", 255); // "Value in hex: 0xff"
 ///
 /// // Formatting TON amounts
-/// val balance = format("Balance: {:ton}", 500000000); // "Balance: 0.5 TON"
+/// val balance = format("Balance: {:ton}", 500_000_000); // "Balance: 0.5 TON"
 ///
 /// // Escaping braces
 /// val escaped = format("Use {{}} to print braces", 0); // "Use {} to print braces"
@@ -35,7 +35,7 @@
 /// val partial = format("{} {}", "left"); // "left {}"
 ///
 /// // Multiple arguments
-/// val info = format("User {} has {} items worth {:ton}", "Alice", 5, 1000000000);
+/// val info = format("User {} has {} items worth {:ton}", "Alice", 5, 1_000_000_000);
 /// ```
 
 import "@stdlib/reflection"

--- a/lib/io.tolk
+++ b/lib/io.tolk
@@ -39,7 +39,7 @@ import "ffi/ffi"
 /// println((1, 2, 3));
 /// println(Data {
 ///     value: 10,
-///     is_set: true
+///     isSet: true
 /// });
 ///
 /// println("Hello, 0x{:x}", 10);

--- a/lib/testing/assert.tolk
+++ b/lib/testing/assert.tolk
@@ -127,7 +127,7 @@ fun Assert.assume(condition: bool, message: string = "", location: string = ""):
 /// Example:
 /// ```tolk
 /// get fun `test gas consumption`() {
-///     val result = Assert.consumesLessThan(fun do_something() {
+///     val result = Assert.consumesLessThan(fun() {
 ///         // do something that consumes gas
 ///         return 42;
 ///     }, 100);
@@ -154,7 +154,7 @@ fun Assert.consumesLessThan<Ret>(fn: () -> Ret, expected: int): Ret {
 /// Example:
 /// ```tolk
 /// get fun `test gas consumption`() {
-///     val result = Assert.consumesLessThan1(fun do_something(a: int) {
+///     val result = Assert.consumesLessThan1(fun(a: int) {
 ///         // do something that consumes gas
 ///         return a + 1;
 ///     }, 100, 100);
@@ -180,7 +180,7 @@ fun Assert.consumesLessThan1<Ret, Arg1>(fn: (Arg1) -> Ret, arg1: Arg1, expected:
 /// Example:
 /// ```tolk
 /// get fun `test gas consumption`() {
-///     val result = Assert.consumesLessThan2(fun do_something(a: int, b: int) {
+///     val result = Assert.consumesLessThan2(fun(a: int, b: int) {
 ///         // do something that consumes gas
 ///         return a + b;
 ///     }, 10, 20, 100);
@@ -212,7 +212,7 @@ fun Assert.consumesLessThan2<Ret, Arg1, Arg2>(
 /// Example:
 /// ```tolk
 /// get fun `test gas consumption`() {
-///     val result = Assert.consumesLessThan3(fun do_something(a: int, b: int, c: int) {
+///     val result = Assert.consumesLessThan3(fun(a: int, b: int, c: int) {
 ///         // do something that consumes gas
 ///         return a + b + c;
 ///     }, 10, 20, 30, 100);

--- a/lib/testing/outlist_expect.tolk
+++ b/lib/testing/outlist_expect.tolk
@@ -35,8 +35,8 @@ import "expect"
 ///
 /// Example:
 /// ```tolk
-/// val out_actions = vm.outActions();
-/// expect(out_actions).toBeSendMessageAt<IncreaseCounter>(0);
+/// val outActions = vm.outActions();
+/// expect(outActions).toBeSendMessageAt<IncreaseCounter>(0);
 /// ```
 ///
 /// Note that you should provide the message type as a generic parameter.

--- a/lib/types/message.tolk
+++ b/lib/types/message.tolk
@@ -30,8 +30,8 @@ import "../tlb/maybe"
 ///
 /// Example:
 /// ```tolk
-/// val out_actions = vm.outActions();
-/// val action = out_actions.at(0);
+/// val outActions = vm.outActions();
+/// val action = outActions.at(0);
 /// if (action is OutActionSendMessage) {
 ///     val message = action.loadGenericMessage();
 ///     val opcode = message.loadOpcode();
@@ -56,8 +56,8 @@ struct MessageRelaxedGeneric {
 ///
 /// Example:
 /// ```tolk
-/// val out_actions = vm.outActions();
-/// val action = out_actions.at(0);
+/// val outActions = vm.outActions();
+/// val action = outActions.at(0);
 /// if (action is OutActionSendMessage) {
 ///     val message = action.loadGenericMessage();
 ///     val opcode = message.loadOpcode(true);
@@ -94,8 +94,8 @@ fun ExtMessageRelaxedGeneric.loadOpcode(self, skipBounce: bool = false): int? {
 ///
 /// Example:
 /// ```tolk
-/// val out_actions = vm.outActions();
-/// val action = out_actions.at(0);
+/// val outActions = vm.outActions();
+/// val action = outActions.at(0);
 /// if (action is OutActionSendMessage) {
 ///     val message = action.loadMessage<IncreaseCounter>();
 ///     val body = message.loadBody();
@@ -119,8 +119,8 @@ struct MessageRelaxed<X> {
 ///
 /// Example:
 /// ```tolk
-/// val out_actions = vm.outActions();
-/// val action = out_actions.at(0);
+/// val outActions = vm.outActions();
+/// val action = outActions.at(0);
 /// if (action is OutActionSendMessage) {
 ///     val message = action.loadMessage<IncreaseCounter>();
 ///     val body = message.loadBody();

--- a/lib/types/out_actions.tolk
+++ b/lib/types/out_actions.tolk
@@ -56,8 +56,8 @@ struct (0x0ec3c86d) OutActionSendMessage {
 ///
 /// Example:
 /// ```tolk
-/// val out_actions = vm.outActions();
-/// val action = out_actions.at(0);
+/// val outActions = vm.outActions();
+/// val action = outActions.at(0);
 /// if (action is OutActionSendMessage) {
 ///     val message = action.loadMessage<IncreaseCounter>();
 ///     val body = message.loadBody();
@@ -74,8 +74,8 @@ fun OutActionSendMessage.loadMessage<Msg>(self): MessageRelaxed<Msg> {
 ///
 /// Example:
 /// ```tolk
-/// val out_actions = vm.outActions();
-/// val action = out_actions.at(0);
+/// val outActions = vm.outActions();
+/// val action = outActions.at(0);
 /// if (action is OutActionSendMessage) {
 ///     val body = action.loadBody<IncreaseCounter>();
 ///     println(body.increaseBy);
@@ -91,8 +91,8 @@ fun OutActionSendMessage.loadBody<Msg>(self): Msg {
 ///
 /// Example:
 /// ```tolk
-/// val out_actions = vm.outActions();
-/// val action = out_actions.at(0);
+/// val outActions = vm.outActions();
+/// val action = outActions.at(0);
 /// if (action is OutActionSendMessage) {
 ///     val message = action.loadGenericMessage();
 ///     val opcode = message.loadOpcode();
@@ -185,8 +185,8 @@ type OutActionList = array<Cell<OutAction>>
 ///
 /// Example:
 /// ```tolk
-/// val out_actions = vm.outActions();
-/// val action = out_actions.at(0);
+/// val outActions = vm.outActions();
+/// val action = outActions.at(0);
 /// println(action.kind());
 /// ```
 fun OutActionList.at(self, i: int): OutAction {
@@ -204,8 +204,8 @@ fun OutActionList.at(self, i: int): OutAction {
 ///
 /// Example:
 /// ```tolk
-/// val out_actions = vm.outActions();
-/// val action = out_actions.getSendMessageAt(0);
+/// val outActions = vm.outActions();
+/// val action = outActions.getSendMessageAt(0);
 /// if (action != null) {
 ///     println(action.mode);
 /// }
@@ -228,8 +228,8 @@ fun OutActionList.getSendMessageAt(self, i: int): OutActionSendMessage? {
 ///
 /// Example:
 /// ```tolk
-/// val out_actions = vm.outActions();
-/// val body = out_actions.getSendMessageBodyAt<IncreaseCounter>(0);
+/// val outActions = vm.outActions();
+/// val body = outActions.getSendMessageBodyAt<IncreaseCounter>(0);
 /// if (body != null) {
 ///     println(body.increaseBy);
 /// }
@@ -255,8 +255,8 @@ fun OutMessage.outActions(self, mode: int): OutActionList {
 ///
 /// Example:
 /// ```tolk
-/// val out_actions = vm.outActions();
-/// println(out_actions.size());
+/// val outActions = vm.outActions();
+/// println(outActions.size());
 /// ```
 fun vm.outActions(): OutActionList {
     return vm.parseOutActions(vm.getC5());
@@ -269,8 +269,8 @@ fun vm.outActions(): OutActionList {
 ///
 /// Example:
 /// ```tolk
-/// val out_actions = vm.parseOutActions(vm.getC5());
-/// println(out_actions.size());
+/// val outActions = vm.parseOutActions(vm.getC5());
+/// println(outActions.size());
 /// ```
 fun vm.parseOutActions(cell: cell): OutActionList {
     val rootSlice = cell.beginParse();

--- a/lib/vm/vm.tolk
+++ b/lib/vm/vm.tolk
@@ -6,7 +6,7 @@
 /// Examples:
 /// ```tolk
 /// // Mock time
-/// vm.setTime(1700000000);
+/// vm.setTime(1_700_000_000);
 ///
 /// // Register a mock library
 /// vm.registerLibrary(myLibCell);


### PR DESCRIPTION
1) `camelCase` variables, not `snake_case`
2) `var p = Point { ... }` not `val p: Point = { ... }` 
3) semicolons
4) `1_000_000` for big numbers
5) fix invalid syntax and typos
6) some more cosmetics