### PR TITLE
fix(docs): various manual fixes to typos and wrong typing in Tolk snippets

### DIFF
--- a/crates/tolk-linter/src/rules/ast/asm_function_missing_safety_comment.rs
+++ b/crates/tolk-linter/src/rules/ast/asm_function_missing_safety_comment.rs
@@ -16,13 +16,13 @@ use tolk_syntax::{FuncBody, FunctionLike, HasName, TopLevel};
 ///
 /// ### Example
 /// ```tolk
-/// fun lowLevelLoad(x: slice): int asm "LDI";
+/// fun lowLevelLoad(x: slice): int asm "32 LDI";
 /// ```
 ///
 /// Use instead:
 /// ```tolk
 /// // SAFETY: `x` always contains at least 32 bits.
-/// fun lowLevelLoad(x: slice): int asm "LDI";
+/// fun lowLevelLoad(x: slice): int asm "32 LDI";
 /// ```
 #[derive(ViolationMetadata)]
 #[violation_metadata(stable_since = "v0.0.1")]

--- a/docs/content/docs/contract-deployment.mdx
+++ b/docs/content/docs/contract-deployment.mdx
@@ -101,6 +101,10 @@ fun main() {
 
 To execute your deployment script on the real blockchain, use the `acton script` command with `--net <network>`.
 
+<Callout>
+  Executing scripts in real blockchain is often called "broadcasting", opposed to local "emulation".
+</Callout>
+
 ### Testnet
 
 ```bash

--- a/docs/content/docs/installation.mdx
+++ b/docs/content/docs/installation.mdx
@@ -216,7 +216,7 @@ acton up 0.1.5
 
 ### Switch to trunk
 
-If you want to try the latest features before they are officially released, you can install the trunk version:
+If you want to try the latest features **before they are officially released**, you can install the trunk version:
 
 ```bash
 acton up --trunk

--- a/docs/content/docs/linting/rules/e015-asm-function-missing-safety-comment.mdx
+++ b/docs/content/docs/linting/rules/e015-asm-function-missing-safety-comment.mdx
@@ -21,13 +21,13 @@ it is hard to review assumptions and soundness constraints.
 
 ### Example
 ```tolk
-fun lowLevelLoad(x: slice): int asm "LDI";
+fun lowLevelLoad(x: slice): int asm "32 LDI";
 ```
 
 Use instead:
 ```tolk
 // SAFETY: `x` always contains at least 32 bits.
-fun lowLevelLoad(x: slice): int asm "LDI";
+fun lowLevelLoad(x: slice): int asm "32 LDI";
 ```
 
 <SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/crates/tolk-linter/src/rules/ast/asm_function_missing_safety_comment.rs#L27" />

--- a/docs/content/docs/project-init.mdx
+++ b/docs/content/docs/project-init.mdx
@@ -51,7 +51,7 @@ $ acton new my-project
 ? Include AGENTS.md guidance? Yes
 ```
 
-If a template supports a UI scaffold, you can skip that prompt by passing
+If a template supports a UI scaffold (TypeScript dApp), you can skip that prompt by passing
 `--app`. In non-interactive mode, Acton keeps the contract-only layout unless
 you pass `--app` explicitly.
 
@@ -126,7 +126,7 @@ A typical contract-only template project starts with the following structure:
 - **`contracts/`**: This is where your `.tolk` smart contract source files live.
 - **`scripts/`**: Contains auxiliary Tolk scripts for deployment, administration, and interaction with your contracts.
 - **`tests/`**: Contains your unit and integration tests.
-- **`wrappers/`**: Contains contract wrappers that provide an interface for testing your contracts.
+- **`wrappers/`**: Contains contract wrappers that provide an interface for testing and scripting.
 - **`Acton.toml`**: The main configuration file for your project. It defines your package metadata, contracts, and dependencies.
 - **`.env`**: Local environment variables template (includes commented `TONCENTER_API_KEY` hint).
 - **`.editorconfig`**: Shared formatting defaults for the generated project.

--- a/docs/content/docs/scripting/passing-arguments.mdx
+++ b/docs/content/docs/scripting/passing-arguments.mdx
@@ -38,7 +38,7 @@ The sum is:
 
 It's important to understand that when you pass arguments to a script, Acton creates a **stack** of values and passes this stack to the TVM executor. The Tolk compiler then generates code that takes these values from the stack and assigns them to your function parameters.
 
-This means you are not limited to simple integers. You can pass any valid TVM stack value, including tuples, cells, and slices.
+This means you are not limited to simple integers. You can pass any valid TVM stack value, including tuples, cells, and strings.
 
 <Callout type="info">
     Be careful when passing complex types like structs, as they may consume
@@ -131,13 +131,13 @@ The stack `[10 20]` will be passed to `main` and automatically converted to a `P
 
 ### Strings
 
-To pass a string, you need to wrap it in double quotes both for the shell and for Acton's argument parser. This results in a `'"..."'` syntax. The string will be converted into a `slice` containing the UTF-8 bytes of the string.
+To pass a string, you need to wrap it in double quotes both for the shell and for Acton's argument parser. This results in a `'"..."'` syntax.
 
 ```tolk title="hello_string.tolk"
 import "@acton/io"
 
-fun main(name: slice) {
-    println("Hello, {}", name.beginParse())
+fun main(name: string) {
+    println("Hello, {}", name);
 }
 ```
 
@@ -192,7 +192,7 @@ Here's a complete reference of all supported argument types:
 | Null    | `null` or `()`    | `null`              | For optional types                   |
 | Tuple   | `(value1 value2)` | `(10 20)`           | Requires quoting                     |
 | Tensor  | `[value1 value2]` | `[10 20 30]`        | Auto-unpacked from tuple             |
-| String  | `"text"`          | `"hello"`           | Converted to slice, requires quoting |
+| String  | `"text"`          | `"hello"`           | Long strings encoded as snaked cells |
 | Cell    | `C{hex}`          | `C{b5ee9c7201...}`  | Hex-encoded BoC                      |
 | Slice   | `CS{hex}`         | `CS{b5ee9c7201...}` | Hex-encoded BoC                      |
 

--- a/docs/content/docs/setup-wallets.mdx
+++ b/docs/content/docs/setup-wallets.mdx
@@ -13,10 +13,10 @@ Wallets are essential for interacting with the real blockchain in Acton. They en
 Use the `acton wallet new` command to generate a new testnet wallet:
 
 ```bash
-# Create a local wallet
+# Create a local wallet (for current project only)
 acton wallet new --name deployer --local
 
-# Create a global wallet
+# Create a global wallet (shared across multiple projects)
 acton wallet new --name shared --global
 ```
 

--- a/docs/content/docs/standard_library/emulation/network.mdx
+++ b/docs/content/docs/standard_library/emulation/network.mdx
@@ -1401,14 +1401,15 @@ println("Network version: {}", globalVersion.version);
 fun crc16(data: string): int
 ```
 
-Calculate the CRC16 checksum of a slice.
+Calculate the CRC16 checksum of a string.
+Unlike a compile-time `"str".crc16()` method, it works with non-constant strings.
 
 Example:
 ```tolk
-val crc = crc16("hello");
+val crc = crc16(someStr);
 ```
 
-<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/emulation/network.tolk#L1343" />
+<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/emulation/network.tolk#L1344" />
 
 ## `tuple.fromTuple`
 
@@ -1416,7 +1417,7 @@ val crc = crc16("hello");
 fun tuple.fromTuple(data: tuple): tuple
 ```
 
-<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/emulation/network.tolk#L1345" />
+<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/emulation/network.tolk#L1346" />
 
 ## `T.externalOutPrefix`
 
@@ -1424,7 +1425,7 @@ fun tuple.fromTuple(data: tuple): tuple
 fun T.externalOutPrefix(): int
 ```
 
-<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/emulation/network.tolk#L1349" />
+<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/emulation/network.tolk#L1350" />
 
 ## `T.externalOutPrefixLen`
 
@@ -1432,7 +1433,7 @@ fun T.externalOutPrefix(): int
 fun T.externalOutPrefixLen(): int
 ```
 
-<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/emulation/network.tolk#L1357" />
+<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/emulation/network.tolk#L1358" />
 
 ## `T.decodeExternalOutBody`
 
@@ -1440,7 +1441,7 @@ fun T.externalOutPrefixLen(): int
 fun T.decodeExternalOutBody(body: RemainingBitsAndRefs): T
 ```
 
-<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/emulation/network.tolk#L1365" />
+<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/emulation/network.tolk#L1366" />
 
 ## `T.getDeclaredPackPrefix2`
 
@@ -1448,5 +1449,5 @@ fun T.decodeExternalOutBody(body: RemainingBitsAndRefs): T
 fun T.getDeclaredPackPrefix2(): int
 ```
 
-<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/emulation/network.tolk#L1421" />
+<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/emulation/network.tolk#L1422" />
 

--- a/docs/content/docs/standard_library/fs.mdx
+++ b/docs/content/docs/standard_library/fs.mdx
@@ -43,8 +43,7 @@ Namespace for file system operations.
 fun fs.readFile(path: string): string?
 ```
 
-Reads the entire contents of a file at the given path as a string slice
-with snake-string encoding.
+Reads the entire contents of a file at the given path.
 
 Behavior details:
 - The file is read as UTF-8 text.
@@ -66,7 +65,7 @@ if (content != null) {
 }
 ```
 
-<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/fs.tolk#L46" />
+<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/fs.tolk#L45" />
 
 ## `fs.readBytes`
 
@@ -80,7 +79,7 @@ Returns:
 - `slice` with file bytes on success.
 - `null` on read failure (missing file, permission error, etc).
 
-<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/fs.tolk#L53" />
+<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/fs.tolk#L52" />
 
 ## `fs.writeString`
 
@@ -94,7 +93,7 @@ Returns:
 - `true` if the file was written successfully.
 - `false` on any host I/O error.
 
-<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/fs.tolk#L60" />
+<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/fs.tolk#L59" />
 
 ## `fs.writeBytes`
 
@@ -108,7 +107,7 @@ Returns:
 - `true` if the file was written successfully.
 - `false` on invalid byte slice input or host I/O error.
 
-<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/fs.tolk#L67" />
+<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/fs.tolk#L66" />
 
 ## `fs.exists`
 
@@ -122,5 +121,5 @@ Returns:
 - `true` when the path exists.
 - `false` when missing or if existence check fails.
 
-<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/fs.tolk#L74" />
+<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/fs.tolk#L73" />
 

--- a/docs/content/docs/standard_library/io.mdx
+++ b/docs/content/docs/standard_library/io.mdx
@@ -88,7 +88,7 @@ Notes:
 fun eprintln(str: string): void
 ```
 
-Prints the given slice string to the standard error output.
+Prints the given string to the standard error output.
 
 Example:
 ```tolk

--- a/docs/content/docs/standard_library/testing/expect.mdx
+++ b/docs/content/docs/standard_library/testing/expect.mdx
@@ -294,11 +294,11 @@ expect(noneValue).toBeNone();
 fun Expectation<slice>.toBeNonEmpty(self): void
 ```
 
-Asserts that actual value is not empty.
+Asserts that actual value is not empty (contains some bits of refs).
 
 Example:
 ```tolk
-expect("hello").toBeNonEmpty();
+expect(someSlice).toBeNonEmpty();
 ```
 
 <SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/testing/expect.tolk#L298" />
@@ -309,14 +309,14 @@ expect("hello").toBeNonEmpty();
 fun Expectation<slice>.toBeEmpty(self): void
 ```
 
-Asserts that actual value is empty.
+Asserts that actual value is empty (contains 0 bits and 0 refs).
 
 Example:
 ```tolk
-expect("").toBeEmpty();
+expect(someSlice).toBeEmpty();
 ```
 
-<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/testing/expect.tolk#L308" />
+<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/testing/expect.tolk#L310" />
 
 ## `Expectation<int>.toBeNaN`
 
@@ -331,7 +331,7 @@ Example:
 expect(nan()).toBeNaN();
 ```
 
-<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/testing/expect.tolk#L318" />
+<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/testing/expect.tolk#L322" />
 
 ## `Expectation<int>.toBeNonNaN`
 
@@ -346,7 +346,7 @@ Example:
 expect(0).toBeNonNaN();
 ```
 
-<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/testing/expect.tolk#L328" />
+<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/testing/expect.tolk#L332" />
 
 ## `Expectation<bool>.toBeTrue`
 
@@ -361,7 +361,7 @@ Example:
 expect(true).toBeTrue();
 ```
 
-<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/testing/expect.tolk#L338" />
+<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/testing/expect.tolk#L342" />
 
 ## `Expectation<bool>.toBeFalse`
 
@@ -376,7 +376,7 @@ Example:
 expect(false).toBeFalse();
 ```
 
-<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/testing/expect.tolk#L348" />
+<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/testing/expect.tolk#L352" />
 
 ## `Expectation<any_address>.toBeInternalAddress`
 
@@ -391,7 +391,7 @@ Example:
 expect(addr).toBeInternalAddress();
 ```
 
-<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/testing/expect.tolk#L358" />
+<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/testing/expect.tolk#L362" />
 
 ## `Expectation<any_address>.toBeNoneAddress`
 
@@ -406,7 +406,7 @@ Example:
 expect(addr).toBeNoneAddress();
 ```
 
-<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/testing/expect.tolk#L373" />
+<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/testing/expect.tolk#L377" />
 
 ## `Expectation<any_address>.toBeExternalAddress`
 
@@ -421,7 +421,7 @@ Example:
 expect(addr).toBeExternalAddress();
 ```
 
-<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/testing/expect.tolk#L388" />
+<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/testing/expect.tolk#L392" />
 
 ## `Expectation<array<E>>.toContain`
 
@@ -437,7 +437,7 @@ val arr = [1, 2, 3];
 expect(arr).toContain(2);
 ```
 
-<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/testing/expect.tolk#L404" />
+<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/testing/expect.tolk#L408" />
 
 ## `Expectation<BigArray<E>>.toContain`
 
@@ -445,7 +445,7 @@ expect(arr).toContain(2);
 fun Expectation<BigArray<E>>.toContain<U>(self, expected: U): void
 ```
 
-<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/testing/expect.tolk#L416" />
+<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/testing/expect.tolk#L420" />
 
 ## `Expectation<array<E>>.toNotContain`
 
@@ -461,7 +461,7 @@ val arr = [1, 2, 3];
 expect(arr).toNotContain(4);
 ```
 
-<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/testing/expect.tolk#L435" />
+<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/testing/expect.tolk#L439" />
 
 ## `Expectation<BigArray<E>>.toNotContain`
 
@@ -469,7 +469,7 @@ expect(arr).toNotContain(4);
 fun Expectation<BigArray<E>>.toNotContain<U>(self, expected: U): void
 ```
 
-<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/testing/expect.tolk#L446" />
+<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/testing/expect.tolk#L450" />
 
 ## `Expectation<array<E>>.toBeEmpty`
 
@@ -485,7 +485,7 @@ val arr = array<int> [];
 expect(arr).toBeEmpty();
 ```
 
-<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/testing/expect.tolk#L464" />
+<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/testing/expect.tolk#L468" />
 
 ## `Expectation<BigArray<E>>.toBeEmpty`
 
@@ -493,7 +493,7 @@ expect(arr).toBeEmpty();
 fun Expectation<BigArray<E>>.toBeEmpty(self): void
 ```
 
-<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/testing/expect.tolk#L470" />
+<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/testing/expect.tolk#L474" />
 
 ## `Expectation<array<E>>.toBeNonEmpty`
 
@@ -509,7 +509,7 @@ val arr = [1, 2, 3];
 expect(arr).toBeNonEmpty();
 ```
 
-<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/testing/expect.tolk#L483" />
+<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/testing/expect.tolk#L487" />
 
 ## `Expectation<BigArray<E>>.toBeNonEmpty`
 
@@ -517,7 +517,7 @@ expect(arr).toBeNonEmpty();
 fun Expectation<BigArray<E>>.toBeNonEmpty(self): void
 ```
 
-<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/testing/expect.tolk#L489" />
+<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/testing/expect.tolk#L493" />
 
 ## `Expectation<array<E>>.toHaveLength`
 
@@ -533,7 +533,7 @@ val arr = [1, 2, 3];
 expect(arr).toHaveLength(3);
 ```
 
-<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/testing/expect.tolk#L502" />
+<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/testing/expect.tolk#L506" />
 
 ## `Expectation<BigArray<E>>.toHaveLength`
 
@@ -541,7 +541,7 @@ expect(arr).toHaveLength(3);
 fun Expectation<BigArray<E>>.toHaveLength(self, length: int): void
 ```
 
-<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/testing/expect.tolk#L511" />
+<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/testing/expect.tolk#L515" />
 
 ## `Expectation<map<K, V>>.toContainKey`
 
@@ -559,7 +559,7 @@ map.set(2, 3);
 expect(map).toContainKey(2);
 ```
 
-<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/testing/expect.tolk#L529" />
+<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/testing/expect.tolk#L533" />
 
 ## `Expectation<map<K, V>>.toNotContainKey`
 
@@ -577,7 +577,7 @@ map.set(2, 3);
 expect(map).toNotContainKey(4);
 ```
 
-<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/testing/expect.tolk#L551" />
+<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/testing/expect.tolk#L555" />
 
 ## `Expectation<map<K, V>>.toContainValue`
 
@@ -595,7 +595,7 @@ map.set(2, 3);
 expect(map).toContainValue(2);
 ```
 
-<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/testing/expect.tolk#L573" />
+<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/testing/expect.tolk#L577" />
 
 ## `Expectation<map<K, V>>.toNotContainValue`
 
@@ -613,7 +613,7 @@ map.set(2, 3);
 expect(map).toNotContainValue(4);
 ```
 
-<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/testing/expect.tolk#L601" />
+<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/testing/expect.tolk#L605" />
 
 ## `Expectation<map<K, V>>.toBeEmpty`
 
@@ -629,7 +629,7 @@ var map = createEmptyMap<int32, int32>();
 expect(map).toBeEmpty();
 ```
 
-<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/testing/expect.tolk#L625" />
+<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/testing/expect.tolk#L629" />
 
 ## `Expectation<map<K, V>>.toBeNonEmpty`
 
@@ -647,7 +647,7 @@ map.set(2, 3);
 expect(map).toBeNonEmpty();
 ```
 
-<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/testing/expect.tolk#L640" />
+<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/testing/expect.tolk#L644" />
 
 ## `Expectation<map<K, V>>.toHaveLength`
 
@@ -665,7 +665,7 @@ map.set(2, 3);
 expect(map).toHaveLength(2);
 ```
 
-<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/testing/expect.tolk#L655" />
+<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/testing/expect.tolk#L659" />
 
 ## `formatExpectLocation`
 
@@ -673,7 +673,7 @@ expect(map).toHaveLength(2);
 fun formatExpectLocation(loc: SourceLocation): string
 ```
 
-<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/testing/expect.tolk#L666" />
+<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/testing/expect.tolk#L670" />
 
 ## `expect`
 
@@ -694,7 +694,7 @@ Optional location can be provided to specify the location of the expectation to
 be printed in the error message. You likely don't want to set this manually,
 as the location will be automatically set by the test framework.
 
-<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/testing/expect.tolk#L682" />
+<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/testing/expect.tolk#L686" />
 
 ## `expectToEndWithExitCode`
 
@@ -722,5 +722,5 @@ get fun `test fail with`() {
 
 This function is more flexible and can be used conditionally in the test.
 
-<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/testing/expect.tolk#L709" />
+<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/testing/expect.tolk#L713" />
 

--- a/docs/content/docs/standard_library/tlb/maybe.mdx
+++ b/docs/content/docs/standard_library/tlb/maybe.mdx
@@ -108,7 +108,7 @@ This is the safe way to access optional values.
 
 Example:
 ```tolk
-val maybeValue = Maybe<slice>.none();
+val maybeValue = Maybe<string>.none();
 val name = maybeValue.unwrapOr("default"); // Returns "default"
 ```
 

--- a/docs/content/docs/test-runner/writing-your-own-matchers.mdx
+++ b/docs/content/docs/test-runner/writing-your-own-matchers.mdx
@@ -124,30 +124,31 @@ get fun `test address workchain`() {
 }
 ```
 
-#### Example: `slice` Matcher
+#### Example: `string` Matcher
 
-Here is how you can write a matcher for a `slice` to check if it starts with a specific prefix.
+Here is how you can write a matcher for a `string` to check if it has desired length.
 
 ```tolk
 import "@acton/testing/expect"
 import "@acton/testing/assert"
 import "@acton/fmt"
+import "@stdlib/strings"
 
-fun Expectation<slice>.toStartWith(self, prefix: slice) {
-    if (!self.value.getFirstBits(prefix.remainingBitsCount()).bitsEqual(prefix)) {
+fun Expectation<string>.toHaveLength(self, expectedLen: int) {
+    if (self.value.calculateLength() != expectedLen) {
         Assert.fail(
             format(
-                "Expected slice '{}' to start with prefix '{}'",
+                "Expected string '{}' to have length '{}'",
                 self.value,
-                prefix
+                expectedLen
             ),
             self.location
         );
     }
 }
 
-get fun `test slice prefix`() {
-    expect("hello world").toStartWith("hello");
+get fun `test string len`() {
+    expect("hello world").toHaveLength(11);
 }
 ```
 
@@ -160,7 +161,7 @@ Let's say you have a `User` struct:
 ```tolk
 struct User {
     id: int
-    name: slice
+    name: string
     isActive: bool
 }
 ```

--- a/docs/content/docs/test-runner/your-first-integration-test-in-tolk.mdx
+++ b/docs/content/docs/test-runner/your-first-integration-test-in-tolk.mdx
@@ -110,7 +110,7 @@ struct Counter {
 
 fun Counter.fromStorage(storage: Storage): Counter {
     val init = ContractState {
-        code: build("Counter", "counter.tolk"),
+        code: build("Counter"),
         data: storage.toCell(),
     };
     val address = AutoDeployAddress { stateInit: init }.calculateAddress();

--- a/docs/grammars/grammar-tolk.json
+++ b/docs/grammars/grammar-tolk.json
@@ -39,7 +39,7 @@
     },
     {
       "name": "constant.numeric",
-      "match": "\\b(-?([\\d]+|0x[\\da-fA-F]+|0b[01]+))\\b"
+      "match": "\\b(-?([\\d][\\d_]*|0x[\\da-fA-F]+|0b[01]+))\\b"
     },
     {
       "name": "keyword.control",

--- a/lib/emulation/network.tolk
+++ b/lib/emulation/network.tolk
@@ -1334,11 +1334,12 @@ fun net.getConfig(): Config {
     return createMapFromLowLevelDict(ffi.getConfig());
 }
 
-/// Calculate the CRC16 checksum of a slice.
+/// Calculate the CRC16 checksum of a string.
+/// Unlike a compile-time `"str".crc16()` method, it works with non-constant strings.
 ///
 /// Example:
 /// ```tolk
-/// val crc = crc16("hello");
+/// val crc = crc16(someStr);
 /// ```
 fun crc16(data: string): int asm "13 EXTCALL"
 

--- a/lib/fs.tolk
+++ b/lib/fs.tolk
@@ -21,8 +21,7 @@
 /// Namespace for file system operations.
 struct fs
 
-/// Reads the entire contents of a file at the given path as a string slice
-/// with snake-string encoding.
+/// Reads the entire contents of a file at the given path.
 ///
 /// Behavior details:
 /// - The file is read as UTF-8 text.

--- a/lib/io.tolk
+++ b/lib/io.tolk
@@ -84,7 +84,7 @@ fun println<T1, T2 = void, T3 = void, T4 = void, T5 = void, T6 = void>(
     );
 }
 
-/// Prints the given slice string to the standard error output.
+/// Prints the given string to the standard error output.
 ///
 /// Example:
 /// ```tolk

--- a/lib/testing/expect.tolk
+++ b/lib/testing/expect.tolk
@@ -289,24 +289,28 @@ fun Expectation<Maybe<T>>.toBeNone(self): void {
     }
 }
 
-/// Asserts that actual value is not empty.
+/// Asserts that actual value is not empty (contains some bits of refs).
 ///
 /// Example:
 /// ```tolk
-/// expect("hello").toBeNonEmpty();
+/// expect(someSlice).toBeNonEmpty();
 /// ```
 fun Expectation<slice>.toBeNonEmpty(self): void {
-    Assert.notEqual(self.value, "", "expect(<actual>).toBeNonEmpty()", self.location);
+    if (self.value.isEmpty()) {
+        Assert.fail("expect(<actual>).toBeNonEmpty()", self.location);
+    }
 }
 
-/// Asserts that actual value is empty.
+/// Asserts that actual value is empty (contains 0 bits and 0 refs).
 ///
 /// Example:
 /// ```tolk
-/// expect("").toBeEmpty();
+/// expect(someSlice).toBeEmpty();
 /// ```
 fun Expectation<slice>.toBeEmpty(self): void {
-    Assert.equal(self.value, "", "expect(<actual>).toBeEmpty()", self.location);
+    if (!self.value.isEmpty()) {
+        Assert.fail("expect(<actual>).toBeEmpty()", self.location);
+    }
 }
 
 /// Asserts that actual value is NaN.

--- a/lib/tlb/maybe.tolk
+++ b/lib/tlb/maybe.tolk
@@ -60,7 +60,7 @@ fun Maybe<X>.unwrap(self): X {
 ///
 /// Example:
 /// ```tolk
-/// val maybeValue = Maybe<slice>.none();
+/// val maybeValue = Maybe<string>.none();
 /// val name = maybeValue.unwrapOr("default"); // Returns "default"
 /// ```
 fun Maybe<X>.unwrapOr(self, default: X): X {


### PR DESCRIPTION
For instance, replace `slice` to `string` in old examples