### PR TITLE
chore(tolk): new abi schema with unique_types and monomorphic instantiations

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -30,7 +30,7 @@
         "@ton/core": "0.62.0",
         "@types/react-router-dom": "^5.3.3",
         "buffer": "^6.0.3",
-        "gen-typescript-from-tolk-dev": "^0.2.4",
+        "gen-typescript-from-tolk-dev": "^0.3.1",
         "lucide-react": "^0.474.0",
         "react-d3-tree": "^3.6.6",
         "react-icons": "^5.5.0",
@@ -57,7 +57,7 @@
         "@ton/core": "0.62.0",
         "buffer": "^6.0.3",
         "clsx": "^2.1.1",
-        "gen-typescript-from-tolk-dev": "^0.2.4",
+        "gen-typescript-from-tolk-dev": "^0.3.1",
         "lucide-react": "^0.474.0",
         "react-d3-tree": "^3.6.6",
         "react-icons": "^5.5.0",
@@ -81,7 +81,7 @@
         "bignumber.js": "^9.3.1",
         "buffer": "^6.0.3",
         "d3-hierarchy": "^1.1.9",
-        "gen-typescript-from-tolk-dev": "^0.2.4",
+        "gen-typescript-from-tolk-dev": "^0.3.1",
         "react-d3-tree": "^3.6.6",
         "react-icons": "^5.5.0",
         "shiki": "^3.22.0",
@@ -731,7 +731,7 @@
 
     "functions-have-names": ["functions-have-names@1.2.3", "", {}, "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ=="],
 
-    "gen-typescript-from-tolk-dev": ["gen-typescript-from-tolk-dev@0.2.4", "", { "bin": { "gen-typescript-from-tolk": "dist/cli.js" } }, "sha512-ebpVT/sfYBpv0YBjnaEf6vueNgMZAbgEmWtR2FrKqrQMqY9m6hkRAnjTWSvJuaIIJqoYp7UOpEq3D8sUvGjuLA=="],
+    "gen-typescript-from-tolk-dev": ["gen-typescript-from-tolk-dev@0.3.1", "", { "bin": { "gen-typescript-from-tolk": "dist/cli.js" } }, "sha512-moBmYdNEDG870hjRLAzEkhPjwXbILBW1QIcALETGn5iDP9lUccy4GTJ7IFmGLajus4JfEvzoD+a+E1VgaTvl0A=="],
 
     "generator-function": ["generator-function@2.0.1", "", {}, "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g=="],
 

--- a/crates/acton-debug/src/core/evaluate.rs
+++ b/crates/acton-debug/src/core/evaluate.rs
@@ -1,13 +1,10 @@
 use crate::replayer::LocalVarRendered;
-use crate::types_render::{RenderedValue, render_cell_like_as_type};
+use crate::types_render::RenderedValue;
 use anyhow::{Result, anyhow, bail};
 use num_bigint::BigInt;
 use std::cmp::Ordering;
-use tolk_compiler::source_map::{Declaration, SourceMap};
-use tolk_compiler::types_kernel::Ty;
 use tolk_syntax::{
-    AstNode, DotAccessField, Expr, FuncBody, FunctionLike, Stmt, TopLevel, Type,
-    parse_tolk_int_literal,
+    AstNode, DotAccessField, Expr, FuncBody, FunctionLike, Stmt, TopLevel, parse_tolk_int_literal,
 };
 use tvm_logs::parser::CellLike;
 
@@ -25,13 +22,12 @@ struct ParsedValuePath {
 
 pub(crate) fn evaluate_expression(
     locals: &[LocalVarRendered],
-    source_map: Option<&SourceMap>,
     expression: &str,
 ) -> Result<RenderedValue> {
     let source_file = parse_wrapped_source(expression)?;
     let expr = wrapped_expression(&source_file)
         .ok_or_else(|| anyhow!("expected a single expression statement"))?;
-    evaluate_parsed_expression(locals, source_map, expr, source_file.source.as_ref())
+    evaluate_parsed_expression(locals, expr, source_file.source.as_ref())
 }
 
 pub(crate) fn evaluate_condition_expression(
@@ -41,7 +37,7 @@ pub(crate) fn evaluate_condition_expression(
     let source_file = parse_wrapped_source(expression)?;
     let expr = wrapped_expression(&source_file)
         .ok_or_else(|| anyhow!("expected a single expression statement"))?;
-    evaluate_boolean_expression(locals, None, expr, source_file.source.as_ref())
+    evaluate_boolean_expression(locals, expr, source_file.source.as_ref())
 }
 
 fn resolve_locals_path(
@@ -183,7 +179,6 @@ fn parse_numeric_index(raw: &str) -> Result<usize> {
 
 fn evaluate_parsed_expression(
     locals: &[LocalVarRendered],
-    source_map: Option<&SourceMap>,
     expr: Expr<'_>,
     source: &str,
 ) -> Result<RenderedValue> {
@@ -196,16 +191,16 @@ fn evaluate_parsed_expression(
             let inner = paren
                 .inner()
                 .ok_or_else(|| anyhow!("expected expression inside parentheses"))?;
-            evaluate_parsed_expression(locals, source_map, inner, source)
+            evaluate_parsed_expression(locals, inner, source)
         }
-        Expr::Unary(unary) => evaluate_unary_expression(locals, source_map, &unary, source),
-        Expr::AsCast(as_cast) => evaluate_as_cast_expression(locals, source_map, &as_cast, source),
+        Expr::Unary(unary) => evaluate_unary_expression(locals, &unary, source),
+        Expr::AsCast(_) => bail!("`as` casts are not supported in debugger evaluate"),
         Expr::Bin(bin) => match bin.operator_name(source) {
             "&&" => {
                 let left = bin
                     .left()
                     .ok_or_else(|| anyhow!("expected left operand for `&&`"))?;
-                let left = evaluate_boolean_expression(locals, source_map, left, source)?;
+                let left = evaluate_boolean_expression(locals, left, source)?;
                 if !left {
                     return Ok(render_bool(false));
                 }
@@ -214,14 +209,14 @@ fn evaluate_parsed_expression(
                     .right()
                     .ok_or_else(|| anyhow!("expected right operand for `&&`"))?;
                 Ok(render_bool(evaluate_boolean_expression(
-                    locals, source_map, right, source,
+                    locals, right, source,
                 )?))
             }
             "||" => {
                 let left = bin
                     .left()
                     .ok_or_else(|| anyhow!("expected left operand for `||`"))?;
-                let left = evaluate_boolean_expression(locals, source_map, left, source)?;
+                let left = evaluate_boolean_expression(locals, left, source)?;
                 if left {
                     return Ok(render_bool(true));
                 }
@@ -230,14 +225,12 @@ fn evaluate_parsed_expression(
                     .right()
                     .ok_or_else(|| anyhow!("expected right operand for `||`"))?;
                 Ok(render_bool(evaluate_boolean_expression(
-                    locals, source_map, right, source,
+                    locals, right, source,
                 )?))
             }
-            "==" => evaluate_equality_expression(locals, source_map, &bin, source, true),
-            "!=" => evaluate_equality_expression(locals, source_map, &bin, source, false),
-            "<" | "<=" | ">" | ">=" => {
-                evaluate_ordering_expression(locals, source_map, &bin, source)
-            }
+            "==" => evaluate_equality_expression(locals, &bin, source, true),
+            "!=" => evaluate_equality_expression(locals, &bin, source, false),
+            "<" | "<=" | ">" | ">=" => evaluate_ordering_expression(locals, &bin, source),
             operator => bail!("binary operator `{operator}` is not supported"),
         },
         _ => {
@@ -249,7 +242,6 @@ fn evaluate_parsed_expression(
 
 fn evaluate_unary_expression(
     locals: &[LocalVarRendered],
-    source_map: Option<&SourceMap>,
     unary: &tolk_syntax::Unary<'_>,
     source: &str,
 ) -> Result<RenderedValue> {
@@ -260,11 +252,11 @@ fn evaluate_unary_expression(
 
     match operator {
         "!" => {
-            let value = evaluate_parsed_expression(locals, source_map, argument, source)?;
+            let value = evaluate_parsed_expression(locals, argument, source)?;
             Ok(render_bool(!rendered_value_as_bool(&value)?))
         }
         "-" => {
-            let value = evaluate_parsed_expression(locals, source_map, argument, source)?;
+            let value = evaluate_parsed_expression(locals, argument, source)?;
             let number = parse_rendered_number(&value)
                 .ok_or_else(|| anyhow!("unary operator `-` requires numeric operand"))?;
             Ok(RenderedValue::typed_leaf((-number).to_string(), "int"))
@@ -275,11 +267,10 @@ fn evaluate_unary_expression(
 
 fn evaluate_boolean_expression(
     locals: &[LocalVarRendered],
-    source_map: Option<&SourceMap>,
     expr: Expr<'_>,
     source: &str,
 ) -> Result<bool> {
-    let value = evaluate_parsed_expression(locals, source_map, expr, source)?;
+    let value = evaluate_parsed_expression(locals, expr, source)?;
     rendered_value_as_bool(&value)
 }
 
@@ -293,7 +284,6 @@ fn rendered_value_as_bool(value: &RenderedValue) -> Result<bool> {
 
 fn evaluate_equality_expression(
     locals: &[LocalVarRendered],
-    source_map: Option<&SourceMap>,
     bin: &tolk_syntax::Bin<'_>,
     source: &str,
     expected_equal: bool,
@@ -305,15 +295,14 @@ fn evaluate_equality_expression(
         .right()
         .ok_or_else(|| anyhow!("expected right operand for equality comparison"))?;
 
-    let left = evaluate_parsed_expression(locals, source_map, left, source)?;
-    let right = evaluate_parsed_expression(locals, source_map, right, source)?;
+    let left = evaluate_parsed_expression(locals, left, source)?;
+    let right = evaluate_parsed_expression(locals, right, source)?;
     let equal = rendered_value_text(&left) == rendered_value_text(&right);
     Ok(render_bool(equal == expected_equal))
 }
 
 fn evaluate_ordering_expression(
     locals: &[LocalVarRendered],
-    source_map: Option<&SourceMap>,
     bin: &tolk_syntax::Bin<'_>,
     source: &str,
 ) -> Result<RenderedValue> {
@@ -325,8 +314,8 @@ fn evaluate_ordering_expression(
         .right()
         .ok_or_else(|| anyhow!("expected right operand for `{operator}`"))?;
 
-    let left = evaluate_parsed_expression(locals, source_map, left, source)?;
-    let right = evaluate_parsed_expression(locals, source_map, right, source)?;
+    let left = evaluate_parsed_expression(locals, left, source)?;
+    let right = evaluate_parsed_expression(locals, right, source)?;
     let comparison = compare_rendered_values_as_numbers(&left, &right, operator)?;
 
     let result = match operator {
@@ -337,226 +326,6 @@ fn evaluate_ordering_expression(
         _ => unreachable!("unsupported ordering operator"),
     };
     Ok(render_bool(result))
-}
-
-fn evaluate_as_cast_expression(
-    locals: &[LocalVarRendered],
-    source_map: Option<&SourceMap>,
-    as_cast: &tolk_syntax::AsCast<'_>,
-    source: &str,
-) -> Result<RenderedValue> {
-    let expr = as_cast
-        .expr()
-        .ok_or_else(|| anyhow!("expected expression before `as`"))?;
-    let target = as_cast
-        .casted_to()
-        .ok_or_else(|| anyhow!("expected type after `as`"))?;
-    let source_map = source_map
-        .ok_or_else(|| anyhow!("type casts are not supported in this debugger context"))?;
-
-    let value = evaluate_parsed_expression(locals, Some(source_map), expr, source)?;
-    let ty = lower_evaluate_cast_type(target, source, source_map)?;
-
-    match &ty {
-        Ty::CellOf { .. } => {
-            render_cell_like_as_type(source_map, &value, &ty).map_err(anyhow::Error::msg)
-        }
-        _ => bail!("Debugger evaluate currently supports only casts to `Cell<T>`"),
-    }
-}
-
-fn lower_evaluate_cast_type(ty: Type<'_>, source: &str, source_map: &SourceMap) -> Result<Ty> {
-    match ty {
-        Type::TypeIdent(ident) => {
-            lower_named_or_primitive_type(ident.text(source), None, source_map)
-        }
-        Type::TypeInstantiatedTs(inst) => {
-            let name = inst
-                .name()
-                .ok_or_else(|| anyhow!("expected type name"))?
-                .text(source);
-            let type_args = inst
-                .arguments()
-                .map(|args| {
-                    args.types()
-                        .map(|arg| lower_evaluate_cast_type(arg, source, source_map))
-                        .collect::<Result<Vec<_>>>()
-                })
-                .transpose()?;
-            lower_named_or_primitive_type(name, type_args, source_map)
-        }
-        Type::ParenthesizedType(paren) => {
-            let inner = paren
-                .inner()
-                .ok_or_else(|| anyhow!("expected type inside parentheses"))?;
-            lower_evaluate_cast_type(inner, source, source_map)
-        }
-        Type::NullableType(nullable) => {
-            let inner = nullable
-                .inner()
-                .ok_or_else(|| anyhow!("expected type before `?`"))?;
-            Ok(Ty::Nullable {
-                inner: Box::new(lower_evaluate_cast_type(inner, source, source_map)?),
-                stack_type_id: None,
-                stack_width: None,
-            })
-        }
-        Type::TensorType(tensor) => Ok(Ty::Tensor {
-            items: tensor
-                .elements()
-                .map(|item| lower_evaluate_cast_type(item, source, source_map))
-                .collect::<Result<Vec<_>>>()?,
-        }),
-        Type::TupleType(tuple) => Ok(Ty::ShapedTuple {
-            items: tuple
-                .elements()
-                .map(|item| lower_evaluate_cast_type(item, source, source_map))
-                .collect::<Result<Vec<_>>>()?,
-        }),
-        Type::UnionType(_) => bail!(
-            "inline union types are not supported in debugger evaluate casts; cast to a named ABI type instead"
-        ),
-        Type::FunCallableType(_) => {
-            bail!("callable types are not supported in debugger evaluate casts")
-        }
-        Type::NullLit(_) => Ok(Ty::NullLiteral),
-        Type::Unmapped(raw) => bail!(
-            "unsupported cast type `{}`",
-            raw.0
-                .utf8_text(source.as_bytes())
-                .unwrap_or("<invalid utf8>")
-        ),
-    }
-}
-
-fn lower_named_or_primitive_type(
-    name: &str,
-    type_args: Option<Vec<Ty>>,
-    source_map: &SourceMap,
-) -> Result<Ty> {
-    if let Some(ty) = lower_primitive_type(name, type_args.as_deref())? {
-        return Ok(ty);
-    }
-
-    match resolve_named_declaration_kind(source_map, name) {
-        Some(NamedDeclarationKind::Struct) => Ok(Ty::StructRef {
-            struct_name: name.to_owned(),
-            type_args,
-        }),
-        Some(NamedDeclarationKind::Alias) => Ok(Ty::AliasRef {
-            alias_name: name.to_owned(),
-            type_args,
-        }),
-        Some(NamedDeclarationKind::Enum) => {
-            if type_args.as_ref().is_some_and(|args| !args.is_empty()) {
-                bail!("enum `{name}` does not take type arguments");
-            }
-            Ok(Ty::EnumRef {
-                enum_name: name.to_owned(),
-            })
-        }
-        None => bail!("type `{name}` is not known in the current SourceMap"),
-    }
-}
-
-fn lower_primitive_type(name: &str, type_args: Option<&[Ty]>) -> Result<Option<Ty>> {
-    let primitive = match name {
-        "int" => Some(Ty::Int),
-        "coins" => Some(Ty::Coins),
-        "bool" => Some(Ty::Bool),
-        "cell" | "Cell" if type_args.is_none() => Some(Ty::Cell),
-        "builder" => Some(Ty::Builder),
-        "slice" => Some(Ty::Slice),
-        "string" => Some(Ty::String),
-        "RemainingBitsAndRefs" => Some(Ty::Remaining),
-        "address" => Some(Ty::Address),
-        "ext_address" => Some(Ty::AddressExt),
-        "any_address" => Some(Ty::AddressAny),
-        "null" => Some(Ty::NullLiteral),
-        "Cell" => {
-            let [inner] = type_args.unwrap_or_default() else {
-                bail!("`Cell` expects exactly one type argument");
-            };
-            Some(Ty::CellOf {
-                inner: Box::new(inner.clone()),
-            })
-        }
-        "array" => {
-            let [inner] = type_args.unwrap_or_default() else {
-                bail!("`array` expects exactly one type argument");
-            };
-            Some(Ty::ArrayOf {
-                inner: Box::new(inner.clone()),
-            })
-        }
-        "lisp_list" => {
-            let [inner] = type_args.unwrap_or_default() else {
-                bail!("`lisp_list` expects exactly one type argument");
-            };
-            Some(Ty::LispListOf {
-                inner: Box::new(inner.clone()),
-            })
-        }
-        "map" => {
-            let [key, value] = type_args.unwrap_or_default() else {
-                bail!("`map` expects exactly two type arguments");
-            };
-            Some(Ty::MapKV {
-                k: Box::new(key.clone()),
-                v: Box::new(value.clone()),
-            })
-        }
-        _ => parse_sized_primitive_type(name),
-    };
-
-    Ok(primitive)
-}
-
-fn parse_sized_primitive_type(name: &str) -> Option<Ty> {
-    fn parse_suffix(name: &str, prefix: &str) -> Option<u32> {
-        name.strip_prefix(prefix)
-            .filter(|suffix| !suffix.is_empty())
-            .and_then(|suffix| suffix.parse::<u32>().ok())
-    }
-
-    if let Some(n) = parse_suffix(name, "int") {
-        return Some(Ty::IntN { n });
-    }
-    if let Some(n) = parse_suffix(name, "uint") {
-        return Some(Ty::UintN { n });
-    }
-    if let Some(n) = parse_suffix(name, "varint") {
-        return Some(Ty::VarintN { n });
-    }
-    if let Some(n) = parse_suffix(name, "varuint") {
-        return Some(Ty::VaruintN { n });
-    }
-    if let Some(n) = parse_suffix(name, "bits") {
-        return Some(Ty::BitsN { n });
-    }
-    None
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum NamedDeclarationKind {
-    Struct,
-    Alias,
-    Enum,
-}
-
-fn resolve_named_declaration_kind(
-    source_map: &SourceMap,
-    name: &str,
-) -> Option<NamedDeclarationKind> {
-    source_map
-        .declarations()
-        .iter()
-        .find_map(|decl| match decl {
-            Declaration::Struct(decl) if decl.name == name => Some(NamedDeclarationKind::Struct),
-            Declaration::Alias(decl) if decl.name == name => Some(NamedDeclarationKind::Alias),
-            Declaration::Enum(decl) if decl.name == name => Some(NamedDeclarationKind::Enum),
-            _ => None,
-        })
 }
 
 fn compare_rendered_values_as_numbers(
@@ -646,8 +415,7 @@ mod tests {
     use crate::replayer::LocalVarRendered;
     use crate::types_render::{RenderedValue, render_runtime_vm_value};
     use anyhow::anyhow;
-    use tolk_compiler::source_map::SourceMap;
-    use tvm_logs::parser::{CellLike, CellSlice, VmStackValue};
+    use tvm_logs::parser::{CellLike, VmStackValue};
     use tycho_types::boc::Boc;
     use tycho_types::cell::CellBuilder;
 
@@ -656,25 +424,6 @@ mod tests {
         let expr = wrapped_expression(&source_file)
             .ok_or_else(|| anyhow!("expected a single expression statement"))?;
         parse_expr_to_path(expr, source_file.source.as_ref())
-    }
-
-    fn foo_source_map() -> SourceMap {
-        serde_json::from_value(serde_json::json!({
-            "files": [],
-            "declarations": [{
-                "kind": "struct",
-                "name": "Foo",
-                "ident_loc": [0, 0, 0, 0, 0],
-                "fields": [{
-                    "name": "value",
-                    "ty": {"kind": "uintN", "n": 32}
-                }]
-            }],
-            "unique_ty": [],
-            "functions": [],
-            "debug_marks": []
-        }))
-        .expect("valid source map")
     }
 
     fn foo_value_cell() -> tycho_types::cell::Cell {
@@ -740,8 +489,7 @@ mod tests {
             },
         }];
 
-        let value =
-            evaluate_expression(&locals, None, "foo.bar.0.baz").expect("path should resolve");
+        let value = evaluate_expression(&locals, "foo.bar.0.baz").expect("path should resolve");
         assert_eq!(value.to_string(), "42");
     }
 
@@ -758,7 +506,7 @@ mod tests {
             },
         ];
 
-        let value = evaluate_expression(&locals, None, "foo").expect("path should resolve");
+        let value = evaluate_expression(&locals, "foo").expect("path should resolve");
         assert_eq!(value.to_string(), "2");
     }
 
@@ -799,7 +547,7 @@ mod tests {
             },
         }];
 
-        let value = evaluate_expression(&locals, None, "foo.enabled && (!foo.blocked || false)")
+        let value = evaluate_expression(&locals, "foo.enabled && (!foo.blocked || false)")
             .expect("logical expression should resolve");
         assert_eq!(value.to_string(), "true");
     }
@@ -821,11 +569,11 @@ mod tests {
     fn logical_operators_short_circuit() {
         let locals = Vec::new();
 
-        let value = evaluate_expression(&locals, None, "false && missing.flag")
+        let value = evaluate_expression(&locals, "false && missing.flag")
             .expect("short-circuit should avoid rhs lookup");
         assert_eq!(value.to_string(), "false");
 
-        let value = evaluate_expression(&locals, None, "true || missing.flag")
+        let value = evaluate_expression(&locals, "true || missing.flag")
             .expect("short-circuit should avoid rhs lookup");
         assert_eq!(value.to_string(), "true");
     }
@@ -837,7 +585,7 @@ mod tests {
             value: RenderedValue::typed_leaf("42", "int"),
         }];
 
-        let err = evaluate_expression(&locals, None, "count && true")
+        let err = evaluate_expression(&locals, "count && true")
             .expect_err("non-boolean operand should be rejected");
         assert_eq!(
             err.to_string(),
@@ -862,12 +610,11 @@ mod tests {
             },
         ];
 
-        let value =
-            evaluate_expression(&locals, None, "lhs == rhs").expect("equality should resolve");
+        let value = evaluate_expression(&locals, "lhs == rhs").expect("equality should resolve");
         assert_eq!(value.to_string(), "true");
 
         let value =
-            evaluate_expression(&locals, None, "lhs != other").expect("inequality should resolve");
+            evaluate_expression(&locals, "lhs != other").expect("inequality should resolve");
         assert_eq!(value.to_string(), "true");
     }
 
@@ -885,37 +632,37 @@ mod tests {
         ];
 
         assert_eq!(
-            evaluate_expression(&locals, None, "small < big")
+            evaluate_expression(&locals, "small < big")
                 .expect("comparison should resolve")
                 .to_string(),
             "true"
         );
         assert_eq!(
-            evaluate_expression(&locals, None, "big >= small")
+            evaluate_expression(&locals, "big >= small")
                 .expect("comparison should resolve")
                 .to_string(),
             "true"
         );
         assert_eq!(
-            evaluate_expression(&locals, None, "big >= 42")
+            evaluate_expression(&locals, "big >= 42")
                 .expect("comparison should resolve")
                 .to_string(),
             "true"
         );
         assert_eq!(
-            evaluate_expression(&locals, None, "small > -1")
+            evaluate_expression(&locals, "small > -1")
                 .expect("negative literal comparison should resolve")
                 .to_string(),
             "true"
         );
         assert_eq!(
-            evaluate_expression(&locals, None, "-small < 0")
+            evaluate_expression(&locals, "-small < 0")
                 .expect("unary minus on variables should resolve")
                 .to_string(),
             "true"
         );
         assert_eq!(
-            evaluate_expression(&locals, None, "small < 10")
+            evaluate_expression(&locals, "small < 10")
                 .expect("literal comparison should resolve")
                 .to_string(),
             "true"
@@ -952,7 +699,7 @@ mod tests {
         ];
 
         assert_eq!(
-            evaluate_expression(&locals, None, "msg.itemIndex <= storage.nextItemIndex")
+            evaluate_expression(&locals, "msg.itemIndex <= storage.nextItemIndex")
                 .expect("last seen numeric comparison should resolve")
                 .to_string(),
             "true"
@@ -989,7 +736,7 @@ mod tests {
         ];
 
         assert_eq!(
-            evaluate_expression(&locals, None, "msg.itemIndex <= storage.nextItemIndex")
+            evaluate_expression(&locals, "msg.itemIndex <= storage.nextItemIndex")
                 .expect("lazy preview numeric comparison should resolve")
                 .to_string(),
             "true"
@@ -1011,7 +758,7 @@ mod tests {
             },
         }];
 
-        let value = evaluate_expression(&locals, None, "storage.nextItemIndex")
+        let value = evaluate_expression(&locals, "storage.nextItemIndex")
             .expect("field access through lazy preview should resolve");
         assert_eq!(value.to_string(), "8");
     }
@@ -1023,7 +770,7 @@ mod tests {
             value: RenderedValue::typed_leaf("alice", "string"),
         }];
 
-        let err = evaluate_expression(&locals, None, "name < 10")
+        let err = evaluate_expression(&locals, "name < 10")
             .expect_err("non-numeric ordering operand should be rejected");
         assert_eq!(err.to_string(), "operator `<` requires numeric operands");
     }
@@ -1036,19 +783,19 @@ mod tests {
         }];
 
         assert_eq!(
-            evaluate_expression(&locals, None, "\"alice\"")
+            evaluate_expression(&locals, "\"alice\"")
                 .expect("string literal should resolve")
                 .to_string(),
             "\"alice\""
         );
         assert_eq!(
-            evaluate_expression(&locals, None, "name == \"alice\"")
+            evaluate_expression(&locals, "name == \"alice\"")
                 .expect("string equality should resolve")
                 .to_string(),
             "true"
         );
         assert_eq!(
-            evaluate_expression(&locals, None, "name != \"bob\"")
+            evaluate_expression(&locals, "name != \"bob\"")
                 .expect("string inequality should resolve")
                 .to_string(),
             "true"
@@ -1069,89 +816,23 @@ mod tests {
         ];
 
         assert_eq!(
-            evaluate_expression(&locals, None, "null")
+            evaluate_expression(&locals, "null")
                 .expect("null literal should resolve")
                 .to_string(),
             "null"
         );
         assert_eq!(
-            evaluate_expression(&locals, None, "missing == null")
+            evaluate_expression(&locals, "missing == null")
                 .expect("null equality should resolve")
                 .to_string(),
             "true"
         );
         assert_eq!(
-            evaluate_expression(&locals, None, "present != null")
+            evaluate_expression(&locals, "present != null")
                 .expect("null inequality should resolve")
                 .to_string(),
             "true"
         );
-    }
-
-    #[test]
-    fn evaluates_cell_cast_to_typed_cell_from_source_map() {
-        let source_map = foo_source_map();
-        let cell = foo_value_cell();
-        let locals = vec![LocalVarRendered {
-            var_name: "payload".to_owned(),
-            value: render_runtime_vm_value(&VmStackValue::Cell(CellLike::Cell(Boc::encode_hex(
-                &cell,
-            )))),
-        }];
-
-        let rendered = evaluate_expression(&locals, Some(&source_map), "payload as Cell<Foo>")
-            .expect("cell cast should decode");
-
-        let RenderedValue::CellOf {
-            type_name, fields, ..
-        } = rendered
-        else {
-            panic!("expected Cell<Foo>");
-        };
-        assert_eq!(type_name, "Cell<Foo>");
-        assert_eq!(fields[0].0, "decoded");
-        let RenderedValue::Struct {
-            type_name,
-            fields: decoded_fields,
-        } = &fields[0].1
-        else {
-            panic!("expected decoded Foo");
-        };
-        assert_eq!(type_name, "Foo");
-        assert_eq!(decoded_fields[0].0, "value");
-        assert_eq!(decoded_fields[0].1.dap_parts().0, "42");
-        assert_eq!(decoded_fields[0].1.dap_parts().1.as_deref(), Some("uint32"));
-    }
-
-    #[test]
-    fn evaluates_slice_cast_to_typed_cell_from_source_map() {
-        let source_map = foo_source_map();
-        let cell = foo_value_cell();
-        let locals = vec![LocalVarRendered {
-            var_name: "payload".to_owned(),
-            value: render_runtime_vm_value(&VmStackValue::CellSlice(CellSlice {
-                value: Boc::encode_hex(&cell),
-                bits: None,
-                refs: None,
-            })),
-        }];
-
-        let rendered = evaluate_expression(&locals, Some(&source_map), "payload as Cell<Foo>")
-            .expect("slice cast should decode");
-
-        let RenderedValue::CellOf { fields, .. } = rendered else {
-            panic!("expected Cell<Foo>");
-        };
-        let RenderedValue::Struct {
-            fields: decoded_fields,
-            ..
-        } = &fields[0].1
-        else {
-            panic!("expected decoded Foo");
-        };
-        assert_eq!(decoded_fields[0].0, "value");
-        assert_eq!(decoded_fields[0].1.dap_parts().0, "42");
-        assert_eq!(decoded_fields[0].1.dap_parts().1.as_deref(), Some("uint32"));
     }
 
     #[test]

--- a/crates/acton-debug/src/core/replayer.rs
+++ b/crates/acton-debug/src/core/replayer.rs
@@ -17,7 +17,7 @@ use std::sync::{Arc, OnceLock};
 use tolk_compiler::abi::ContractABI;
 use tolk_compiler::debug_marks_dict::DebugMarksDict;
 use tolk_compiler::source_map::{DebugMark, SourceMap, SrcRange};
-use tolk_compiler::types_kernel::Ty;
+use tolk_compiler::types_kernel::{Ty, TyIdx, render_ty};
 use tvm_logs::parser::{VmLine, VmStack, VmStackValue};
 
 // ---------------------------------------------------------------------------
@@ -128,7 +128,7 @@ pub trait RuntimeEventSource {
 #[derive(Debug, Clone)]
 struct LocalVarInScope {
     name: String,
-    ty_idx: usize,
+    ty_idx: TyIdx,
     ir_slots: Vec<usize>,
     // None = not lazy; Some((ir_slot, slice)) = lazy, with the original CellSlice for field preview
     lazy_info: Option<(usize, VmStackValue)>,
@@ -481,19 +481,19 @@ pub enum Tick {
     },
     LocalVar {
         var_name: String,
-        ty_idx: usize,
+        ty_idx: TyIdx,
         ir_slots: Vec<usize>,
         is_parameter: bool,
         ir_lazy_slice: Option<usize>,
     },
     SmartCast {
         var_name: String,
-        ty_idx: usize,
+        ty_idx: TyIdx,
         ir_slots: Vec<usize>,
     },
     SetGlob {
         glob_name: String,
-        ty_idx: usize,
+        ty_idx: TyIdx,
         ir_slots: Vec<usize>,
     },
     ScopeStart {
@@ -1152,7 +1152,7 @@ impl TolkReplayer {
                 let is_void = self
                     .source_map
                     .get_function_by_idx(f_idx)
-                    .and_then(|f| self.source_map.resolve_ty(f.return_ty_idx))
+                    .and_then(|f| self.source_map.ty_by_idx(f.return_ty_idx))
                     .is_some_and(|ty| matches!(ty, Ty::Void));
                 if let Some(frame) = self.call_stack.last_mut() {
                     frame.pending_ir_return = Some(ir_return);
@@ -1425,14 +1425,12 @@ impl TolkReplayer {
             })
             .collect();
 
-        let return_ty = self
-            .source_map
-            .get_function_by_idx(f_idx)
-            .and_then(|f| self.source_map.resolve_ty(f.return_ty_idx));
-
-        match return_ty {
-            Some(ty) => debug_print_from_stack(&self.source_map, &values, ty),
-            None => RenderedValue::leaf("return type not found"),
+        let leaving_f = self.source_map.get_function_by_idx(f_idx);
+        match leaving_f {
+            Some(leaving_f) => {
+                debug_print_from_stack(&self.source_map, &values, leaving_f.return_ty_idx)
+            }
+            None => RenderedValue::leaf("leaving_f not found"),
         }
     }
 
@@ -1480,22 +1478,16 @@ impl TolkReplayer {
                 .collect();
 
             let debug_val = if let Some((_, ref slice)) = var.lazy_info {
-                match self.source_map.resolve_ty(var.ty_idx) {
-                    Some(ty) => debug_format_lazy(
-                        &self.source_map,
-                        &slot_values,
-                        &var.ir_slots,
-                        ty,
-                        last_seen,
-                        slice,
-                    ),
-                    None => RenderedValue::leaf("var.ty_idx not found"),
-                }
+                debug_format_lazy(
+                    &self.source_map,
+                    &slot_values,
+                    &var.ir_slots,
+                    var.ty_idx,
+                    last_seen,
+                    slice,
+                )
             } else {
-                match self.source_map.resolve_ty(var.ty_idx) {
-                    Some(ty) => debug_print_from_stack(&self.source_map, &slot_values, ty),
-                    None => RenderedValue::leaf("var.ty_idx not found"),
-                }
+                debug_print_from_stack(&self.source_map, &slot_values, var.ty_idx)
             };
             result.push(LocalVarRendered {
                 var_name: var.name.clone(),
@@ -1527,13 +1519,10 @@ impl TolkReplayer {
 
         for (name, (ty_idx, values)) in &self.global_var_values {
             let slot_values: Vec<SlotValue> = values.iter().map(SlotValue::Live).collect();
-            let debug_val = match self.source_map.resolve_ty(*ty_idx) {
-                Some(ty) => debug_print_from_stack(&self.source_map, &slot_values, ty),
-                None => RenderedValue::leaf("var.ty_idx not found"),
-            };
+            let rendered_g = debug_print_from_stack(&self.source_map, &slot_values, *ty_idx);
             result.push(LocalVarRendered {
                 var_name: format!("global {name}"),
-                value: debug_val,
+                value: rendered_g,
             });
         }
 
@@ -1652,8 +1641,10 @@ impl TolkReplayer {
     }
 
     #[must_use]
-    pub fn type_name(&self, ty_idx: usize) -> Option<String> {
-        self.source_map.resolve_ty(ty_idx).map(ToString::to_string)
+    pub fn type_name(&self, ty_idx: TyIdx) -> Option<String> {
+        self.source_map
+            .ty_by_idx(ty_idx)
+            .map(|_| render_ty(&self.source_map, ty_idx))
     }
 
     #[must_use]

--- a/crates/acton-debug/src/core/types_render.rs
+++ b/crates/acton-debug/src/core/types_render.rs
@@ -7,7 +7,7 @@ use tolk_compiler::SourceMap;
 use tolk_compiler::abi::ContractABI;
 use tolk_compiler::dynamic_unpack::{self, UnpackedValue};
 use tolk_compiler::source_map::AbiStruct;
-use tolk_compiler::types_kernel::{Ty, calc_width_on_stack, instantiate_generics};
+use tolk_compiler::types_kernel::{Ty, TyIdx, calc_width_on_stack, render_ty};
 use tvm_ffi::from_stack::FromStack;
 use tvm_ffi::stack::{Tuple, TupleItem};
 use tvm_logs::parser::{CellLike, CellSlice, VmStackValue};
@@ -274,15 +274,6 @@ impl RenderedValue {
         }
     }
 
-    pub(crate) fn raw_cell_like(&self) -> Option<&CellLike> {
-        match self {
-            RenderedValue::CellLike { raw: Some(raw), .. }
-            | RenderedValue::CellOf { raw: Some(raw), .. } => Some(raw),
-            RenderedValue::LastSeen { inner } => inner.raw_cell_like(),
-            _ => None,
-        }
-    }
-
     #[must_use]
     pub fn to_pretty_string(&self, options: PrettyRenderOptions) -> String {
         let mut out = String::new();
@@ -305,11 +296,13 @@ impl RenderedValue {
                     pretty_leaf_value(value, type_field.as_deref(), options)
                 )
             }
-            RenderedValue::CellLike { value, raw, .. } => {
+            RenderedValue::CellLike {
+                value, fields, raw, ..
+            } => {
                 write!(
                     out,
                     "{}",
-                    pretty_cell_like_value(value, raw.as_ref(), options)
+                    pretty_cell_like_value(value, raw.as_ref(), fields, options)
                 )
             }
             RenderedValue::EnumValue { value, .. } => {
@@ -328,7 +321,7 @@ impl RenderedValue {
                 out,
                 "{} {}",
                 pretty_magenta(type_name, options),
-                pretty_cell_like_value(value, raw.as_ref(), options)
+                pretty_cell_like_value(value, raw.as_ref(), &[], options)
             ),
             RenderedValue::UnionCase {
                 variant_name,
@@ -453,7 +446,7 @@ fn pretty_leaf_value(
         return pretty_cyan(value, options);
     }
     if type_is_cell_like(type_field) {
-        return pretty_cell_like_value(value, None, options);
+        return pretty_cell_like_value(value, None, &[], options);
     }
 
     value.to_owned()
@@ -474,7 +467,7 @@ fn pretty_map_key(type_name: &str, key: &str, options: &PrettyRenderOptions) -> 
         return pretty_cyan(key, options);
     }
     if type_is_cell_like(key_ty) {
-        return pretty_cell_like_value(key, None, options);
+        return pretty_cell_like_value(key, None, &[], options);
     }
 
     key.to_owned()
@@ -572,9 +565,13 @@ fn pretty_dimmed(value: &str, options: &PrettyRenderOptions) -> String {
 fn pretty_cell_like_value(
     value: &str,
     raw: Option<&CellLike>,
+    fields: &[(String, RenderedValue)],
     options: &PrettyRenderOptions,
 ) -> String {
-    let value = raw.map_or_else(|| compact_cell_like_text(value), raw_cell_like_hex);
+    let value = slice_raw_field(fields).map_or_else(
+        || raw.map_or_else(|| compact_cell_like_text(value), raw_cell_like_hex),
+        Cow::Borrowed,
+    );
     pretty_dimmed(&value, options)
 }
 
@@ -582,6 +579,18 @@ fn raw_cell_like_hex(raw: &CellLike) -> Cow<'_, str> {
     match raw {
         CellLike::Cell(hex) | CellLike::Builder(hex) => Cow::Borrowed(hex),
     }
+}
+
+fn slice_raw_field(fields: &[(String, RenderedValue)]) -> Option<&str> {
+    fields.iter().find_map(|(name, value)| {
+        if name != "raw" {
+            return None;
+        }
+        let RenderedValue::Leaf { value, .. } = value else {
+            return None;
+        };
+        value.starts_with("slice{").then_some(value.as_str())
+    })
 }
 
 fn compact_cell_like_text(value: &str) -> Cow<'_, str> {
@@ -1200,7 +1209,7 @@ fn slice_as_cell_like(cs: &CellSlice) -> Option<CellLike> {
 }
 
 fn render_openable_cell_like(
-    ty: &Ty,
+    type_name: impl Into<String>,
     value: impl Into<String>,
     bits: Option<usize>,
     refs: Option<usize>,
@@ -1211,7 +1220,30 @@ fn render_openable_cell_like(
     let summarize_value = bits.is_some() || refs.is_some() || hash.is_some();
 
     RenderedValue::CellLike {
-        type_name: ty.to_string(),
+        type_name: type_name.into(),
+        value: if summarize_value {
+            render_cell_summary(bits, refs, hash.as_deref())
+        } else {
+            raw_value.clone()
+        },
+        fields: render_cell_fields(bits, refs, hash, summarize_value.then_some(raw_value)),
+        raw,
+    }
+}
+
+fn render_openable_cell_like_name(
+    type_name: impl Into<String>,
+    value: impl Into<String>,
+    bits: Option<usize>,
+    refs: Option<usize>,
+    hash: Option<String>,
+    raw: Option<CellLike>,
+) -> RenderedValue {
+    let raw_value = value.into();
+    let summarize_value = bits.is_some() || refs.is_some() || hash.is_some();
+
+    RenderedValue::CellLike {
+        type_name: type_name.into(),
         value: if summarize_value {
             render_cell_summary(bits, refs, hash.as_deref())
         } else {
@@ -1233,7 +1265,7 @@ pub(crate) fn render_runtime_vm_value(value: &VmStackValue) -> RenderedValue {
         VmStackValue::Cell(cell) => {
             let (bits, refs, hash) = cell_like_meta(cell);
             render_openable_cell_like(
-                &Ty::Cell,
+                "cell",
                 render_cell_like(cell),
                 bits,
                 refs,
@@ -1245,7 +1277,7 @@ pub(crate) fn render_runtime_vm_value(value: &VmStackValue) -> RenderedValue {
             let cell_like = CellLike::Builder(builder_hex.clone());
             let (bits, refs, hash) = cell_like_meta(&cell_like);
             render_openable_cell_like(
-                &Ty::Builder,
+                "builder",
                 render_builder(builder_hex),
                 bits,
                 refs,
@@ -1256,7 +1288,7 @@ pub(crate) fn render_runtime_vm_value(value: &VmStackValue) -> RenderedValue {
         VmStackValue::CellSlice(slice) => {
             let (bits, refs, hash) = slice_meta(slice);
             render_openable_cell_like(
-                &Ty::Slice,
+                "slice",
                 render_slice(slice),
                 bits,
                 refs,
@@ -1272,7 +1304,7 @@ pub(crate) fn render_runtime_vm_value(value: &VmStackValue) -> RenderedValue {
 }
 
 fn render_union_case(
-    ty: &Ty,
+    type_name: impl Into<String>,
     variant_name: impl Into<String>,
     value: Option<RenderedValue>,
 ) -> RenderedValue {
@@ -1281,22 +1313,34 @@ fn render_union_case(
         fields.push(("value".to_owned(), value));
     }
     RenderedValue::UnionCase {
-        type_name: ty.to_string(),
+        type_name: type_name.into(),
         variant_name: variant_name.into(),
         fields,
     }
 }
 
-fn render_enum_value(ty: &Ty, value: impl Into<String>, raw_value: RenderedValue) -> RenderedValue {
+fn render_enum_value(
+    type_name: impl Into<String>,
+    value: impl Into<String>,
+    raw_value: RenderedValue,
+) -> RenderedValue {
     RenderedValue::EnumValue {
-        type_name: ty.to_string(),
+        type_name: type_name.into(),
         value: value.into(),
         fields: vec![("value".to_owned(), raw_value)],
     }
 }
 
-fn map_type_name(k: &Ty, v: &Ty) -> String {
-    format!("map<{k}, {v}>")
+fn render_enum_value_name(
+    type_name: String,
+    value: impl Into<String>,
+    raw_value: RenderedValue,
+) -> RenderedValue {
+    RenderedValue::EnumValue {
+        type_name,
+        value: value.into(),
+        fields: vec![("value".to_owned(), raw_value)],
+    }
 }
 
 fn render_map_raw(type_name: String, root: Option<&Cell>) -> RenderedValue {
@@ -1424,9 +1468,9 @@ fn format_map_raw_value(slice: TyCellSlice<'_>) -> Result<String, String> {
 fn decode_abi_data(
     symbols: &SourceMap,
     parser: &mut TyCellSlice<'_>,
-    ty: &Ty,
+    ty_idx: TyIdx,
 ) -> Option<UnpackedValue> {
-    let data = dynamic_unpack::unpack_from_slice(parser, symbols, ty).ok()?;
+    let data = dynamic_unpack::unpack_from_slice(parser, symbols, ty_idx).ok()?;
     if parser.size_bits() != 0 || parser.size_refs() != 0 {
         // there are remaining data
         return None;
@@ -1437,42 +1481,50 @@ fn decode_abi_data(
 fn render_map_value_with_symbols(
     symbols: &SourceMap,
     value_slice: TyCellSlice<'_>,
-    value_ty: &Ty,
+    value_ty_idx: TyIdx,
 ) -> Option<RenderedValue> {
     let mut parser = value_slice;
-    let data = decode_abi_data(symbols, &mut parser, value_ty)?;
-    Some(render_abi_data(symbols, data, value_ty))
+    let data = decode_abi_data(symbols, &mut parser, value_ty_idx)?;
+    Some(render_abi_data(symbols, data, value_ty_idx))
 }
 
-fn render_typed_cell(symbols: &SourceMap, ty: &Ty, inner: &Ty, cell: &CellLike) -> RenderedValue {
+fn render_typed_cell(
+    symbols: &SourceMap,
+    type_name: String,
+    inner_ty_idx: TyIdx,
+    cell: &CellLike,
+) -> RenderedValue {
     let decoded = if let Some(cell) = decode_cell_like(cell) {
         let mut parser = cell.as_slice_allow_exotic();
-        decode_abi_data(symbols, &mut parser, inner).map(|data| (inner, data))
+        decode_abi_data(symbols, &mut parser, inner_ty_idx).map(|data| (inner_ty_idx, data))
     } else {
         None
     };
-    render_typed_cell_with_decoded_data(symbols, ty, cell, decoded)
+    render_typed_cell_with_decoded_data(symbols, type_name, cell, decoded)
 }
 
 fn render_typed_cell_with_decoded_data(
     symbols: &SourceMap,
-    ty: &Ty,
+    type_name: String,
     cell: &CellLike,
-    decoded: Option<(&Ty, UnpackedValue)>,
+    decoded: Option<(TyIdx, UnpackedValue)>,
 ) -> RenderedValue {
     let value = render_cell_like(cell);
     let (bits, refs, hash) = cell_like_meta(cell);
     let mut fields = render_cell_fields(bits, refs, hash.clone(), Some(value));
 
-    if let Some((inner, data)) = decoded {
+    if let Some((inner_ty_idx, data)) = decoded {
         fields.insert(
             0,
-            ("decoded".to_owned(), render_abi_data(symbols, data, inner)),
+            (
+                "decoded".to_owned(),
+                render_abi_data(symbols, data, inner_ty_idx),
+            ),
         );
     }
 
     RenderedValue::CellOf {
-        type_name: ty.to_string(),
+        type_name,
         value: render_cell_summary(bits, refs, hash.as_deref()),
         fields,
         raw: Some(cell.clone()),
@@ -1491,24 +1543,19 @@ pub(crate) fn render_runtime_storage_with_abi(
     let decoded_cell = decode_cell_like(cell)?;
 
     // Try deployment storage first and then default one
-    for storage_ty in abi
+    for storage_ty_idx in abi
         .storage
-        .storage_at_deployment_ty
-        .as_ref()
+        .storage_at_deployment_ty_idx
         .into_iter()
-        .chain(abi.storage.storage_ty.as_ref())
+        .chain(abi.storage.storage_ty_idx)
     {
         let mut parser = decoded_cell.as_slice_allow_exotic();
-        if let Some(data) = decode_abi_data(symbols, &mut parser, storage_ty) {
-            let cell_ty = Ty::CellOf {
-                inner: Box::new(storage_ty.clone()),
-            };
-
+        if let Some(data) = decode_abi_data(symbols, &mut parser, storage_ty_idx) {
             return Some(render_typed_cell_with_decoded_data(
                 symbols,
-                &cell_ty,
+                format!("Cell<{}>", render_ty(symbols, storage_ty_idx)),
                 cell,
-                Some((storage_ty, data)),
+                Some((storage_ty_idx, data)),
             ));
         }
     }
@@ -1516,159 +1563,84 @@ pub(crate) fn render_runtime_storage_with_abi(
     None
 }
 
-fn decode_abi_data_result(
-    symbols: &SourceMap,
-    parser: &mut TyCellSlice<'_>,
-    ty: &Ty,
-) -> Result<UnpackedValue, String> {
-    let data =
-        dynamic_unpack::unpack_from_slice(parser, symbols, ty).map_err(|err| err.to_string())?;
-    if parser.size_bits() != 0 || parser.size_refs() != 0 {
-        return Err(format!(
-            "remaining bits/refs after decode: {} bits, {} refs",
-            parser.size_bits(),
-            parser.size_refs()
-        ));
-    }
-    Ok(data)
-}
-
-pub(crate) fn render_cell_like_as_type(
-    symbols: &SourceMap,
-    value: &RenderedValue,
-    ty: &Ty,
-) -> Result<RenderedValue, String> {
-    let cell_like = value.raw_cell_like().ok_or_else(|| {
-        format!(
-            "Expression must evaluate to a `cell` or `slice` to decode as `{ty}`, got {}",
-            debugger_value_kind(value)
-        )
-    })?;
-    let CellLike::Cell(_) = cell_like else {
-        return Err(format!(
-            "Expression must evaluate to a `cell` or `slice` to decode as `{ty}`, got {}",
-            debugger_value_kind(value)
-        ));
-    };
-
-    let Ty::CellOf { inner } = ty else {
-        return Err(format!(
-            "Debugger evaluate only supports casts to Cell<T>, got `{ty}`"
-        ));
-    };
-
-    let decoded_cell = decode_cell_like(cell_like).ok_or_else(|| {
-        format!(
-            "Failed to materialize {} as a TVM cell while decoding `{ty}`",
-            debugger_value_kind(value)
-        )
-    })?;
-    let mut parser = decoded_cell.as_slice_allow_exotic();
-    let data = decode_abi_data_result(symbols, &mut parser, inner.as_ref())?;
-
-    Ok(render_typed_cell_with_decoded_data(
-        symbols,
-        ty,
-        cell_like,
-        Some((inner.as_ref(), data)),
-    ))
-}
-
-fn debugger_value_kind(value: &RenderedValue) -> String {
-    match value {
-        RenderedValue::Leaf {
-            value,
-            type_field: Some(type_field),
-        } => format!("`{type_field}` (`{value}`)"),
-        RenderedValue::Leaf { value, .. } => format!("`{value}`"),
-        RenderedValue::CellLike { type_name, .. }
-        | RenderedValue::CellOf { type_name, .. }
-        | RenderedValue::EnumValue { type_name, .. }
-        | RenderedValue::UnionCase { type_name, .. }
-        | RenderedValue::Struct { type_name, .. }
-        | RenderedValue::Address { type_name, .. }
-        | RenderedValue::Tensor { type_name, .. }
-        | RenderedValue::ArrayOf { type_name, .. }
-        | RenderedValue::LazyUnresolved { type_name } => format!("`{type_name}`"),
-        RenderedValue::LastSeen { inner } => debugger_value_kind(inner),
-        RenderedValue::OptimizedOut => "<optimized out>".to_owned(),
-        RenderedValue::LazyNotYetLoaded { preview } => debugger_value_kind(preview),
-        RenderedValue::LazyCantParseSlice => "<not loaded>".to_owned(),
-    }
-}
-
-fn render_abi_data(symbols: &SourceMap, data: UnpackedValue, ty: &Ty) -> RenderedValue {
+fn render_abi_data(symbols: &SourceMap, data: UnpackedValue, ty_idx: TyIdx) -> RenderedValue {
+    let type_name = render_ty(symbols, ty_idx);
     match data {
-        UnpackedValue::Object { name, fields } if abi_object_is_enum(symbols, ty) => {
+        UnpackedValue::Object { name, fields } if abi_object_is_enum(symbols, ty_idx) => {
             let mut fields = fields.into_iter();
             match fields.next() {
                 Some((_, value)) => {
-                    let enum_ty = resolve_alias_shape_ty(symbols, ty).unwrap_or_else(|| ty.clone());
-                    let raw_ty = enum_raw_value_ty(symbols, &enum_ty).unwrap_or(Ty::Unknown);
-                    render_enum_value(ty, name, render_abi_data(symbols, value, &raw_ty))
+                    let enum_ty_idx = resolve_alias_shape_ty(symbols, ty_idx).unwrap_or(ty_idx);
+                    let raw_ty_idx = enum_raw_value_ty(symbols, enum_ty_idx).unwrap_or(ty_idx);
+                    render_enum_value_name(
+                        type_name,
+                        name,
+                        render_abi_data(symbols, value, raw_ty_idx),
+                    )
                 }
-                None => typed_leaf_for_ty(ty, name),
+                None => typed_leaf(type_name, name),
             }
         }
         UnpackedValue::Object { name, fields } => {
-            let object_ty = abi_object_context_ty(symbols, &name, ty).unwrap_or_else(|| ty.clone());
+            let object_ty_idx = abi_object_context_ty(symbols, &name, ty_idx).unwrap_or(ty_idx);
             RenderedValue::Struct {
                 type_name: name.clone(),
                 fields: fields
                     .into_iter()
                     .map(|(field_name, value)| {
-                        let field_ty = abi_object_field_ty(symbols, &object_ty, &name, &field_name)
-                            .unwrap_or(Ty::Unknown);
-                        (field_name, render_abi_data(symbols, value, &field_ty))
+                        let field_ty_idx =
+                            abi_object_field_ty(symbols, object_ty_idx, &name, &field_name)
+                                .unwrap_or(object_ty_idx);
+                        (field_name, render_abi_data(symbols, value, field_ty_idx))
                     })
                     .collect(),
             }
         }
         UnpackedValue::Array(items) => RenderedValue::ArrayOf {
-            type_name: ty.to_string(),
-            items: render_abi_array_items(symbols, items, ty),
+            type_name,
+            items: render_abi_array_items(symbols, items, ty_idx),
         },
-        UnpackedValue::Map(entries) => render_abi_map(symbols, entries, ty),
+        UnpackedValue::Map(entries) => render_abi_map(symbols, entries, ty_idx),
         UnpackedValue::Address(IntAddr::Std(addr)) => {
-            render_std_address(ty.to_string(), addr.to_string(), &addr)
+            render_std_address(type_name, addr.to_string(), &addr)
         }
-        UnpackedValue::Address(addr) => render_int_address(ty.to_string(), &addr),
-        UnpackedValue::ExtAddress(addr) => typed_leaf_for_ty(ty, addr.to_string()),
+        UnpackedValue::Address(addr) => render_int_address(type_name, &addr),
+        UnpackedValue::ExtAddress(addr) => typed_leaf(type_name, addr.to_string()),
         UnpackedValue::Cell(cell) | UnpackedValue::RemainingBitsAndRefs(cell) => {
-            typed_leaf_for_ty(ty, Boc::encode_hex(&cell))
+            typed_leaf(type_name, Boc::encode_hex(&cell))
         }
         UnpackedValue::Bits((bytes, bit_len)) => {
-            typed_leaf_for_ty(ty, format_abi_bits(&bytes, bit_len))
+            typed_leaf(type_name, format_abi_bits(&bytes, bit_len))
         }
-        UnpackedValue::Null => typed_leaf_for_ty(ty, "null"),
-        UnpackedValue::Number(value) => typed_leaf_for_ty(ty, value.to_string()),
-        UnpackedValue::Bool(value) => typed_leaf_for_ty(ty, value.to_string()),
-        UnpackedValue::String(value) => typed_leaf_for_ty(ty, format!("\"{value}\"")),
+        UnpackedValue::Null => typed_leaf(type_name, "null"),
+        UnpackedValue::Number(value) => typed_leaf(type_name, value.to_string()),
+        UnpackedValue::Bool(value) => typed_leaf(type_name, value.to_string()),
+        UnpackedValue::String(value) => typed_leaf(type_name, format!("\"{value}\"")),
     }
 }
 
 fn render_abi_array_items(
     symbols: &SourceMap,
     items: Vec<UnpackedValue>,
-    ty: &Ty,
+    ty_idx: TyIdx,
 ) -> Vec<RenderedValue> {
-    let shape_ty = resolve_alias_shape_ty(symbols, ty).unwrap_or_else(|| ty.clone());
-    match &shape_ty {
-        Ty::ArrayOf { inner } => items
+    let shape_ty_idx = resolve_alias_shape_ty(symbols, ty_idx).unwrap_or(ty_idx);
+    match symbols.ty_by_idx(shape_ty_idx).unwrap_or(&Ty::Unknown) {
+        Ty::ArrayOf { inner_ty_idx } => items
             .into_iter()
-            .map(|item| render_abi_data(symbols, item, inner.as_ref()))
+            .map(|item| render_abi_data(symbols, item, *inner_ty_idx))
             .collect(),
-        Ty::Tensor { items: item_types } | Ty::ShapedTuple { items: item_types } => items
+        Ty::Tensor { items_ty_idx } | Ty::ShapedTuple { items_ty_idx } => items
             .into_iter()
             .enumerate()
             .map(|(index, item)| {
-                let item_ty = item_types.get(index).cloned().unwrap_or(Ty::Unknown);
-                render_abi_data(symbols, item, &item_ty)
+                let item_ty_idx = items_ty_idx.get(index).copied().unwrap_or(shape_ty_idx);
+                render_abi_data(symbols, item, item_ty_idx)
             })
             .collect(),
         _ => items
             .into_iter()
-            .map(|item| render_abi_data(symbols, item, &Ty::Unknown))
+            .map(|item| render_abi_data(symbols, item, ty_idx))
             .collect(),
     }
 }
@@ -1676,13 +1648,16 @@ fn render_abi_array_items(
 fn render_abi_map(
     symbols: &SourceMap,
     entries: Vec<(UnpackedValue, UnpackedValue)>,
-    ty: &Ty,
+    ty_idx: TyIdx,
 ) -> RenderedValue {
-    let type_name = ty.to_string();
-    let shape_ty = resolve_alias_shape_ty(symbols, ty).unwrap_or_else(|| ty.clone());
-    let (key_ty, value_ty) = match &shape_ty {
-        Ty::MapKV { k, v } => (k.as_ref().clone(), v.as_ref().clone()),
-        _ => (Ty::Unknown, Ty::Unknown),
+    let type_name = render_ty(symbols, ty_idx);
+    let shape_ty_idx = resolve_alias_shape_ty(symbols, ty_idx).unwrap_or(ty_idx);
+    let (key_ty, value_ty) = match symbols.ty_by_idx(shape_ty_idx).unwrap_or(&Ty::Unknown) {
+        Ty::MapKV {
+            key_ty_idx,
+            value_ty_idx,
+        } => (*key_ty_idx, *value_ty_idx),
+        _ => (ty_idx, ty_idx),
     };
 
     RenderedValue::Struct {
@@ -1691,21 +1666,23 @@ fn render_abi_map(
             .into_iter()
             .map(|(key, value)| {
                 (
-                    format_abi_map_key(symbols, &key, &key_ty),
-                    render_abi_data(symbols, value, &value_ty),
+                    format_abi_map_key(symbols, &key, key_ty),
+                    render_abi_data(symbols, value, value_ty),
                 )
             })
             .collect(),
     }
 }
 
-fn format_abi_map_key(symbols: &SourceMap, data: &UnpackedValue, key_ty: &Ty) -> String {
+fn format_abi_map_key(symbols: &SourceMap, data: &UnpackedValue, key_ty_idx: TyIdx) -> String {
     match data {
         UnpackedValue::Null => "null".to_owned(),
         UnpackedValue::Number(value) => value.to_string(),
         UnpackedValue::Bool(value) => value.to_string(),
         UnpackedValue::String(value) => format!("\"{value}\""),
-        UnpackedValue::Object { name, .. } if abi_object_is_enum(symbols, key_ty) => name.clone(),
+        UnpackedValue::Object { name, .. } if abi_object_is_enum(symbols, key_ty_idx) => {
+            name.clone()
+        }
         UnpackedValue::Address(value) => value.to_string(),
         UnpackedValue::ExtAddress(value) => value.to_string(),
         UnpackedValue::Cell(value) | UnpackedValue::RemainingBitsAndRefs(value) => {
@@ -1713,40 +1690,33 @@ fn format_abi_map_key(symbols: &SourceMap, data: &UnpackedValue, key_ty: &Ty) ->
         }
         UnpackedValue::Bits((bytes, bit_len)) => format_abi_bits(bytes, *bit_len),
         UnpackedValue::Object { .. } | UnpackedValue::Array(_) | UnpackedValue::Map(_) => {
-            typed_leaf_for_ty(key_ty, "<key>").dap_value()
+            typed_leaf(render_ty(symbols, key_ty_idx), "<key>").dap_value()
         }
     }
 }
 
-fn abi_object_is_enum(symbols: &SourceMap, ty: &Ty) -> bool {
+fn abi_object_is_enum(symbols: &SourceMap, ty_idx: TyIdx) -> bool {
     matches!(
-        resolve_alias_shape_ty(symbols, ty).as_ref().unwrap_or(ty),
+        symbols
+            .ty_by_idx(resolve_alias_shape_ty(symbols, ty_idx).unwrap_or(ty_idx))
+            .unwrap_or(&Ty::Unknown),
         Ty::EnumRef { .. }
     )
 }
 
-fn enum_raw_value_ty(symbols: &SourceMap, ty: &Ty) -> Option<Ty> {
-    match ty {
-        Ty::EnumRef { enum_name } => Some(symbols.get_enum(enum_name).encoded_as.clone()),
-        Ty::AliasRef {
-            alias_name,
-            type_args,
-        } => {
-            let target = resolve_alias_target_ty(symbols, alias_name, type_args.as_deref())?;
-            enum_raw_value_ty(symbols, &target)
-        }
+fn enum_raw_value_ty(symbols: &SourceMap, ty_idx: TyIdx) -> Option<TyIdx> {
+    match symbols.ty_by_idx(ty_idx)? {
+        Ty::EnumRef { enum_name } => Some(symbols.get_enum(enum_name).encoded_as_ty_idx),
+        Ty::AliasRef { .. } => enum_raw_value_ty(symbols, symbols.alias_target_of(ty_idx)?),
         _ => None,
     }
 }
 
-fn abi_object_context_ty(symbols: &SourceMap, object_name: &str, ty: &Ty) -> Option<Ty> {
-    match ty {
-        Ty::AliasRef {
-            alias_name,
-            type_args,
-        } => {
-            let target = resolve_alias_target_ty(symbols, alias_name, type_args.as_deref())?;
-            abi_object_context_ty(symbols, object_name, &target).or(Some(target))
+fn abi_object_context_ty(symbols: &SourceMap, object_name: &str, ty_idx: TyIdx) -> Option<TyIdx> {
+    match symbols.ty_by_idx(ty_idx)? {
+        Ty::AliasRef { .. } => {
+            let target = symbols.alias_target_of(ty_idx)?;
+            abi_object_context_ty(symbols, object_name, target).or(Some(target))
         }
         Ty::Union { variants, .. } => resolve_union_object_ty(symbols, variants, object_name),
         _ => None,
@@ -1755,56 +1725,46 @@ fn abi_object_context_ty(symbols: &SourceMap, object_name: &str, ty: &Ty) -> Opt
 
 fn abi_object_field_ty(
     symbols: &SourceMap,
-    ty: &Ty,
+    ty_idx: TyIdx,
     object_name: &str,
     field_name: &str,
-) -> Option<Ty> {
-    match ty {
-        Ty::StructRef {
-            struct_name,
-            type_args,
-        } => {
-            let struct_ref = symbols.get_struct(struct_name);
-            let type_args = type_args.as_deref().unwrap_or(&[]);
-            struct_ref
-                .fields
-                .iter()
-                .find(|field| field.name == field_name)
-                .map(|field| {
-                    instantiate_generics(
-                        &field.ty,
-                        struct_ref.type_params.as_deref().unwrap_or(&[]),
-                        type_args,
-                    )
-                })
-        }
+) -> Option<TyIdx> {
+    match symbols.ty_by_idx(ty_idx)? {
+        Ty::StructRef { struct_name: _, .. } => symbols
+            .struct_fields_of(ty_idx)?
+            .into_iter()
+            .find(|field| field.name == field_name)
+            .map(|field| field.ty_idx),
         Ty::EnumRef { enum_name } if field_name == "value" => {
-            Some(symbols.get_enum(enum_name).encoded_as.clone())
+            Some(symbols.get_enum(enum_name).encoded_as_ty_idx)
         }
-        Ty::CellOf { inner } if object_name == "Cell" && field_name == "ref" => {
-            Some(inner.as_ref().clone())
+        Ty::CellOf { inner_ty_idx } if object_name == "Cell" && field_name == "ref" => {
+            Some(*inner_ty_idx)
         }
-        Ty::AliasRef {
-            alias_name,
-            type_args,
-        } => {
-            let target = resolve_alias_target_ty(symbols, alias_name, type_args.as_deref())?;
-            abi_object_field_ty(symbols, &target, object_name, field_name)
+        Ty::AliasRef { .. } => {
+            let target = symbols.alias_target_of(ty_idx)?;
+            abi_object_field_ty(symbols, target, object_name, field_name)
         }
         Ty::Union { variants, .. } => {
             for (variant, label) in variants.iter().zip(union_variant_labels(symbols, variants)) {
                 if label.as_deref() == Some(object_name) {
                     return if field_name == "value" {
-                        Some(variant.variant_ty.clone())
+                        Some(variant.variant_ty_idx)
                     } else {
-                        abi_object_field_ty(symbols, &variant.variant_ty, object_name, field_name)
+                        abi_object_field_ty(
+                            symbols,
+                            variant.variant_ty_idx,
+                            object_name,
+                            field_name,
+                        )
                     };
                 }
-                if union_label_simple(symbols, &variant.variant_ty).as_deref() == Some(object_name)
+                if union_label_simple(symbols, variant.variant_ty_idx).as_deref()
+                    == Some(object_name)
                 {
                     return abi_object_field_ty(
                         symbols,
-                        &variant.variant_ty,
+                        variant.variant_ty_idx,
                         object_name,
                         field_name,
                     );
@@ -1816,43 +1776,24 @@ fn abi_object_field_ty(
     }
 }
 
-fn resolve_alias_shape_ty(symbols: &SourceMap, ty: &Ty) -> Option<Ty> {
-    match ty {
-        Ty::AliasRef {
-            alias_name,
-            type_args,
-        } => resolve_alias_target_ty(symbols, alias_name, type_args.as_deref()),
+fn resolve_alias_shape_ty(symbols: &SourceMap, ty_idx: TyIdx) -> Option<TyIdx> {
+    match symbols.ty_by_idx(ty_idx)? {
+        Ty::AliasRef { .. } => symbols.alias_target_of(ty_idx),
         _ => None,
     }
-}
-
-fn resolve_alias_target_ty(
-    symbols: &SourceMap,
-    alias_name: &str,
-    type_args: Option<&[Ty]>,
-) -> Option<Ty> {
-    let alias_ref = symbols.get_alias(alias_name);
-    Some(match type_args {
-        Some(type_args) => instantiate_generics(
-            &alias_ref.target_ty,
-            alias_ref.type_params.as_deref().unwrap_or(&[]),
-            type_args,
-        ),
-        None => alias_ref.target_ty.clone(),
-    })
 }
 
 fn resolve_union_object_ty(
     symbols: &SourceMap,
     variants: &[tolk_compiler::types_kernel::UnionVariant],
     object_name: &str,
-) -> Option<Ty> {
+) -> Option<TyIdx> {
     let labels = union_variant_labels(symbols, variants);
     variants.iter().zip(labels).find_map(|(variant, label)| {
         if label.as_deref() == Some(object_name)
-            || union_label_simple(symbols, &variant.variant_ty).as_deref() == Some(object_name)
+            || union_label_simple(symbols, variant.variant_ty_idx).as_deref() == Some(object_name)
         {
-            Some(variant.variant_ty.clone())
+            Some(variant.variant_ty_idx)
         } else {
             None
         }
@@ -1865,7 +1806,7 @@ fn union_variant_labels(
 ) -> Vec<Option<String>> {
     let simple_labels = variants
         .iter()
-        .map(|variant| union_label_simple(symbols, &variant.variant_ty))
+        .map(|variant| union_label_simple(symbols, variant.variant_ty_idx))
         .collect::<Vec<_>>();
     let has_duplicates = simple_labels.iter().enumerate().any(|(idx, label)| {
         label.is_some() && simple_labels[..idx].iter().any(|prev| prev == label)
@@ -1875,10 +1816,13 @@ fn union_variant_labels(
         .iter()
         .zip(simple_labels)
         .map(|(variant, simple_label)| {
-            if matches!(variant.variant_ty, Ty::NullLiteral) {
+            if matches!(
+                symbols.ty_by_idx(variant.variant_ty_idx),
+                Some(Ty::NullLiteral)
+            ) {
                 Some(String::new())
             } else if has_duplicates {
-                Some(variant.variant_ty.render_type())
+                Some(render_ty(symbols, variant.variant_ty_idx))
             } else {
                 simple_label
             }
@@ -1886,7 +1830,8 @@ fn union_variant_labels(
         .collect()
 }
 
-fn union_label_simple(symbols: &SourceMap, ty: &Ty) -> Option<String> {
+fn union_label_simple(symbols: &SourceMap, ty_idx: TyIdx) -> Option<String> {
+    let ty = symbols.ty_by_idx(ty_idx)?;
     Some(match ty {
         Ty::Int => "int".to_owned(),
         Ty::IntN { n } => format!("int{n}"),
@@ -1907,23 +1852,19 @@ fn union_label_simple(symbols: &SourceMap, ty: &Ty) -> Option<String> {
         Ty::NullLiteral => "null".to_owned(),
         Ty::Callable => "callable".to_owned(),
         Ty::Void => "void".to_owned(),
-        Ty::Nullable { inner, .. } => format!("{}?", union_label_simple(symbols, inner)?),
+        Ty::Nullable { inner_ty_idx, .. } => {
+            format!("{}?", union_label_simple(symbols, *inner_ty_idx)?)
+        }
         Ty::CellOf { .. } => "Cell".to_owned(),
         Ty::Tensor { .. } | Ty::ShapedTuple { .. } => "tensor".to_owned(),
         Ty::MapKV { .. } => "map".to_owned(),
         Ty::EnumRef { enum_name } => enum_name.clone(),
         Ty::StructRef { struct_name, .. } => struct_name.clone(),
-        Ty::AliasRef {
-            alias_name,
-            type_args,
-        } => {
-            let target = resolve_alias_target_ty(symbols, alias_name, type_args.as_deref())?;
-            union_label_simple(symbols, &target)?
-        }
+        Ty::AliasRef { .. } => union_label_simple(symbols, symbols.alias_target_of(ty_idx)?)?,
         Ty::GenericT { name_t } => name_t.clone(),
         Ty::Union { variants, .. } => variants
             .iter()
-            .filter_map(|variant| union_label_simple(symbols, &variant.variant_ty))
+            .filter_map(|variant| union_label_simple(symbols, variant.variant_ty_idx))
             .collect::<Vec<_>>()
             .join("|"),
         Ty::ArrayOf { .. } => "array".to_owned(),
@@ -1949,8 +1890,9 @@ fn format_abi_bits(bytes: &[u8], bit_len: usize) -> String {
 fn render_map_value(
     symbols: &SourceMap,
     value_slice: TyCellSlice<'_>,
-    value_ty: &Ty,
+    value_ty_idx: TyIdx,
 ) -> RenderedValue {
+    let value_ty = symbols.ty_by_idx(value_ty_idx).unwrap_or(&Ty::Unknown);
     let scalar_type = parse_map_value_type(value_ty);
     let allow_raw_value_fallback =
         scalar_type.is_none() && !matches!(value_ty, Ty::Nullable { .. } | Ty::MapKV { .. });
@@ -1958,39 +1900,44 @@ fn render_map_value(
     let mut value_slice = value_slice;
     if matches!(scalar_type, Some(MapScalarType::Address)) {
         return match IntAddr::load_from(&mut value_slice) {
-            Ok(addr) => render_int_address(value_ty.to_string(), &addr),
-            Err(err) => typed_leaf_for_ty(value_ty, format!("<value: {err}>")),
+            Ok(addr) => render_int_address(render_ty(symbols, value_ty_idx), &addr),
+            Err(err) => typed_leaf_for_ty(symbols, value_ty_idx, format!("<value: {err}>")),
         };
     }
 
     if let Some(scalar_type) = scalar_type {
         return match format_map_scalar(&mut value_slice, scalar_type) {
-            Ok(value) => typed_leaf_for_ty(value_ty, value),
-            Err(err) => typed_leaf_for_ty(value_ty, format!("<value: {err}>")),
+            Ok(value) => typed_leaf_for_ty(symbols, value_ty_idx, value),
+            Err(err) => typed_leaf_for_ty(symbols, value_ty_idx, format!("<value: {err}>")),
         };
     }
 
-    if let Some(value) = render_map_value_with_symbols(symbols, value_slice, value_ty) {
+    if let Some(value) = render_map_value_with_symbols(symbols, value_slice, value_ty_idx) {
         return value;
     }
 
     if allow_raw_value_fallback {
         return match format_map_raw_value(value_slice) {
-            Ok(value) => typed_leaf_for_ty(value_ty, value),
-            Err(err) => typed_leaf_for_ty(value_ty, format!("<value: {err}>")),
+            Ok(value) => typed_leaf_for_ty(symbols, value_ty_idx, value),
+            Err(err) => typed_leaf_for_ty(symbols, value_ty_idx, format!("<value: {err}>")),
         };
     }
 
-    typed_leaf_for_ty(value_ty, "<value>")
+    typed_leaf_for_ty(symbols, value_ty_idx, "<value>")
 }
 
 fn render_map_dict(
     symbols: &SourceMap,
     root: Option<Cell>,
-    key_ty: &Ty,
-    value_ty: &Ty,
+    key_ty_idx: TyIdx,
+    value_ty_idx: TyIdx,
 ) -> RenderedValue {
-    let type_name = map_type_name(key_ty, value_ty);
+    let type_name = format!(
+        "map<{}, {}>",
+        render_ty(symbols, key_ty_idx),
+        render_ty(symbols, value_ty_idx)
+    );
+    let key_ty = symbols.ty_by_idx(key_ty_idx).unwrap_or(&Ty::Unknown);
 
     let Some(key_type) = parse_map_key_type(key_ty) else {
         return render_map_raw(type_name, root.as_ref());
@@ -2006,7 +1953,7 @@ fn render_map_dict(
             let mut key_slice = key_data.as_data_slice();
             format_map_scalar(&mut key_slice, key_type).unwrap_or_else(|_| "<key>".to_string())
         };
-        let value = render_map_value(symbols, value_slice, value_ty);
+        let value = render_map_value(symbols, value_slice, value_ty_idx);
         fields.push((key, value));
     }
 
@@ -2056,6 +2003,12 @@ fn refs_suffix(ref_count: usize) -> String {
 /// Render a `CellSlice` as `slice{HEX}`, extracting only the bits in `start..end`.
 /// Appends `+ N refs` when the slice carries cell references.
 fn render_slice(cs: &CellSlice) -> String {
+    if let Some(cell) = exact_slice_cell(cs)
+        && let Some(rendered) = render_exact_slice_cell(&cell)
+    {
+        return rendered;
+    }
+
     let ref_count = cs
         .refs
         .as_ref()
@@ -2083,6 +2036,24 @@ fn render_slice(cs: &CellSlice) -> String {
         &cs.value
     };
     format!("slice{{{data_hex}}}{r_suf}")
+}
+
+fn render_exact_slice_cell(cell: &Cell) -> Option<String> {
+    let mut slice = cell.as_slice_allow_exotic();
+    let bit_len = slice.size_bits();
+    let bit_count = bit_len as usize;
+    let ref_count = slice.size_refs() as usize;
+    let mut raw_bits = vec![0u8; bit_count.div_ceil(8)];
+    slice.load_raw(&mut raw_bits, bit_len).ok()?;
+
+    let mut data_hex = String::with_capacity(raw_bits.len() * 2);
+    for byte in raw_bits {
+        write!(data_hex, "{byte:02x}").ok()?;
+    }
+
+    let nibbles = hex_to_nibbles(&data_hex);
+    let rendered = bits_to_hex(&nibbles, 0, bit_count);
+    Some(format!("slice{{{rendered}}}{}", refs_suffix(ref_count)))
 }
 
 /// Render a Builder (BC{hex}) as `builder{DATA_HEX}`, stripping descriptor bytes.
@@ -2144,8 +2115,16 @@ fn flatten_lisp_list(items: &[VmStackValue]) -> Vec<&VmStackValue> {
     }
 }
 
-fn typed_leaf_for_ty(ty: &Ty, value: impl Into<String>) -> RenderedValue {
-    RenderedValue::typed_leaf(value, ty.to_string())
+fn typed_leaf_for_ty(
+    symbols: &SourceMap,
+    ty_idx: TyIdx,
+    value: impl Into<String>,
+) -> RenderedValue {
+    RenderedValue::typed_leaf(value, render_ty(symbols, ty_idx))
+}
+
+fn typed_leaf(type_name: impl Into<String>, value: impl Into<String>) -> RenderedValue {
+    RenderedValue::typed_leaf(value, type_name)
 }
 
 // ---------------------------------------------------------------------------
@@ -2158,10 +2137,12 @@ fn typed_leaf_for_ty(ty: &Ty, value: impl Into<String>) -> RenderedValue {
 fn debug_format(
     symbols: &SourceMap,
     r: &mut StackReader,
-    ty: &Ty,
+    ty_idx: TyIdx,
     un_tuple_if_w: bool,
 ) -> RenderedValue {
-    let width = calc_width_on_stack(symbols, ty);
+    let ty = symbols.ty_by_idx(ty_idx).unwrap_or(&Ty::Unknown);
+    let ty_name = render_ty(symbols, ty_idx);
+    let width = calc_width_on_stack(symbols, ty_idx);
 
     if width > 0 && r.peek_n_all_optimized_out(width) {
         r.skip(width);
@@ -2176,7 +2157,7 @@ fn debug_format(
             .collect();
         r.skip(width);
         let mut sub = StackReader::new(&as_live);
-        let inner = debug_format(symbols, &mut sub, ty, un_tuple_if_w);
+        let inner = debug_format(symbols, &mut sub, ty_idx, un_tuple_if_w);
         return RenderedValue::LastSeen {
             inner: Box::new(inner),
         };
@@ -2188,7 +2169,7 @@ fn debug_format(
     {
         let as_live: Vec<SlotValue> = t.iter().map(SlotValue::Live).collect();
         let mut sub = StackReader::new(&as_live);
-        return debug_format(symbols, &mut sub, ty, false);
+        return debug_format(symbols, &mut sub, ty_idx, false);
     }
 
     match ty {
@@ -2198,29 +2179,31 @@ fn debug_format(
         | Ty::VarintN { .. }
         | Ty::VaruintN { .. }
         | Ty::Coins => match r.read_slot() {
-            SlotValue::Live(VmStackValue::Integer(s)) => typed_leaf_for_ty(ty, s.clone()),
-            SlotValue::Live(VmStackValue::NaN) => typed_leaf_for_ty(ty, "NaN"),
-            SlotValue::Live(VmStackValue::Null) => typed_leaf_for_ty(ty, "null"),
-            _ => typed_leaf_for_ty(ty, "not a TVM int"),
+            SlotValue::Live(VmStackValue::Integer(s)) => {
+                typed_leaf_for_ty(symbols, ty_idx, s.clone())
+            }
+            SlotValue::Live(VmStackValue::NaN) => typed_leaf_for_ty(symbols, ty_idx, "NaN"),
+            SlotValue::Live(VmStackValue::Null) => typed_leaf_for_ty(symbols, ty_idx, "null"),
+            _ => typed_leaf_for_ty(symbols, ty_idx, "not a TVM int"),
         },
 
         Ty::Bool => match r.read_slot() {
             SlotValue::Live(VmStackValue::Integer(s)) => {
                 if s == "0" {
-                    typed_leaf_for_ty(ty, "false")
+                    typed_leaf_for_ty(symbols, ty_idx, "false")
                 } else {
-                    typed_leaf_for_ty(ty, "true")
+                    typed_leaf_for_ty(symbols, ty_idx, "true")
                 }
             }
-            SlotValue::Live(VmStackValue::Null) => typed_leaf_for_ty(ty, "null"),
-            _ => typed_leaf_for_ty(ty, "not a TVM int"),
+            SlotValue::Live(VmStackValue::Null) => typed_leaf_for_ty(symbols, ty_idx, "null"),
+            _ => typed_leaf_for_ty(symbols, ty_idx, "not a TVM int"),
         },
 
         Ty::Cell => match r.read_slot() {
             SlotValue::Live(VmStackValue::Cell(cell)) => {
                 let (bits, refs, hash) = cell_like_meta(cell);
                 render_openable_cell_like(
-                    ty,
+                    ty_name,
                     render_cell_like(cell),
                     bits,
                     refs,
@@ -2228,49 +2211,53 @@ fn debug_format(
                     Some(cell.clone()),
                 )
             }
-            SlotValue::Live(VmStackValue::Null) => typed_leaf_for_ty(ty, "null"),
-            _ => typed_leaf_for_ty(ty, "not a TVM cell"),
+            SlotValue::Live(VmStackValue::Null) => typed_leaf_for_ty(symbols, ty_idx, "null"),
+            _ => typed_leaf_for_ty(symbols, ty_idx, "not a TVM cell"),
         },
 
-        Ty::CellOf { inner } => match r.read_slot() {
+        Ty::CellOf { inner_ty_idx } => match r.read_slot() {
             SlotValue::Live(VmStackValue::Cell(cell)) => {
-                render_typed_cell(symbols, ty, inner, cell)
+                render_typed_cell(symbols, ty_name, *inner_ty_idx, cell)
             }
-            SlotValue::Live(VmStackValue::Null) => typed_leaf_for_ty(ty, "null"),
-            _ => typed_leaf_for_ty(ty, "not a TVM cell"),
+            SlotValue::Live(VmStackValue::Null) => typed_leaf_for_ty(symbols, ty_idx, "null"),
+            _ => typed_leaf_for_ty(symbols, ty_idx, "not a TVM cell"),
         },
 
         Ty::String => match r.read_slot() {
-            SlotValue::Live(VmStackValue::String(s)) => typed_leaf_for_ty(ty, format!("\"{s}\"")),
+            SlotValue::Live(VmStackValue::String(s)) => {
+                typed_leaf_for_ty(symbols, ty_idx, format!("\"{s}\""))
+            }
             SlotValue::Live(VmStackValue::Cell(cell)) => typed_leaf_for_ty(
-                ty,
+                symbols,
+                ty_idx,
                 try_parse_string_cell_like(cell)
                     .map_or_else(|| render_cell_like(cell), |string| format!("\"{string}\"")),
             ),
             SlotValue::Live(VmStackValue::CellSlice(cs)) => typed_leaf_for_ty(
-                ty,
+                symbols,
+                ty_idx,
                 try_parse_string_slice(cs)
                     .map_or_else(|| render_slice(cs), |string| format!("\"{string}\"")),
             ),
-            SlotValue::Live(VmStackValue::Null) => typed_leaf_for_ty(ty, "null"),
-            _ => typed_leaf_for_ty(ty, "not a TVM cell"),
+            SlotValue::Live(VmStackValue::Null) => typed_leaf_for_ty(symbols, ty_idx, "null"),
+            _ => typed_leaf_for_ty(symbols, ty_idx, "not a TVM cell"),
         },
 
         Ty::Builder => match r.read_slot() {
             SlotValue::Live(VmStackValue::Builder(b)) => {
                 let cell = CellLike::Builder(b.clone());
                 let (bits, refs, hash) = cell_like_meta(&cell);
-                render_openable_cell_like(ty, render_builder(b), bits, refs, hash, Some(cell))
+                render_openable_cell_like(ty_name, render_builder(b), bits, refs, hash, Some(cell))
             }
-            SlotValue::Live(VmStackValue::Null) => typed_leaf_for_ty(ty, "null"),
-            _ => typed_leaf_for_ty(ty, "not a TVM builder"),
+            SlotValue::Live(VmStackValue::Null) => typed_leaf_for_ty(symbols, ty_idx, "null"),
+            _ => typed_leaf_for_ty(symbols, ty_idx, "not a TVM builder"),
         },
 
         Ty::Slice | Ty::Remaining | Ty::BitsN { .. } => match r.read_slot() {
             SlotValue::Live(VmStackValue::CellSlice(cs)) => {
                 let (bits, refs, hash) = slice_meta(cs);
                 render_openable_cell_like(
-                    ty,
+                    ty_name,
                     render_slice(cs),
                     bits,
                     refs,
@@ -2278,11 +2265,11 @@ fn debug_format(
                     slice_as_cell_like(cs),
                 )
             }
-            SlotValue::Live(VmStackValue::Null) => typed_leaf_for_ty(ty, "null"),
-            _ => typed_leaf_for_ty(ty, "not a TVM slice"),
+            SlotValue::Live(VmStackValue::Null) => typed_leaf_for_ty(symbols, ty_idx, "null"),
+            _ => typed_leaf_for_ty(symbols, ty_idx, "not a TVM slice"),
         },
 
-        Ty::ArrayOf { inner } => {
+        Ty::ArrayOf { inner_ty_idx } => {
             // array len N => N sub-items => N calls to inner debug_format
             match r.read_slot() {
                 SlotValue::Live(VmStackValue::Tuple(t)) => {
@@ -2290,77 +2277,86 @@ fn debug_format(
                     let mut sub = StackReader::new(&as_live);
                     let items: Vec<RenderedValue> = as_live
                         .iter()
-                        .map(|_| debug_format(symbols, &mut sub, inner, true))
+                        .map(|_| debug_format(symbols, &mut sub, *inner_ty_idx, true))
                         .collect();
                     RenderedValue::ArrayOf {
-                        type_name: ty.to_string(),
+                        type_name: ty_name,
                         items,
                     }
                 }
-                SlotValue::Live(VmStackValue::Null) => typed_leaf_for_ty(ty, "null"),
-                _ => typed_leaf_for_ty(ty, "not a TVM tuple"),
+                SlotValue::Live(VmStackValue::Null) => typed_leaf_for_ty(symbols, ty_idx, "null"),
+                _ => typed_leaf_for_ty(symbols, ty_idx, "not a TVM tuple"),
             }
         }
 
-        Ty::LispListOf { inner } => match r.read_slot() {
+        Ty::LispListOf { inner_ty_idx } => match r.read_slot() {
             SlotValue::Live(VmStackValue::Tuple(t)) => {
                 let elements = flatten_lisp_list(t);
                 let as_live: Vec<SlotValue> = elements.iter().map(|v| SlotValue::Live(v)).collect();
                 let n = as_live.len();
                 let mut sub = StackReader::new(&as_live);
                 let items: Vec<RenderedValue> = (0..n)
-                    .map(|_| debug_format(symbols, &mut sub, inner, true))
+                    .map(|_| debug_format(symbols, &mut sub, *inner_ty_idx, true))
                     .collect();
                 RenderedValue::ArrayOf {
-                    type_name: ty.to_string(),
+                    type_name: ty_name,
                     items,
                 }
             }
             SlotValue::Live(VmStackValue::Null) => RenderedValue::ArrayOf {
-                type_name: ty.to_string(),
+                type_name: ty_name,
                 items: vec![],
             },
-            _ => typed_leaf_for_ty(ty, "not a TVM tuple"),
+            _ => typed_leaf_for_ty(symbols, ty_idx, "not a TVM tuple"),
         },
 
         Ty::Address | Ty::AddressOpt | Ty::AddressExt | Ty::AddressAny => match r.read_slot() {
             SlotValue::Live(VmStackValue::CellSlice(cs)) => match try_parse_address(cs) {
                 Some(raw) => match raw.parse::<StdAddr>() {
-                    Ok(addr) => render_std_address(ty.to_string(), addr.to_string(), &addr),
-                    Err(_) => typed_leaf_for_ty(ty, raw),
+                    Ok(addr) => render_std_address(ty_name, addr.to_string(), &addr),
+                    Err(_) => typed_leaf_for_ty(symbols, ty_idx, raw),
                 },
-                None => typed_leaf_for_ty(ty, render_slice(cs)),
+                None => typed_leaf_for_ty(symbols, ty_idx, render_slice(cs)),
             },
-            SlotValue::Live(VmStackValue::Null) => typed_leaf_for_ty(ty, "null"),
-            _ => typed_leaf_for_ty(ty, "not a TVM slice"),
+            SlotValue::Live(VmStackValue::Null) => typed_leaf_for_ty(symbols, ty_idx, "null"),
+            _ => typed_leaf_for_ty(symbols, ty_idx, "not a TVM slice"),
         },
 
-        Ty::MapKV { k, v } => match r.read_slot() {
+        Ty::MapKV {
+            key_ty_idx,
+            value_ty_idx,
+        } => match r.read_slot() {
             SlotValue::Live(VmStackValue::Null) => RenderedValue::Struct {
-                type_name: map_type_name(k, v),
+                type_name: format!(
+                    "map<{}, {}>",
+                    render_ty(symbols, *key_ty_idx),
+                    render_ty(symbols, *value_ty_idx)
+                ),
                 fields: vec![],
             },
             SlotValue::Live(VmStackValue::Cell(cell)) => {
                 if let Some(root) = decode_cell_like(cell) {
-                    render_map_dict(symbols, Some(root), k, v)
+                    render_map_dict(symbols, Some(root), *key_ty_idx, *value_ty_idx)
                 } else {
-                    typed_leaf_for_ty(ty, "not a TVM cell")
+                    typed_leaf_for_ty(symbols, ty_idx, "not a TVM cell")
                 }
             }
-            _ => typed_leaf_for_ty(ty, "not a TVM cell"),
+            _ => typed_leaf_for_ty(symbols, ty_idx, "not a TVM cell"),
         },
 
         Ty::NullLiteral => match r.read_slot() {
-            SlotValue::Live(VmStackValue::Null) => typed_leaf_for_ty(ty, "null"),
-            _ => typed_leaf_for_ty(ty, "not a TVM null"),
+            SlotValue::Live(VmStackValue::Null) => typed_leaf_for_ty(symbols, ty_idx, "null"),
+            _ => typed_leaf_for_ty(symbols, ty_idx, "not a TVM null"),
         },
 
-        Ty::Void => typed_leaf_for_ty(ty, "(void)"),
+        Ty::Void => typed_leaf_for_ty(symbols, ty_idx, "(void)"),
 
         Ty::Callable => match r.read_slot() {
-            SlotValue::Live(VmStackValue::Continuation(_)) => typed_leaf_for_ty(ty, "continuation"),
-            SlotValue::Live(VmStackValue::Null) => typed_leaf_for_ty(ty, "null"),
-            _ => typed_leaf_for_ty(ty, "not a TVM continuation"),
+            SlotValue::Live(VmStackValue::Continuation(_)) => {
+                typed_leaf_for_ty(symbols, ty_idx, "continuation")
+            }
+            SlotValue::Live(VmStackValue::Null) => typed_leaf_for_ty(symbols, ty_idx, "null"),
+            _ => typed_leaf_for_ty(symbols, ty_idx, "not a TVM continuation"),
         },
         Ty::Unknown => match r.read_slot() {
             SlotValue::Live(any) => RenderedValue::leaf(any.to_string()),
@@ -2368,7 +2364,9 @@ fn debug_format(
         },
 
         Ty::Nullable {
-            inner, stack_width, ..
+            inner_ty_idx,
+            stack_width,
+            ..
         } => {
             if let Some(sw) = stack_width {
                 // read wide nullable: [null, null, ... 0] or [smth, smth, ... type_id]
@@ -2378,17 +2376,17 @@ fn debug_format(
                     SlotValue::Live(VmStackValue::Integer(type_id))
                     | SlotValue::LastSeen(VmStackValue::Integer(type_id)) => {
                         if type_id == "0" {
-                            typed_leaf_for_ty(ty, "null")
+                            typed_leaf(ty_name, "null")
                         } else {
                             let mut sub = StackReader::new(&nullable_slots[..sw - 1]);
-                            debug_format(symbols, &mut sub, inner, false)
+                            debug_format(symbols, &mut sub, *inner_ty_idx, false)
                         }
                     }
                     SlotValue::OptimizedOut => {
                         let mut sub = StackReader::new(&nullable_slots[..sw - 1]);
-                        debug_format(symbols, &mut sub, inner, false)
+                        debug_format(symbols, &mut sub, *inner_ty_idx, false)
                     }
-                    _ => typed_leaf_for_ty(ty, "corrupted stack for nullable"),
+                    _ => typed_leaf_for_ty(symbols, ty_idx, "corrupted stack for nullable"),
                 }
             } else {
                 // read a primitive one-slot nullable: either TVM null or a value of type inner
@@ -2396,67 +2394,30 @@ fn debug_format(
                     SlotValue::Live(VmStackValue::Null)
                     | SlotValue::LastSeen(VmStackValue::Null) => {
                         r.read_slot();
-                        typed_leaf_for_ty(ty, "null")
+                        typed_leaf(ty_name, "null")
                     }
-                    _ => debug_format(symbols, r, inner, false),
+                    _ => debug_format(symbols, r, *inner_ty_idx, false),
                 }
             }
         }
 
-        Ty::StructRef {
-            struct_name,
-            type_args,
-        } => {
-            let struct_ref = symbols.get_struct(struct_name);
-            let struct_name = match type_args {
-                None => struct_name.clone(),
-                Some(type_args) => format!(
-                    "{}<{}>",
-                    struct_name,
-                    type_args
-                        .iter()
-                        .map(ToString::to_string)
-                        .collect::<Vec<_>>()
-                        .join(", ")
-                ),
-            };
+        Ty::StructRef { .. } => {
             let mut fields: Vec<(String, RenderedValue)> = Vec::new();
-            for f in &struct_ref.fields {
-                let field_val = match type_args {
-                    Some(type_args) => {
-                        let f_ty = instantiate_generics(
-                            &f.ty,
-                            struct_ref.type_params.as_deref().unwrap_or(&[]),
-                            type_args,
-                        );
-                        debug_format(symbols, r, &f_ty, false)
-                    }
-                    None => debug_format(symbols, r, &f.ty, false),
-                };
+            for f in symbols.struct_fields_of(ty_idx).unwrap_or_default() {
+                let field_val = debug_format(symbols, r, f.ty_idx, false);
                 fields.push((f.name.clone(), field_val));
             }
             RenderedValue::Struct {
-                type_name: struct_name,
+                type_name: ty_name,
                 fields,
             }
         }
 
-        Ty::AliasRef {
-            alias_name,
-            type_args,
-        } => {
-            let alias_ref = symbols.get_alias(alias_name);
-            match type_args {
-                Some(type_args) => {
-                    let target_ty = instantiate_generics(
-                        &alias_ref.target_ty,
-                        alias_ref.type_params.as_deref().unwrap_or(&[]),
-                        type_args,
-                    );
-                    debug_format(symbols, r, &target_ty, false)
-                }
-                None => debug_format(symbols, r, &alias_ref.target_ty, false),
-            }
+        Ty::AliasRef { .. } => {
+            let Some(target_ty_idx) = symbols.alias_target_of(ty_idx) else {
+                return typed_leaf_for_ty(symbols, ty_idx, "unresolved alias");
+            };
+            debug_format(symbols, r, target_ty_idx, false)
         }
 
         Ty::EnumRef { enum_name } => match r.read_slot() {
@@ -2469,39 +2430,39 @@ fn debug_format(
                 let slot = VmStackValue::Integer(s.clone());
                 let slots = [SlotValue::Live(&slot)];
                 let mut sub = StackReader::new(&slots);
-                let raw_value = debug_format(symbols, &mut sub, &enum_ref.encoded_as, false);
-                render_enum_value(ty, text, raw_value)
+                let raw_value = debug_format(symbols, &mut sub, enum_ref.encoded_as_ty_idx, false);
+                render_enum_value(ty_name, text, raw_value)
             }
-            SlotValue::Live(VmStackValue::Null) => typed_leaf_for_ty(ty, "null"),
-            _ => typed_leaf_for_ty(ty, "not a TVM int"),
+            SlotValue::Live(VmStackValue::Null) => typed_leaf_for_ty(symbols, ty_idx, "null"),
+            _ => typed_leaf_for_ty(symbols, ty_idx, "not a TVM int"),
         },
 
-        Ty::Tensor { items } => {
-            let items: Vec<RenderedValue> = items
+        Ty::Tensor { items_ty_idx } => {
+            let items: Vec<RenderedValue> = items_ty_idx
                 .iter()
-                .map(|item| debug_format(symbols, r, item, false))
+                .map(|&item| debug_format(symbols, r, item, false))
                 .collect();
             RenderedValue::Tensor {
-                type_name: ty.to_string(),
+                type_name: ty_name,
                 items,
             }
         }
 
-        Ty::ShapedTuple { items } => match r.read_slot() {
+        Ty::ShapedTuple { items_ty_idx } => match r.read_slot() {
             SlotValue::Live(VmStackValue::Tuple(t)) => {
                 let as_live: Vec<SlotValue> = t.iter().map(SlotValue::Live).collect();
                 let mut sub = StackReader::new(&as_live);
-                let items: Vec<RenderedValue> = items
+                let items: Vec<RenderedValue> = items_ty_idx
                     .iter()
-                    .map(|item| debug_format(symbols, &mut sub, item, true))
+                    .map(|&item| debug_format(symbols, &mut sub, item, true))
                     .collect();
                 RenderedValue::ArrayOf {
-                    type_name: ty.to_string(),
+                    type_name: ty_name,
                     items,
                 }
             }
-            SlotValue::Live(VmStackValue::Null) => typed_leaf_for_ty(ty, "null"),
-            _ => typed_leaf_for_ty(ty, "not a TVM tuple"),
+            SlotValue::Live(VmStackValue::Null) => typed_leaf_for_ty(symbols, ty_idx, "null"),
+            _ => typed_leaf_for_ty(symbols, ty_idx, "not a TVM tuple"),
         },
 
         Ty::Union {
@@ -2521,33 +2482,42 @@ fn debug_format(
                     {
                         let variant_width = variant.stack_width.unwrap_or(0);
                         let Some(variant_start) = stack_width.checked_sub(1 + variant_width) else {
-                            return typed_leaf_for_ty(ty, "corrupted stack for union");
+                            return typed_leaf_for_ty(symbols, ty_idx, "corrupted stack for union");
                         };
                         let value = if variant_width == 0 {
                             None
                         } else {
                             let mut sub =
                                 StackReader::new(&union_slots[variant_start..stack_width - 1]);
-                            Some(debug_format(symbols, &mut sub, &variant.variant_ty, false))
+                            Some(debug_format(
+                                symbols,
+                                &mut sub,
+                                variant.variant_ty_idx,
+                                false,
+                            ))
                         };
-                        render_union_case(ty, variant.variant_ty.to_string(), value)
+                        render_union_case(
+                            ty_name,
+                            render_ty(symbols, variant.variant_ty_idx),
+                            value,
+                        )
                     } else {
                         // corrupted stack, type_id on a stack mismatches all variants
-                        typed_leaf_for_ty(ty, "union with unknown variant")
+                        typed_leaf_for_ty(symbols, ty_idx, "union with unknown variant")
                     }
                 }
                 SlotValue::OptimizedOut => {
                     // this should not happen in practice, because if UTag for a union was erased during compilation,
                     // a union was definitely smart cast, and its type is narrowed, not Ty::Union
-                    typed_leaf_for_ty(ty, "union with unknown variant")
+                    typed_leaf_for_ty(symbols, ty_idx, "union with unknown variant")
                 }
-                _ => typed_leaf_for_ty(ty, "corrupted stack for union"),
+                _ => typed_leaf_for_ty(symbols, ty_idx, "corrupted stack for union"),
             }
         }
 
         Ty::Union { .. } => {
             r.read_n_slots(width);
-            typed_leaf_for_ty(ty, "union with unresolved layout")
+            typed_leaf(ty_name, "union with unresolved layout")
         }
 
         Ty::GenericT { name_t } => {
@@ -2559,10 +2529,10 @@ fn debug_format(
 pub(crate) fn debug_print_from_stack(
     symbols: &SourceMap,
     slots: &[SlotValue],
-    ty: &Ty,
+    ty_idx: TyIdx,
 ) -> RenderedValue {
     let mut r = StackReader::new(slots);
-    debug_format(symbols, &mut r, ty, false)
+    debug_format(symbols, &mut r, ty_idx, false)
 }
 
 fn tuple_item_to_vm_stack_value(item: &TupleItem) -> VmStackValue {
@@ -2586,54 +2556,54 @@ fn tuple_items_to_vm_stack_values(tuple: &Tuple) -> Vec<VmStackValue> {
     tuple.iter().map(tuple_item_to_vm_stack_value).collect()
 }
 
-pub fn render_tuple_as_tolk_type(symbols: &SourceMap, tuple: &Tuple, ty: &Ty) -> RenderedValue {
+pub fn render_tuple_as_tolk_type(
+    symbols: &SourceMap,
+    tuple: &Tuple,
+    ty_idx: TyIdx,
+) -> RenderedValue {
     let stack_values = tuple_items_to_vm_stack_values(tuple);
     let slots: Vec<SlotValue<'_>> = stack_values.iter().map(SlotValue::Live).collect();
-    debug_print_from_stack(symbols, &slots, ty)
+    debug_print_from_stack(symbols, &slots, ty_idx)
 }
 
 pub fn render_tuple_item_as_tolk_type(
     symbols: &SourceMap,
     item: &TupleItem,
-    ty: &Ty,
+    ty_idx: TyIdx,
 ) -> RenderedValue {
     match item {
-        TupleItem::Tuple(tuple) if top_level_tuple_is_stack_frame(symbols, ty) => {
-            render_tuple_as_tolk_type(symbols, tuple, ty)
+        TupleItem::Tuple(tuple) if top_level_tuple_is_stack_frame(symbols, ty_idx) => {
+            render_tuple_as_tolk_type(symbols, tuple, ty_idx)
         }
         _ => {
             let stack_value = tuple_item_to_vm_stack_value(item);
             let slots = [SlotValue::Live(&stack_value)];
-            debug_print_from_stack(symbols, &slots, ty)
+            debug_print_from_stack(symbols, &slots, ty_idx)
         }
     }
 }
 
-fn top_level_tuple_is_stack_frame(symbols: &SourceMap, ty: &Ty) -> bool {
+fn top_level_tuple_is_stack_frame(symbols: &SourceMap, ty_idx: TyIdx) -> bool {
+    let Some(ty) = symbols.ty_by_idx(ty_idx) else {
+        return false;
+    };
     match ty {
         Ty::Tensor { .. } | Ty::StructRef { .. } => true,
         Ty::Nullable {
-            inner, stack_width, ..
-        } => stack_width.is_some_and(|w| w != 1) || top_level_tuple_is_stack_frame(symbols, inner),
+            inner_ty_idx,
+            stack_width,
+            ..
+        } => {
+            stack_width.is_some_and(|w| w != 1)
+                || top_level_tuple_is_stack_frame(symbols, *inner_ty_idx)
+        }
         Ty::Union {
             stack_width: Some(stack_width),
             ..
         } => *stack_width != 1,
-        Ty::AliasRef {
-            alias_name,
-            type_args,
-        } => {
-            let alias_ref = symbols.get_alias(alias_name);
-            let target_ty = match type_args {
-                Some(type_args) => instantiate_generics(
-                    &alias_ref.target_ty,
-                    alias_ref.type_params.as_deref().unwrap_or(&[]),
-                    type_args,
-                ),
-                None => alias_ref.target_ty.clone(),
-            };
-            top_level_tuple_is_stack_frame(symbols, &target_ty)
-        }
+        Ty::AliasRef { .. } => symbols
+            .alias_target_of(ty_idx)
+            .is_some_and(|target_ty_idx| top_level_tuple_is_stack_frame(symbols, target_ty_idx)),
         _ => false,
     }
 }
@@ -2641,7 +2611,7 @@ fn top_level_tuple_is_stack_frame(symbols: &SourceMap, ty: &Ty) -> bool {
 fn render_lazy_struct_fields(
     symbols: &SourceMap,
     struct_ref: &AbiStruct,
-    type_args: Option<&[Ty]>,
+    struct_ty_idx: TyIdx,
     slot_values: &[SlotValue],
     ir_slots: &[usize],
     last_seen: &HashMap<usize, VmStackValue>,
@@ -2657,23 +2627,18 @@ fn render_lazy_struct_fields(
 
     let mut fields = Vec::new();
     let mut offset = 0;
-    for f in &struct_ref.fields {
-        let f_ty = match type_args {
-            Some(type_args) => instantiate_generics(
-                &f.ty,
-                struct_ref.type_params.as_deref().unwrap_or(&[]),
-                type_args,
-            ),
-            None => f.ty.clone(),
-        };
-        let f_width = calc_width_on_stack(symbols, &f_ty);
+    let fields_to_render = symbols
+        .struct_fields_of(struct_ty_idx)
+        .unwrap_or_else(|| struct_ref.fields.clone());
+    for f in &fields_to_render {
+        let f_width = calc_width_on_stack(symbols, f.ty_idx);
         let field_ir_slots = &ir_slots[offset..offset + f_width];
         let field_ever_seen = field_ir_slots.iter().any(|s| last_seen.contains_key(s));
 
         let preview = match lazy_s.as_mut() {
             Some(lazy_s) => {
-                if let Ok(parsed) = dynamic_unpack::unpack_from_slice(lazy_s, symbols, &f_ty) {
-                    Some(render_abi_data(symbols, parsed, &f_ty))
+                if let Ok(parsed) = dynamic_unpack::unpack_from_slice(lazy_s, symbols, f.ty_idx) {
+                    Some(render_abi_data(symbols, parsed, f.ty_idx))
                 } else {
                     None
                 }
@@ -2684,7 +2649,7 @@ fn render_lazy_struct_fields(
         let field_val = if field_ever_seen {
             let field_slot_values = &slot_values[offset..offset + f_width];
             let mut r = StackReader::new(field_slot_values);
-            debug_format(symbols, &mut r, &f_ty, false)
+            debug_format(symbols, &mut r, f.ty_idx, false)
         } else {
             match preview {
                 None => RenderedValue::LazyCantParseSlice,
@@ -2710,31 +2675,25 @@ pub(crate) fn debug_format_lazy(
     symbols: &SourceMap,
     slot_values: &[SlotValue],
     ir_slots: &[usize],
-    ty: &Ty,
+    ty_idx: TyIdx,
     last_seen: &HashMap<usize, VmStackValue>,
     lazy_original_slice: &VmStackValue,
 ) -> RenderedValue {
+    let ty = symbols.ty_by_idx(ty_idx).unwrap_or(&Ty::Unknown);
     match ty {
         Ty::Union { .. } => {
             // when a lazy var is still Ty::Union, DEBUG_SMART_CAST not appeared, it's still unresolved
-            let type_name = format!("{ty}");
+            let type_name = render_ty(symbols, ty_idx);
             RenderedValue::LazyUnresolved { type_name }
         }
 
-        Ty::AliasRef {
-            alias_name,
-            type_args,
-        } => {
-            let alias_ref = symbols.get_alias(alias_name);
-            let resolved = match type_args {
-                Some(type_args) => instantiate_generics(
-                    &alias_ref.target_ty,
-                    alias_ref.type_params.as_deref().unwrap_or(&[]),
-                    type_args,
-                ),
-                None => alias_ref.target_ty.clone(),
+        Ty::AliasRef { alias_name, .. } => {
+            let Some(resolved_ty_idx) = symbols.alias_target_of(ty_idx) else {
+                return RenderedValue::LazyUnresolved {
+                    type_name: alias_name.clone(),
+                };
             };
-            if matches!(&resolved, Ty::Union { .. }) {
+            if matches!(symbols.ty_by_idx(resolved_ty_idx), Some(Ty::Union { .. })) {
                 return RenderedValue::LazyUnresolved {
                     type_name: alias_name.clone(),
                 };
@@ -2743,28 +2702,24 @@ pub(crate) fn debug_format_lazy(
                 symbols,
                 slot_values,
                 ir_slots,
-                &resolved,
+                resolved_ty_idx,
                 last_seen,
                 lazy_original_slice,
             )
         }
 
-        Ty::StructRef {
-            struct_name,
-            type_args,
-        } => {
+        Ty::StructRef { struct_name, .. } => {
             let struct_ref = symbols.get_struct(struct_name);
             let slice_as_cell = match lazy_original_slice {
                 VmStackValue::CellSlice(cs) => exact_slice_cell(cs),
                 _ => None,
             };
 
-            let ty_args = type_args.as_deref();
             let fields = match &slice_as_cell {
                 Some(cell) => render_lazy_struct_fields(
                     symbols,
                     struct_ref,
-                    ty_args,
+                    ty_idx,
                     slot_values,
                     ir_slots,
                     last_seen,
@@ -2773,7 +2728,7 @@ pub(crate) fn debug_format_lazy(
                 None => render_lazy_struct_fields(
                     symbols,
                     struct_ref,
-                    ty_args,
+                    ty_idx,
                     slot_values,
                     ir_slots,
                     last_seen,
@@ -2789,7 +2744,7 @@ pub(crate) fn debug_format_lazy(
 
         _ => {
             let mut r = StackReader::new(slot_values);
-            debug_format(symbols, &mut r, ty, false)
+            debug_format(symbols, &mut r, ty_idx, false)
         }
     }
 }
@@ -3022,13 +2977,15 @@ fn resolve_send_message_body_meta(
         RelaxedMsgInfo::Int(_) => try_resolve_message_body(
             body,
             symbols,
-            abi.outgoing_messages.iter().map(|message| &message.body_ty),
+            abi.outgoing_messages
+                .iter()
+                .map(|message| message.body_ty_idx),
             prefix_to_skip,
         ),
         RelaxedMsgInfo::ExtOut(_) => try_resolve_message_body(
             body,
             symbols,
-            abi.emitted_events.iter().map(|message| &message.body_ty),
+            abi.emitted_events.iter().map(|message| message.body_ty_idx),
             prefix_to_skip,
         ),
     });
@@ -3052,42 +3009,42 @@ struct ResolvedDecodedMessageBody {
     decoded: RenderedValue,
 }
 
-fn try_resolve_message_body<'a, I>(
-    body: TyCellSlice<'a>,
+fn try_resolve_message_body<I>(
+    body: TyCellSlice,
     symbols: &SourceMap,
     candidates: I,
     prefix_to_skip: u16,
 ) -> Option<ResolvedDecodedMessageBody>
 where
-    I: IntoIterator<Item = &'a Ty>,
+    I: IntoIterator<Item = TyIdx>,
 {
-    for body_ty in candidates {
+    for body_ty_idx in candidates {
         let mut parser = body;
         if prefix_to_skip > 0 && parser.skip_first(prefix_to_skip, 0).is_err() {
             continue;
         }
 
-        let Ok(data) = dynamic_unpack::unpack_from_slice(&mut parser, symbols, body_ty) else {
+        let Ok(data) = dynamic_unpack::unpack_from_slice(&mut parser, symbols, body_ty_idx) else {
             continue;
         };
         if parser.size_bits() != 0 || parser.size_refs() != 0 {
             continue;
         }
 
-        let Some(type_name) = compiler_body_type_name(body_ty) else {
+        let Some(type_name) = compiler_body_type_name(symbols, body_ty_idx) else {
             continue;
         };
         return Some(ResolvedDecodedMessageBody {
             type_name,
-            decoded: render_abi_data(symbols, data, body_ty),
+            decoded: render_abi_data(symbols, data, body_ty_idx),
         });
     }
 
     None
 }
 
-fn compiler_body_type_name(body_ty: &Ty) -> Option<String> {
-    match body_ty {
+fn compiler_body_type_name(symbols: &SourceMap, body_ty_idx: TyIdx) -> Option<String> {
+    match symbols.ty_by_idx(body_ty_idx)? {
         Ty::StructRef { struct_name, .. } => Some(struct_name.clone()),
         Ty::AliasRef { alias_name, .. } => Some(alias_name.clone()),
         _ => None,
@@ -3487,13 +3444,9 @@ fn render_runtime_uint_field(value: &VmStackValue, ty: &str) -> RenderedValue {
 fn render_runtime_extra_currencies_field(value: &VmStackValue) -> RenderedValue {
     match value {
         VmStackValue::Cell(cell) => {
-            let ty = Ty::MapKV {
-                k: Box::new(Ty::IntN { n: 32 }),
-                v: Box::new(Ty::VaruintN { n: 32 }),
-            };
             let (bits, refs, hash) = cell_like_meta(cell);
-            render_openable_cell_like(
-                &ty,
+            render_openable_cell_like_name(
+                "map<int32, varuint32>",
                 render_cell_like(cell),
                 bits,
                 refs,
@@ -3523,18 +3476,40 @@ mod tests {
     use tycho_types::models::{RelaxedIntMsgInfo, SendMsgFlags};
     use tycho_types::models::{ReserveCurrencyFlags, StdAddr};
 
-    fn source_map_with_declarations(declarations: Vec<Declaration>) -> SourceMap {
+    fn source_map_with_declarations_and_types(
+        declarations: Vec<Declaration>,
+        unique_types: Vec<Ty>,
+    ) -> SourceMap {
         serde_json::from_value(serde_json::json!({
             "files": [],
             "declarations": declarations,
-            "unique_ty": [],
+            "unique_types": unique_types,
+            "struct_instantiations": [],
+            "alias_instantiations": [],
             "functions": [],
         }))
         .unwrap()
     }
 
+    fn source_map_with_declarations(declarations: Vec<Declaration>) -> SourceMap {
+        source_map_with_declarations_and_types(declarations, Vec::new())
+    }
+
+    fn source_map_with_types(unique_types: Vec<Ty>) -> SourceMap {
+        source_map_with_declarations_and_types(Vec::new(), unique_types)
+    }
+
     fn empty_symbols() -> SourceMap {
         source_map_with_declarations(Vec::new())
+    }
+
+    fn add_ty(unique_types: &mut Vec<Ty>, ty: Ty) -> TyIdx {
+        if let Some(idx) = unique_types.iter().position(|existing| existing == &ty) {
+            return idx;
+        }
+        let idx = unique_types.len();
+        unique_types.push(ty);
+        idx
     }
 
     fn loc() -> SrcRange {
@@ -3543,27 +3518,37 @@ mod tests {
 
     #[test]
     fn render_abi_data_uses_field_type_for_object_fields() {
-        let symbols = source_map_with_declarations(vec![Declaration::Struct(AbiStruct {
-            name: "Payload".to_owned(),
-            ident_loc: loc(),
-            type_params: None,
-            prefix: None,
-            fields: vec![FieldInfo {
-                name: "flag".to_owned(),
-                ty: Ty::Bool,
-            }],
-            custom_pack_unpack: None,
-        })]);
+        let mut unique_types = Vec::new();
+        let bool_ty_idx = add_ty(&mut unique_types, Ty::Bool);
+        let payload_ty_idx = add_ty(
+            &mut unique_types,
+            Ty::StructRef {
+                struct_name: "Payload".to_owned(),
+                type_args_ty_idx: None,
+            },
+        );
+        let symbols = source_map_with_declarations_and_types(
+            vec![Declaration::Struct(AbiStruct {
+                name: "Payload".to_owned(),
+                ty_idx: payload_ty_idx,
+                ident_loc: loc(),
+                type_params: None,
+                prefix: None,
+                fields: vec![FieldInfo {
+                    name: "flag".to_owned(),
+                    ty_idx: bool_ty_idx,
+                }],
+                custom_pack_unpack: None,
+            })],
+            unique_types,
+        );
         let rendered = render_abi_data(
             &symbols,
             UnpackedValue::Object {
                 name: "Payload".to_owned(),
                 fields: vec![("flag".to_owned(), UnpackedValue::Bool(true))],
             },
-            &Ty::StructRef {
-                struct_name: "Payload".to_owned(),
-                type_args: None,
-            },
+            payload_ty_idx,
         );
 
         let RenderedValue::Struct { fields, .. } = rendered else {
@@ -3575,15 +3560,22 @@ mod tests {
 
     #[test]
     fn render_abi_data_uses_container_types_for_tensor_items() {
+        let mut unique_types = Vec::new();
+        let bool_ty_idx = add_ty(&mut unique_types, Ty::Bool);
+        let uint32_ty_idx = add_ty(&mut unique_types, Ty::UintN { n: 32 });
+        let tensor_ty_idx = add_ty(
+            &mut unique_types,
+            Ty::Tensor {
+                items_ty_idx: vec![bool_ty_idx, uint32_ty_idx],
+            },
+        );
         let rendered = render_abi_data(
-            &empty_symbols(),
+            &source_map_with_types(unique_types),
             UnpackedValue::Array(vec![
                 UnpackedValue::Bool(true),
                 UnpackedValue::Number(7.into()),
             ]),
-            &Ty::Tensor {
-                items: vec![Ty::Bool, Ty::UintN { n: 32 }],
-            },
+            tensor_ty_idx,
         );
 
         let RenderedValue::ArrayOf { items, .. } = rendered else {
@@ -3595,25 +3587,35 @@ mod tests {
 
     #[test]
     fn render_abi_enum_value_exposes_raw_value_field() {
-        let symbols = source_map_with_declarations(vec![Declaration::Enum(AbiEnum {
-            name: "Color".to_owned(),
-            ident_loc: loc(),
-            encoded_as: Ty::UintN { n: 8 },
-            members: vec![EnumMemberInfo {
-                name: "Blue".to_owned(),
-                value: "2".to_owned(),
-            }],
-            custom_pack_unpack: None,
-        })]);
+        let mut unique_types = Vec::new();
+        let uint8_ty_idx = add_ty(&mut unique_types, Ty::UintN { n: 8 });
+        let color_ty_idx = add_ty(
+            &mut unique_types,
+            Ty::EnumRef {
+                enum_name: "Color".to_owned(),
+            },
+        );
+        let symbols = source_map_with_declarations_and_types(
+            vec![Declaration::Enum(AbiEnum {
+                name: "Color".to_owned(),
+                ty_idx: color_ty_idx,
+                ident_loc: loc(),
+                encoded_as_ty_idx: uint8_ty_idx,
+                members: vec![EnumMemberInfo {
+                    name: "Blue".to_owned(),
+                    value: "2".to_owned(),
+                }],
+                custom_pack_unpack: None,
+            })],
+            unique_types,
+        );
         let rendered = render_abi_data(
             &symbols,
             UnpackedValue::Object {
                 name: "Color.Blue".to_owned(),
                 fields: vec![("value".to_owned(), UnpackedValue::Number(2.into()))],
             },
-            &Ty::EnumRef {
-                enum_name: "Color".to_owned(),
-            },
+            color_ty_idx,
         );
 
         let RenderedValue::EnumValue {
@@ -3642,7 +3644,7 @@ mod tests {
 
         let (bits, refs, hash) = cell_like_meta(&CellLike::Cell(Boc::encode_hex(&cell)));
         let rendered = render_openable_cell_like(
-            &Ty::Cell,
+            "cell",
             render_cell_like(&CellLike::Cell(Boc::encode_hex(&cell))),
             bits,
             refs,
@@ -3737,39 +3739,63 @@ mod tests {
 
     #[test]
     fn render_runtime_storage_chooses_storage_type_that_decodes_cell() {
-        let symbols = source_map_with_declarations(vec![
-            Declaration::Struct(AbiStruct {
-                name: "Storage".to_owned(),
-                ident_loc: loc(),
-                type_params: None,
-                prefix: None,
-                fields: vec![FieldInfo {
-                    name: "count".to_owned(),
-                    ty: Ty::UintN { n: 32 },
-                }],
-                custom_pack_unpack: None,
-            }),
-            Declaration::Struct(AbiStruct {
-                name: "DeploymentStorage".to_owned(),
-                ident_loc: loc(),
-                type_params: None,
-                prefix: None,
-                fields: vec![FieldInfo {
-                    name: "ready".to_owned(),
-                    ty: Ty::Bool,
-                }],
-                custom_pack_unpack: None,
-            }),
-        ]);
+        let mut unique_types = Vec::new();
+        let storage_ty_idx = add_ty(
+            &mut unique_types,
+            Ty::StructRef {
+                struct_name: "Storage".to_owned(),
+                type_args_ty_idx: None,
+            },
+        );
+        let deployment_ty_idx = add_ty(
+            &mut unique_types,
+            Ty::StructRef {
+                struct_name: "DeploymentStorage".to_owned(),
+                type_args_ty_idx: None,
+            },
+        );
+        let count_ty_idx = add_ty(&mut unique_types, Ty::UintN { n: 32 });
+        let ready_ty_idx = add_ty(&mut unique_types, Ty::Bool);
+        let symbols = source_map_with_declarations_and_types(
+            vec![
+                Declaration::Struct(AbiStruct {
+                    name: "Storage".to_owned(),
+                    ty_idx: storage_ty_idx,
+                    ident_loc: loc(),
+                    type_params: None,
+                    prefix: None,
+                    fields: vec![FieldInfo {
+                        name: "count".to_owned(),
+                        ty_idx: count_ty_idx,
+                    }],
+                    custom_pack_unpack: None,
+                }),
+                Declaration::Struct(AbiStruct {
+                    name: "DeploymentStorage".to_owned(),
+                    ty_idx: deployment_ty_idx,
+                    ident_loc: loc(),
+                    type_params: None,
+                    prefix: None,
+                    fields: vec![FieldInfo {
+                        name: "ready".to_owned(),
+                        ty_idx: ready_ty_idx,
+                    }],
+                    custom_pack_unpack: None,
+                }),
+            ],
+            unique_types.clone(),
+        );
         let abi = ContractABI {
+            unique_types,
             declarations: vec![
                 ABIDeclaration::Struct {
                     name: "Storage".to_owned(),
+                    ty_idx: storage_ty_idx,
                     type_params: None,
                     prefix: None,
                     fields: vec![ABIStructField {
                         name: "count".to_owned(),
-                        ty: Ty::UintN { n: 32 },
+                        ty_idx: count_ty_idx,
                         default_value: None,
                         description: String::new(),
                     }],
@@ -3778,11 +3804,12 @@ mod tests {
                 },
                 ABIDeclaration::Struct {
                     name: "DeploymentStorage".to_owned(),
+                    ty_idx: deployment_ty_idx,
                     type_params: None,
                     prefix: None,
                     fields: vec![ABIStructField {
                         name: "ready".to_owned(),
-                        ty: Ty::Bool,
+                        ty_idx: ready_ty_idx,
                         default_value: None,
                         description: String::new(),
                     }],
@@ -3791,14 +3818,8 @@ mod tests {
                 },
             ],
             storage: ABIStorage {
-                storage_ty: Some(Ty::StructRef {
-                    struct_name: "Storage".to_owned(),
-                    type_args: None,
-                }),
-                storage_at_deployment_ty: Some(Ty::StructRef {
-                    struct_name: "DeploymentStorage".to_owned(),
-                    type_args: None,
-                }),
+                storage_ty_idx: Some(storage_ty_idx),
+                storage_at_deployment_ty_idx: Some(deployment_ty_idx),
                 description: String::new(),
             },
             ..Default::default()
@@ -3936,7 +3957,7 @@ mod tests {
         })];
         let slots = [SlotValue::Live(&stack_values[0])];
 
-        let rendered = debug_print_from_stack(&SourceMap::default(), &slots, &Ty::Address);
+        let rendered = debug_print_from_stack(&source_map_with_types(vec![Ty::Address]), &slots, 0);
 
         let RenderedValue::Address {
             legacy_value,
@@ -3960,13 +3981,19 @@ mod tests {
                 "kind": "enum",
                 "name": "Color",
                 "ident_loc": [0, 0, 0, 0, 0],
-                "encoded_as": {"kind": "uintN", "n": 8},
+                "ty_idx": 1,
+                "encoded_as_ty_idx": 0,
                 "members": [
                     {"name": "Red", "value": "1"},
                     {"name": "Blue", "value": "2"}
                 ]
             }],
-            "unique_ty": [],
+            "unique_types": [
+                {"kind": "uintN", "n": 8},
+                {"kind": "EnumRef", "enum_name": "Color"}
+            ],
+            "struct_instantiations": [],
+            "alias_instantiations": [],
             "functions": [],
             "debug_marks": []
         });
@@ -3974,13 +4001,7 @@ mod tests {
 
         let stack_values = [VmStackValue::Integer("2".to_owned())];
         let slots = [SlotValue::Live(&stack_values[0])];
-        let rendered = debug_print_from_stack(
-            &symbols,
-            &slots,
-            &Ty::EnumRef {
-                enum_name: "Color".to_owned(),
-            },
-        );
+        let rendered = debug_print_from_stack(&symbols, &slots, 1);
 
         let RenderedValue::EnumValue {
             type_name,
@@ -4001,27 +4022,31 @@ mod tests {
     #[test]
     fn render_union_case_preserves_inner_children() {
         let cell = CellBuilder::new().build().unwrap();
-        let union_ty = Ty::Union {
-            variants: vec![
-                UnionVariant {
-                    variant_ty: Ty::Cell,
-                    prefix_str: String::new(),
-                    prefix_len: 0,
-                    is_prefix_implicit: None,
-                    stack_type_id: Some(1),
-                    stack_width: Some(1),
-                },
-                UnionVariant {
-                    variant_ty: Ty::Int,
-                    prefix_str: String::new(),
-                    prefix_len: 0,
-                    is_prefix_implicit: None,
-                    stack_type_id: Some(2),
-                    stack_width: Some(1),
-                },
-            ],
-            stack_width: Some(2),
-        };
+        let unique_types = vec![
+            Ty::Cell,
+            Ty::Int,
+            Ty::Union {
+                variants: vec![
+                    UnionVariant {
+                        variant_ty_idx: 0,
+                        prefix_num: 0,
+                        prefix_len: 0,
+                        is_prefix_implicit: None,
+                        stack_type_id: Some(1),
+                        stack_width: Some(1),
+                    },
+                    UnionVariant {
+                        variant_ty_idx: 1,
+                        prefix_num: 0,
+                        prefix_len: 0,
+                        is_prefix_implicit: None,
+                        stack_type_id: Some(2),
+                        stack_width: Some(1),
+                    },
+                ],
+                stack_width: Some(2),
+            },
+        ];
         let stack_values = [
             VmStackValue::Cell(CellLike::Cell(Boc::encode_hex(&cell))),
             VmStackValue::Integer("1".to_owned()),
@@ -4031,7 +4056,7 @@ mod tests {
             SlotValue::Live(&stack_values[1]),
         ];
 
-        let rendered = debug_print_from_stack(&SourceMap::default(), &slots, &union_ty);
+        let rendered = debug_print_from_stack(&source_map_with_types(unique_types), &slots, 2);
         let (dap_value, dap_type) = rendered.dap_parts();
 
         let RenderedValue::UnionCase {
@@ -4058,34 +4083,38 @@ mod tests {
 
     #[test]
     fn render_null_union_variant_has_no_value_field() {
-        let union_ty = Ty::Union {
-            variants: vec![
-                UnionVariant {
-                    variant_ty: Ty::NullLiteral,
-                    prefix_str: String::new(),
-                    prefix_len: 0,
-                    is_prefix_implicit: None,
-                    stack_type_id: Some(0),
-                    stack_width: Some(0),
-                },
-                UnionVariant {
-                    variant_ty: Ty::Bool,
-                    prefix_str: String::new(),
-                    prefix_len: 0,
-                    is_prefix_implicit: None,
-                    stack_type_id: Some(1),
-                    stack_width: Some(1),
-                },
-            ],
-            stack_width: Some(2),
-        };
+        let unique_types = vec![
+            Ty::NullLiteral,
+            Ty::Bool,
+            Ty::Union {
+                variants: vec![
+                    UnionVariant {
+                        variant_ty_idx: 0,
+                        prefix_num: 0,
+                        prefix_len: 0,
+                        is_prefix_implicit: None,
+                        stack_type_id: Some(0),
+                        stack_width: Some(0),
+                    },
+                    UnionVariant {
+                        variant_ty_idx: 1,
+                        prefix_num: 0,
+                        prefix_len: 0,
+                        is_prefix_implicit: None,
+                        stack_type_id: Some(1),
+                        stack_width: Some(1),
+                    },
+                ],
+                stack_width: Some(2),
+            },
+        ];
         let stack_values = [VmStackValue::Null, VmStackValue::Integer("0".to_owned())];
         let slots = [
             SlotValue::Live(&stack_values[0]),
             SlotValue::Live(&stack_values[1]),
         ];
 
-        let rendered = debug_print_from_stack(&SourceMap::default(), &slots, &union_ty);
+        let rendered = debug_print_from_stack(&source_map_with_types(unique_types), &slots, 2);
 
         let RenderedValue::UnionCase {
             variant_name,
@@ -4101,20 +4130,24 @@ mod tests {
 
     #[test]
     fn render_top_level_nullable_map_unpacks_tuple_as_stack_frame() {
-        let nullable_map_ty = Ty::Nullable {
-            inner: Box::new(Ty::MapKV {
-                k: Box::new(Ty::IntN { n: 32 }),
-                v: Box::new(Ty::IntN { n: 32 }),
-            }),
-            stack_type_id: Some(1),
-            stack_width: Some(2),
-        };
+        let unique_types = vec![
+            Ty::IntN { n: 32 },
+            Ty::MapKV {
+                key_ty_idx: 0,
+                value_ty_idx: 0,
+            },
+            Ty::Nullable {
+                inner_ty_idx: 1,
+                stack_type_id: Some(1),
+                stack_width: Some(2),
+            },
+        ];
         let present_empty_map =
             TupleItem::Tuple(Tuple(vec![TupleItem::Null, TupleItem::Int(1.into())]));
         let rendered = render_tuple_item_as_tolk_type(
-            &SourceMap::default(),
+            &source_map_with_types(unique_types),
             &present_empty_map,
-            &nullable_map_ty,
+            2,
         );
 
         let RenderedValue::Struct { type_name, fields } = rendered else {
@@ -4126,17 +4159,21 @@ mod tests {
 
     #[test]
     fn render_top_level_nullable_map_uses_zero_tag_for_null() {
-        let nullable_map_ty = Ty::Nullable {
-            inner: Box::new(Ty::MapKV {
-                k: Box::new(Ty::IntN { n: 32 }),
-                v: Box::new(Ty::IntN { n: 32 }),
-            }),
-            stack_type_id: Some(1),
-            stack_width: Some(2),
-        };
+        let unique_types = vec![
+            Ty::IntN { n: 32 },
+            Ty::MapKV {
+                key_ty_idx: 0,
+                value_ty_idx: 0,
+            },
+            Ty::Nullable {
+                inner_ty_idx: 1,
+                stack_type_id: Some(1),
+                stack_width: Some(2),
+            },
+        ];
         let null_map = TupleItem::Tuple(Tuple(vec![TupleItem::Null, TupleItem::Int(0.into())]));
         let rendered =
-            render_tuple_item_as_tolk_type(&SourceMap::default(), &null_map, &nullable_map_ty);
+            render_tuple_item_as_tolk_type(&source_map_with_types(unique_types), &null_map, 2);
 
         assert_eq!(rendered.dap_parts().0, "null");
         assert_eq!(
@@ -4147,8 +4184,11 @@ mod tests {
 
     #[test]
     fn render_nan_as_int_like_value() {
-        let rendered =
-            render_tuple_item_as_tolk_type(&SourceMap::default(), &TupleItem::Nan, &Ty::Int);
+        let rendered = render_tuple_item_as_tolk_type(
+            &source_map_with_types(vec![Ty::Int]),
+            &TupleItem::Nan,
+            0,
+        );
 
         assert_eq!(rendered.dap_parts().0, "NaN");
         assert_eq!(rendered.dap_parts().1.as_deref(), Some("int"));
@@ -4156,31 +4196,35 @@ mod tests {
 
     #[test]
     fn render_union_without_stack_width_falls_back_without_panic() {
-        let union_ty = Ty::Union {
-            variants: vec![
-                UnionVariant {
-                    variant_ty: Ty::Int,
-                    prefix_str: String::new(),
-                    prefix_len: 0,
-                    is_prefix_implicit: None,
-                    stack_type_id: Some(1),
-                    stack_width: Some(1),
-                },
-                UnionVariant {
-                    variant_ty: Ty::Cell,
-                    prefix_str: String::new(),
-                    prefix_len: 0,
-                    is_prefix_implicit: None,
-                    stack_type_id: Some(2),
-                    stack_width: Some(1),
-                },
-            ],
-            stack_width: None,
-        };
+        let unique_types = vec![
+            Ty::Int,
+            Ty::Cell,
+            Ty::Union {
+                variants: vec![
+                    UnionVariant {
+                        variant_ty_idx: 0,
+                        prefix_num: 0,
+                        prefix_len: 0,
+                        is_prefix_implicit: None,
+                        stack_type_id: Some(1),
+                        stack_width: Some(1),
+                    },
+                    UnionVariant {
+                        variant_ty_idx: 1,
+                        prefix_num: 0,
+                        prefix_len: 0,
+                        is_prefix_implicit: None,
+                        stack_type_id: Some(2),
+                        stack_width: Some(1),
+                    },
+                ],
+                stack_width: None,
+            },
+        ];
         let stack_values = [VmStackValue::Integer("7".to_owned())];
         let slots = [SlotValue::Live(&stack_values[0])];
 
-        let rendered = debug_print_from_stack(&SourceMap::default(), &slots, &union_ty);
+        let rendered = debug_print_from_stack(&source_map_with_types(unique_types), &slots, 2);
 
         assert_eq!(rendered.dap_parts().0, "union with unresolved layout");
         assert_eq!(rendered.dap_parts().1.as_deref(), Some("int | cell"));
@@ -4193,7 +4237,7 @@ mod tests {
         let cell = builder.build().unwrap();
         let hash = render_cell_hash(&cell);
         let rendered = render_openable_cell_like(
-            &Ty::Slice,
+            "slice",
             "slice{abcd}",
             Some(16),
             Some(0),
@@ -4230,7 +4274,7 @@ mod tests {
         let (bits, refs, hash) = cell_like_meta(&cell_like);
 
         let rendered = render_openable_cell_like(
-            &Ty::Builder,
+            "builder",
             render_builder(&builder_hex),
             bits,
             refs,
@@ -4312,23 +4356,34 @@ mod tests {
 
     #[test]
     fn render_runtime_out_actions_decodes_send_msg() {
-        let symbols = source_map_with_declarations(vec![Declaration::Struct(AbiStruct {
-            name: "Transfer".to_owned(),
-            ident_loc: loc(),
-            type_params: None,
-            prefix: Some(PrefixInfo {
-                prefix_str: "0xfeedbeef".to_owned(),
-                prefix_len: 32,
-            }),
-            fields: vec![],
-            custom_pack_unpack: None,
-        })]);
+        let transfer_ty_idx = 0;
+        let unique_types = vec![Ty::StructRef {
+            struct_name: "Transfer".to_owned(),
+            type_args_ty_idx: None,
+        }];
+        let symbols = source_map_with_declarations_and_types(
+            vec![Declaration::Struct(AbiStruct {
+                name: "Transfer".to_owned(),
+                ty_idx: transfer_ty_idx,
+                ident_loc: loc(),
+                type_params: None,
+                prefix: Some(PrefixInfo {
+                    prefix_num: 0xfeedbeef,
+                    prefix_len: 32,
+                }),
+                fields: vec![],
+                custom_pack_unpack: None,
+            })],
+            unique_types.clone(),
+        );
         let abi = ContractABI {
+            unique_types,
             declarations: vec![ABIDeclaration::Struct {
                 name: "Transfer".to_owned(),
+                ty_idx: transfer_ty_idx,
                 type_params: None,
                 prefix: Some(ABIOpcode {
-                    prefix_str: "0xfeedbeef".to_owned(),
+                    prefix_num: 0xfeedbeef,
                     prefix_len: 32,
                 }),
                 fields: vec![],
@@ -4336,10 +4391,7 @@ mod tests {
                 overrides_client_type: false,
             }],
             outgoing_messages: vec![ABIOutgoingMessage {
-                body_ty: Ty::StructRef {
-                    struct_name: "Transfer".to_owned(),
-                    type_args: None,
-                },
+                body_ty_idx: transfer_ty_idx,
                 description: String::new(),
             }],
             ..Default::default()

--- a/crates/acton-debug/src/multi/replayer_session.rs
+++ b/crates/acton-debug/src/multi/replayer_session.rs
@@ -267,35 +267,25 @@ impl ReplayerDebugSession {
                 .cloned()
                 .ok_or_else(|| anyhow!("Unknown frame id {frame_id}"))?;
             if let Some(locals) = locator.snapshot_locals {
-                let source_map_context = self
-                    .contexts
-                    .get(locator.context_idx)
-                    .and_then(|ctx| ctx.try_borrow().ok());
-                return evaluate_expression(
-                    &locals,
-                    source_map_context
-                        .as_ref()
-                        .map(|ctx| ctx.replayer.source_map()),
-                    expression,
-                );
+                return evaluate_expression(&locals, expression);
             }
             let Some(ctx) = self.contexts.get(locator.context_idx) else {
-                return evaluate_expression(&[], None, expression);
+                return evaluate_expression(&[], expression);
             };
             let Ok(ctx) = ctx.try_borrow() else {
-                return evaluate_expression(&[], None, expression);
+                return evaluate_expression(&[], expression);
             };
             let locals = ctx.replayer.locals_for_frame(locator.depth_from_top);
-            evaluate_expression(&locals, Some(ctx.replayer.source_map()), expression)
+            evaluate_expression(&locals, expression)
         } else {
             let Some(ctx) = self.active_context() else {
-                return evaluate_expression(&[], None, expression);
+                return evaluate_expression(&[], expression);
             };
             let Ok(ctx) = ctx.try_borrow() else {
-                return evaluate_expression(&[], None, expression);
+                return evaluate_expression(&[], expression);
             };
             let locals = ctx.replayer.locals_for_frame(0);
-            evaluate_expression(&locals, Some(ctx.replayer.source_map()), expression)
+            evaluate_expression(&locals, expression)
         }
     }
 

--- a/crates/acton-debug/src/single/dap.rs
+++ b/crates/acton-debug/src/single/dap.rs
@@ -210,7 +210,7 @@ impl DapState {
         expression: &str,
     ) -> anyhow::Result<RenderedValue> {
         let Some(replayer) = self.replayer.as_ref() else {
-            return evaluate_expression(&[], None, expression);
+            return evaluate_expression(&[], expression);
         };
 
         let locals = match frame_id {
@@ -225,7 +225,7 @@ impl DapState {
             None => replayer.locals_for_frame(0),
         };
 
-        evaluate_expression(&locals, Some(replayer.source_map()), expression)
+        evaluate_expression(&locals, expression)
     }
 }
 

--- a/crates/acton-localnet-ui/package.json
+++ b/crates/acton-localnet-ui/package.json
@@ -21,7 +21,7 @@
     "@ton/core": "0.62.0",
     "@types/react-router-dom": "^5.3.3",
     "buffer": "^6.0.3",
-    "gen-typescript-from-tolk-dev": "^0.2.4",
+    "gen-typescript-from-tolk-dev": "^0.3.1",
     "lucide-react": "^0.474.0",
     "react-d3-tree": "^3.6.6",
     "react-icons": "^5.5.0",

--- a/crates/acton-localnet-ui/src/explorer/api/compilerAbi.ts
+++ b/crates/acton-localnet-ui/src/explorer/api/compilerAbi.ts
@@ -1,4 +1,5 @@
-import type {ContractABI} from "gen-typescript-from-tolk-dev"
+import type {ABIStruct, ContractABI, Ty} from "gen-typescript-from-tolk-dev"
+import {SymTable} from "gen-typescript-from-tolk-dev"
 
 import {parseAddress} from "../components/utils"
 
@@ -30,100 +31,62 @@ export function buildMessageNamesByOpcodeNumber(
     return out
   }
 
-  const structDeclarations = new Map<string, Record<string, unknown>>()
-  const aliasDeclarations = new Map<string, Record<string, unknown>>()
-
-  for (const declaration of abi.declarations ?? []) {
-    const item = asRecord(declaration)
-    const kind = typeof item?.kind === "string" ? item.kind : undefined
-    const name = typeof item?.name === "string" ? item.name : undefined
-    if (!item || !kind || !name) {
-      continue
-    }
-    if (kind === "struct") {
-      structDeclarations.set(name, item)
-    } else if (kind === "alias") {
-      aliasDeclarations.set(name, item)
-    }
-  }
+  const symbols = new SymTable(
+    abi.declarations,
+    abi.unique_types,
+    abi.struct_instantiations,
+    abi.alias_instantiations,
+  )
 
   for (const message of abi[messageKey] ?? []) {
-    const bodyTy = asRecord(asRecord(message)?.body_ty)
-    if (!bodyTy) {
-      continue
-    }
-    collectMessageEntries(bodyTy, structDeclarations, aliasDeclarations, out, new Set())
+    collectMessageEntries(message.body_ty_idx, symbols, out, new Set())
   }
 
   return out
 }
 
 function collectMessageEntries(
-  bodyTy: Record<string, unknown>,
-  structDeclarations: Map<string, Record<string, unknown>>,
-  aliasDeclarations: Map<string, Record<string, unknown>>,
+  bodyTyIdx: number,
+  symbols: SymTable,
   out: Map<number, string>,
-  visitedAliases: Set<string>,
+  visitedTyIdx: Set<number>,
 ): void {
-  const kind = typeof bodyTy.kind === "string" ? bodyTy.kind : undefined
-  if (!kind) {
+  if (visitedTyIdx.has(bodyTyIdx)) {
     return
   }
+  visitedTyIdx.add(bodyTyIdx)
+
+  const bodyTy = tryTyByIdx(symbols, bodyTyIdx)
+  const kind = bodyTy?.kind
 
   switch (kind) {
     case "StructRef": {
-      const structName = typeof bodyTy.struct_name === "string" ? bodyTy.struct_name : undefined
-      if (!structName) {
-        return
-      }
-      const declaration = structDeclarations.get(structName)
-      const prefix = asRecord(declaration?.prefix)
+      const declaration = tryGetStruct(symbols, bodyTy.struct_name)
       const opcode = normalizeOpcodePrefix(
-        typeof prefix?.prefix_str === "string" ? prefix.prefix_str : undefined,
-        typeof prefix?.prefix_len === "number" ? prefix.prefix_len : undefined,
+        declaration?.prefix?.prefix_num,
+        declaration?.prefix?.prefix_len,
       )
       if (opcode !== undefined) {
-        out.set(opcode, structName)
+        out.set(opcode, bodyTy.struct_name)
       }
       return
     }
     case "AliasRef": {
-      const aliasName = typeof bodyTy.alias_name === "string" ? bodyTy.alias_name : undefined
-      if (!aliasName || visitedAliases.has(aliasName)) {
+      const targetTyIdx = tryAliasTargetTyIdx(symbols, bodyTyIdx)
+      if (targetTyIdx === undefined) {
         return
       }
-      visitedAliases.add(aliasName)
-      const declaration = aliasDeclarations.get(aliasName)
-      const targetTy = asRecord(declaration?.target_ty)
-      if (declaration && targetTy) {
-          collectMessageEntries(targetTy, structDeclarations, aliasDeclarations, out, visitedAliases)
-        }
-      visitedAliases.delete(aliasName)
+      collectMessageEntries(targetTyIdx, symbols, out, visitedTyIdx)
       return
     }
     case "union": {
-      const variants = Array.isArray(bodyTy.variants) ? bodyTy.variants : []
-      for (const variant of variants) {
-        const item = asRecord(variant)
-        const variantTy = asRecord(item?.variant_ty)
-        if (!item || !variantTy) {
-          continue
-        }
-        const opcode = normalizeOpcodePrefix(
-          typeof item.prefix_str === "string" ? item.prefix_str : undefined,
-          typeof item.prefix_len === "number" ? item.prefix_len : undefined,
-        )
-        const name = resolveMessageTypeName(variantTy, aliasDeclarations, new Set(visitedAliases))
+      for (const variant of bodyTy.variants) {
+        const opcode = normalizeOpcodePrefix(variant.prefix_num, variant.prefix_len)
+        const name = resolveMessageTypeName(variant.variant_ty_idx, symbols, new Set(visitedTyIdx))
         if (opcode !== undefined && name) {
           out.set(opcode, name)
         } else {
-          collectMessageEntries(
-            variantTy,
-            structDeclarations,
-            aliasDeclarations,
-            out,
-            new Set(visitedAliases),
-          )
+          collectMessageEntries(variant.variant_ty_idx, symbols, out, new Set(visitedTyIdx))
         }
       }
       return
@@ -131,17 +94,7 @@ function collectMessageEntries(
     case "nullable":
     case "cellOf":
     case "lispListOf": {
-      const inner = asRecord(bodyTy.inner)
-      if (!inner) {
-        return
-      }
-      collectMessageEntries(
-        inner,
-        structDeclarations,
-        aliasDeclarations,
-        out,
-        visitedAliases,
-      )
+      collectMessageEntries(bodyTy.inner_ty_idx, symbols, out, visitedTyIdx)
       return
     }
     default: {
@@ -151,34 +104,33 @@ function collectMessageEntries(
 }
 
 function resolveMessageTypeName(
-  bodyTy: Record<string, unknown>,
-  aliasDeclarations: Map<string, Record<string, unknown>>,
-  visitedAliases: Set<string>,
+  bodyTyIdx: number,
+  symbols: SymTable,
+  visitedTyIdx: Set<number>,
 ): string | undefined {
-  const kind = typeof bodyTy.kind === "string" ? bodyTy.kind : undefined
-  if (!kind) {
+  if (visitedTyIdx.has(bodyTyIdx)) {
     return undefined
   }
+  visitedTyIdx.add(bodyTyIdx)
+
+  const bodyTy = tryTyByIdx(symbols, bodyTyIdx)
+  const kind = bodyTy?.kind
 
   switch (kind) {
     case "StructRef": {
-      return typeof bodyTy.struct_name === "string" ? bodyTy.struct_name : undefined
+      return bodyTy.struct_name
     }
     case "AliasRef": {
-      const aliasName = typeof bodyTy.alias_name === "string" ? bodyTy.alias_name : undefined
-      if (!aliasName || visitedAliases.has(aliasName)) {
+      const targetTyIdx = tryAliasTargetTyIdx(symbols, bodyTyIdx)
+      if (targetTyIdx === undefined) {
         return undefined
       }
-      visitedAliases.add(aliasName)
-      const declaration = aliasDeclarations.get(aliasName)
-      const targetTy = asRecord(declaration?.target_ty)
-      return targetTy ? resolveMessageTypeName(targetTy, aliasDeclarations, visitedAliases) : undefined
+      return resolveMessageTypeName(targetTyIdx, symbols, visitedTyIdx)
     }
     case "nullable":
     case "cellOf":
     case "lispListOf": {
-      const inner = asRecord(bodyTy.inner)
-      return inner ? resolveMessageTypeName(inner, aliasDeclarations, visitedAliases) : undefined
+      return resolveMessageTypeName(bodyTy.inner_ty_idx, symbols, visitedTyIdx)
     }
     default: {
       return undefined
@@ -186,37 +138,35 @@ function resolveMessageTypeName(
   }
 }
 
-function asRecord(value: unknown): Record<string, unknown> | undefined {
-  return value && typeof value === "object" ? (value as Record<string, unknown>) : undefined
-}
-
-function normalizeOpcodePrefix(prefix?: string, prefixLen?: number): number | undefined {
-  if (!prefix || prefixLen !== 32) {
-    return undefined
-  }
-  return parseOpcode(prefix)
-}
-
-function parseOpcode(opcode: string): number | undefined {
-  const normalized = opcode.trim()
-  if (!normalized) {
-    return undefined
-  }
-
+function tryTyByIdx(symbols: SymTable, tyIdx: number): Ty | undefined {
   try {
-    const value =
-      normalized.startsWith("0x") || normalized.startsWith("0X")
-        ? Number.parseInt(normalized.slice(2), 16)
-        : Number.parseInt(normalized, 10)
-
-    if (!Number.isInteger(value) || value < 0 || value > 0xff_ff_ff_ff) {
-      return undefined
-    }
-
-    return value
+    return symbols.tyByIdx(tyIdx)
   } catch {
     return undefined
   }
+}
+
+function tryGetStruct(symbols: SymTable, structName: string): ABIStruct | undefined {
+  try {
+    return symbols.getStruct(structName)
+  } catch {
+    return undefined
+  }
+}
+
+function tryAliasTargetTyIdx(symbols: SymTable, tyIdx: number): number | undefined {
+  try {
+    return symbols.aliasTargetOf(tyIdx).ty_idx
+  } catch {
+    return undefined
+  }
+}
+
+function normalizeOpcodePrefix(prefixNum?: number, prefixLen?: number): number | undefined {
+  if (prefixLen !== 32 || prefixNum === undefined) {
+    return undefined
+  }
+  return prefixNum
 }
 
 function formatOpcode(opcode: number): string {

--- a/crates/acton-shared-ui/package.json
+++ b/crates/acton-shared-ui/package.json
@@ -19,7 +19,7 @@
     "@ton/core": "0.62.0",
     "buffer": "^6.0.3",
     "clsx": "^2.1.1",
-    "gen-typescript-from-tolk-dev": "^0.2.4",
+    "gen-typescript-from-tolk-dev": "^0.3.1",
     "lucide-react": "^0.474.0",
     "react-d3-tree": "^3.6.6",
     "react-icons": "^5.5.0",

--- a/crates/acton-shared-ui/src/utils/messageBody.ts
+++ b/crates/acton-shared-ui/src/utils/messageBody.ts
@@ -1,7 +1,12 @@
 import {Address, Builder, Cell, Dictionary, Slice, loadShardAccount} from "@ton/core"
 import type {Message, MessageRelaxed} from "@ton/core"
-import type {ContractABI, Ty} from "gen-typescript-from-tolk-dev"
-import {DynamicCtx, renderTy, unpackFromSliceDynamic} from "gen-typescript-from-tolk-dev"
+import type {ContractABI, SymTable, Ty} from "gen-typescript-from-tolk-dev"
+import {
+  DynamicCtx,
+  SymTable as CompilerSymTable,
+  renderTy,
+  unpackFromSliceDynamic,
+} from "gen-typescript-from-tolk-dev"
 
 import type {BackendContractInfo} from "@/types"
 import type {
@@ -13,11 +18,11 @@ import type {
 } from "@/types/transaction"
 
 interface MessageCandidate {
-  readonly body_ty: Ty
+  readonly body_ty_idx: number
 }
 
 interface DeclarationCandidate {
-  readonly body_ty: Ty
+  readonly body_ty_idx: number
   readonly priority: number
 }
 
@@ -29,59 +34,32 @@ interface ParsableMessage {
 const BOUNCED_BODY_PREFIX = 0xff_ff_ff_ff
 const RICH_BOUNCE_BODY_PREFIX = 0xff_ff_ff_fe
 
-const getBodyTypeName = (bodyTy: Ty): string => {
-  switch (bodyTy.kind) {
-    case "StructRef": {
-      return bodyTy.struct_name
-    }
-    case "AliasRef": {
-      return bodyTy.alias_name
-    }
-    case "EnumRef": {
-      return bodyTy.enum_name
-    }
-    default: {
-      return renderTy(bodyTy)
-    }
-  }
+const getBodyTypeName = (symbols: SymTable, bodyTyIdx: number): string => {
+  return renderTy(symbols, bodyTyIdx)
 }
 
-const getBodyTypeKey = (bodyTy: Ty): string => {
-  switch (bodyTy.kind) {
-    case "StructRef": {
-      return `StructRef:${bodyTy.struct_name}`
-    }
-    case "AliasRef": {
-      return `AliasRef:${bodyTy.alias_name}`
-    }
-    case "EnumRef": {
-      return `EnumRef:${bodyTy.enum_name}`
-    }
-    default: {
-      return renderTy(bodyTy)
-    }
-  }
+const getBodyTypeKey = (bodyTyIdx: number): string => {
+  return `ty#${bodyTyIdx}`
 }
 
-const parsePrefixNumber = (prefixStr: string): number | undefined => {
-  try {
-    return Number(BigInt(prefixStr))
-  } catch {
-    return undefined
-  }
-}
+type AbiDeclaration = Readonly<ContractABI["declarations"][number]>
 
-const getDeclarationOpcode = (declaration: ContractABI["declarations"][number]): number | undefined => {
-  if (declaration.kind === "struct" && declaration.prefix?.prefix_len === 32) {
-    return parsePrefixNumber(declaration.prefix.prefix_str)
+const createSymTable = (abi: ContractABI): SymTable =>
+  new CompilerSymTable(
+    abi.declarations,
+    abi.unique_types,
+    abi.struct_instantiations,
+    abi.alias_instantiations,
+  )
+
+const getDeclarationOpcode = (declaration: AbiDeclaration | undefined): number | undefined => {
+  if (declaration?.kind === "struct" && declaration.prefix?.prefix_len === 32) {
+    return declaration.prefix.prefix_num
   }
   return undefined
 }
 
-const findDeclaration = (
-  abi: ContractABI,
-  bodyTy: Ty,
-): ContractABI["declarations"][number] | undefined => {
+const findDeclaration = (abi: ContractABI, bodyTy: Ty): AbiDeclaration | undefined => {
   switch (bodyTy.kind) {
     case "StructRef": {
       return abi.declarations.find(
@@ -106,13 +84,27 @@ const findDeclaration = (
 
 const resolveOpcodeNameFromBodyType = (
   abi: ContractABI,
-  bodyTy: Ty,
+  symbols: SymTable,
+  bodyTyIdx: number,
   opcode: number,
+  visitedTyIdx = new Set<number>(),
 ): string | undefined => {
+  if (visitedTyIdx.has(bodyTyIdx)) {
+    return undefined
+  }
+  visitedTyIdx.add(bodyTyIdx)
+
+  let bodyTy: Ty
+  try {
+    bodyTy = symbols.tyByIdx(bodyTyIdx)
+  } catch {
+    return undefined
+  }
+
   if (bodyTy.kind === "union") {
     for (const variant of bodyTy.variants) {
-      if (variant.prefix_len === 32 && parsePrefixNumber(variant.prefix_str) === opcode) {
-        return getBodyTypeName(variant.variant_ty)
+      if (variant.prefix_len === 32 && variant.prefix_num === opcode) {
+        return getBodyTypeName(symbols, variant.variant_ty_idx)
       }
     }
   }
@@ -127,7 +119,13 @@ const resolveOpcodeNameFromBodyType = (
   }
 
   if (declaration.kind === "alias") {
-    return resolveOpcodeNameFromBodyType(abi, declaration.target_ty, opcode)
+    let targetTyIdx = declaration.target_ty_idx
+    try {
+      targetTyIdx = symbols.aliasTargetOf(bodyTyIdx).ty_idx
+    } catch {
+      // Non-AliasRef ty_idx can still reach an alias declaration only for malformed ABI.
+    }
+    return resolveOpcodeNameFromBodyType(abi, symbols, targetTyIdx, opcode, visitedTyIdx)
   }
 
   if (declaration.kind === "enum") {
@@ -145,6 +143,7 @@ export const resolveAbiOpcodeName = (
   if (!abi) {
     return undefined
   }
+  const symbols = createSymTable(abi)
 
   const messages =
     direction === "outgoing"
@@ -154,7 +153,7 @@ export const resolveAbiOpcodeName = (
         : [...abi.incoming_messages, ...abi.incoming_external, ...abi.outgoing_messages]
 
   for (const message of messages) {
-    const name = resolveOpcodeNameFromBodyType(abi, message.body_ty, opcode)
+    const name = resolveOpcodeNameFromBodyType(abi, symbols, message.body_ty_idx, opcode)
     if (name) {
       return name
     }
@@ -179,10 +178,10 @@ const getDeclarationCandidates = (
         const matchesOpcode =
           opcode !== undefined &&
           declaration.prefix?.prefix_len === 32 &&
-          parsePrefixNumber(declaration.prefix.prefix_str) === opcode
+          declaration.prefix.prefix_num === opcode
 
         candidates.push({
-          body_ty: {kind: "StructRef", struct_name: declaration.name},
+          body_ty_idx: declaration.ty_idx,
           priority: matchesOpcode ? 0 : declaration.prefix ? 1 : 2,
         })
         break
@@ -193,14 +192,14 @@ const getDeclarationCandidates = (
         }
 
         candidates.push({
-          body_ty: {kind: "AliasRef", alias_name: declaration.name},
+          body_ty_idx: declaration.ty_idx,
           priority: 3,
         })
         break
       }
       case "enum": {
         candidates.push({
-          body_ty: {kind: "EnumRef", enum_name: declaration.name},
+          body_ty_idx: declaration.ty_idx,
           priority: 4,
         })
         break
@@ -216,22 +215,20 @@ const getIncomingCandidates = (
   isInternal: boolean,
   opcode: number | undefined,
 ): readonly MessageCandidate[] => {
-  const directCandidates = isInternal
-    ? abi.incoming_messages
-    : abi.incoming_external
+  const directCandidates = isInternal ? abi.incoming_messages : abi.incoming_external
   if (!isInternal) {
     return directCandidates
   }
 
   const deduped = new Map<string, MessageCandidate>()
   for (const candidate of directCandidates) {
-    deduped.set(getBodyTypeKey(candidate.body_ty), candidate)
+    deduped.set(getBodyTypeKey(candidate.body_ty_idx), candidate)
   }
 
   for (const candidate of getDeclarationCandidates(abi, opcode)) {
-    const key = getBodyTypeKey(candidate.body_ty)
+    const key = getBodyTypeKey(candidate.body_ty_idx)
     if (!deduped.has(key)) {
-      deduped.set(key, {body_ty: candidate.body_ty})
+      deduped.set(key, {body_ty_idx: candidate.body_ty_idx})
     }
   }
 
@@ -245,13 +242,13 @@ const getOutgoingCandidates = (
   const deduped = new Map<string, MessageCandidate>()
 
   for (const candidate of abi.outgoing_messages) {
-    deduped.set(getBodyTypeKey(candidate.body_ty), candidate)
+    deduped.set(getBodyTypeKey(candidate.body_ty_idx), candidate)
   }
 
   for (const candidate of getDeclarationCandidates(abi, opcode)) {
-    const key = getBodyTypeKey(candidate.body_ty)
+    const key = getBodyTypeKey(candidate.body_ty_idx)
     if (!deduped.has(key)) {
-      deduped.set(key, {body_ty: candidate.body_ty})
+      deduped.set(key, {body_ty_idx: candidate.body_ty_idx})
     }
   }
 
@@ -423,13 +420,13 @@ const tryDecodeMessageWithCandidates = (
   for (const candidate of candidates) {
     const parser = baseSlice.clone()
     try {
-      const decoded: unknown = unpackFromSliceDynamic(ctx, candidate.body_ty, parser) as unknown
+      const decoded: unknown = unpackFromSliceDynamic(ctx, candidate.body_ty_idx, parser) as unknown
       if (parser.remainingBits !== 0 || parser.remainingRefs !== 0) {
         continue
       }
 
       return {
-        name: getBodyTypeName(candidate.body_ty),
+        name: getBodyTypeName(ctx.symbols, candidate.body_ty_idx),
         value: toParsedValue(decoded),
       }
     } catch {
@@ -458,10 +455,16 @@ const tryDecodeOutgoingMessageWithAbi = (
   return tryDecodeMessageWithCandidates(message, abi, candidates)
 }
 
-const getStorageCandidates = (abi: ContractABI): readonly Ty[] => {
-  const candidates = [abi.storage.storage_ty, abi.storage.storage_at_deployment_ty]
-    .filter((ty): ty is Ty => ty !== undefined && ty.kind !== "nullLiteral")
-    .map(ty => [getBodyTypeKey(ty), ty] as const)
+const getStorageCandidates = (compilerAbi: ContractABI): readonly number[] => {
+  const candidates = [
+    compilerAbi.storage.storage_ty_idx,
+    compilerAbi.storage.storage_at_deployment_ty_idx,
+  ]
+    .filter(
+      (tyIdx): tyIdx is number =>
+        tyIdx !== undefined && compilerAbi.unique_types[tyIdx]?.kind !== "nullLiteral",
+    )
+    .map(tyIdx => [getBodyTypeKey(tyIdx), tyIdx] as const)
 
   return [...new Map(candidates).values()]
 }
@@ -500,7 +503,7 @@ const tryDecodeStorageSliceWithAbi = (
       }
 
       return {
-        name: getBodyTypeName(candidate),
+        name: getBodyTypeName(ctx.symbols, candidate),
         value: toParsedValue(decoded),
       }
     } catch {

--- a/crates/acton-test-ui/package.json
+++ b/crates/acton-test-ui/package.json
@@ -22,7 +22,7 @@
     "bignumber.js": "^9.3.1",
     "buffer": "^6.0.3",
     "d3-hierarchy": "^1.1.9",
-    "gen-typescript-from-tolk-dev": "^0.2.4",
+    "gen-typescript-from-tolk-dev": "^0.3.1",
     "react-d3-tree": "^3.6.6",
     "react-icons": "^5.5.0",
     "shiki": "^3.22.0",

--- a/crates/tolk-compiler/assets/tolk-stdlib/reflection.tolk
+++ b/crates/tolk-compiler/assets/tolk-stdlib/reflection.tolk
@@ -28,14 +28,14 @@ fun reflect.typeNameOf<T>(): string
 fun reflect.typeNameOfObject<T>(anyVariable: T): string
     builtin
 
-/// Get ABI-JSON type description of any T for compile-time reflection.
+/// Get unique ty_idx (from `out.symbolTypes.json`) of any type T.
 @pure
-fun reflect.typeAbiJsonOf<T>(): string
+fun reflect.typeUniqueIdxOf<T>(): int
     builtin
 
-/// Get ABI-JSON type description of any object for compile-time reflection.
+/// Get unique ty_idx (from `out.symbolTypes.json`) of any object.
 @pure
-fun reflect.typeAbiJsonOfObject<T>(anyVariable: T): string
+fun reflect.typeUniqueIdxOfObject<T>(anyVariable: T): int
     builtin
 
 /// Returns the number of stack slots a type T occupies.

--- a/crates/tolk-compiler/src/abi.rs
+++ b/crates/tolk-compiler/src/abi.rs
@@ -1,5 +1,6 @@
 use crate::source_map::SourceMap;
-pub use crate::types_kernel::{Ty, UnionVariant};
+pub use crate::types_kernel::{AliasInstantiation, StructInstantiation, Ty, TyIdx, UnionVariant};
+use crate::types_kernel::{TyResolver, render_param_ty, render_ty};
 use anyhow::anyhow;
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashSet};
@@ -40,7 +41,7 @@ pub enum ABIConstValue {
     #[serde(rename = "castTo")]
     CastTo {
         inner: Box<ABIConstValue>,
-        cast_to: Ty,
+        cast_to_ty_idx: TyIdx,
     },
 
     #[serde(rename = "null")]
@@ -48,11 +49,11 @@ pub enum ABIConstValue {
 }
 
 /// =======================
-/// Declarations (`used_symbols` -> declarations[])
+/// ABI declarations exported by the compiler.
 /// =======================
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ABIOpcode {
-    pub prefix_str: String,
+    pub prefix_num: u64,
     pub prefix_len: i32,
 }
 
@@ -67,7 +68,7 @@ pub struct ABICustomPackUnpack {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ABIStructField {
     pub name: String,
-    pub ty: Ty,
+    pub ty_idx: TyIdx,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub default_value: Option<ABIConstValue>,
@@ -91,6 +92,8 @@ pub enum ABIDeclaration {
     Struct {
         name: String,
 
+        ty_idx: TyIdx,
+
         #[serde(skip_serializing_if = "Option::is_none")]
         type_params: Option<Vec<String>>,
 
@@ -110,7 +113,9 @@ pub enum ABIDeclaration {
     Alias {
         name: String,
 
-        target_ty: Ty,
+        ty_idx: TyIdx,
+
+        target_ty_idx: TyIdx,
 
         #[serde(skip_serializing_if = "Option::is_none")]
         type_params: Option<Vec<String>>,
@@ -122,7 +127,8 @@ pub enum ABIDeclaration {
     #[serde(rename = "enum")]
     Enum {
         name: String,
-        encoded_as: Ty,
+        ty_idx: TyIdx,
+        encoded_as_ty_idx: TyIdx,
         members: Vec<ABIEnumMember>,
 
         #[serde(skip_serializing_if = "Option::is_none")]
@@ -136,7 +142,7 @@ pub enum ABIDeclaration {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ABIFunctionParameter {
     pub name: String,
-    pub ty: Ty,
+    pub ty_idx: TyIdx,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub default_value: Option<ABIConstValue>,
     #[serde(default, skip_serializing_if = "String::is_empty")]
@@ -148,14 +154,14 @@ pub struct ABIGetMethod {
     pub tvm_method_id: i32,
     pub name: String,
     pub parameters: Vec<ABIFunctionParameter>,
-    pub return_ty: Ty,
+    pub return_ty_idx: TyIdx,
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub description: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ABIInternalMessage {
-    pub body_ty: Ty,
+    pub body_ty_idx: TyIdx,
 
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub description: String,
@@ -163,14 +169,14 @@ pub struct ABIInternalMessage {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ABIExternalMessage {
-    pub body_ty: Ty,
+    pub body_ty_idx: TyIdx,
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub description: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ABIOutgoingMessage {
-    pub body_ty: Ty,
+    pub body_ty_idx: TyIdx,
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub description: String,
 }
@@ -178,10 +184,10 @@ pub struct ABIOutgoingMessage {
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct ABIStorage {
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub storage_ty: Option<Ty>,
+    pub storage_ty_idx: Option<TyIdx>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub storage_at_deployment_ty: Option<Ty>,
+    pub storage_at_deployment_ty_idx: Option<TyIdx>,
 
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub description: String,
@@ -218,6 +224,9 @@ pub struct ContractABI {
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub description: String,
 
+    pub unique_types: Vec<Ty>,
+    pub struct_instantiations: Vec<StructInstantiation>,
+    pub alias_instantiations: Vec<AliasInstantiation>,
     pub declarations: Vec<ABIDeclaration>,
 
     pub incoming_messages: Vec<ABIInternalMessage>,
@@ -243,6 +252,108 @@ pub struct ABIResolvedStruct {
 }
 
 impl ContractABI {
+    #[must_use]
+    pub fn ty_by_idx(&self, ty_idx: TyIdx) -> Option<&Ty> {
+        self.unique_types.get(ty_idx)
+    }
+
+    #[must_use]
+    pub fn render_type(&self, ty_idx: TyIdx) -> String {
+        render_ty(self, ty_idx)
+    }
+
+    #[must_use]
+    pub fn render_param_type(&self, ty_idx: TyIdx) -> String {
+        render_param_ty(self, ty_idx)
+    }
+
+    #[must_use]
+    pub fn is_typed_cell(&self, ty_idx: TyIdx) -> bool {
+        self.ty_by_idx(ty_idx).is_some_and(Ty::is_typed_cell)
+    }
+
+    #[must_use]
+    pub fn typed_cell_payload_default_value(&self, ty_idx: TyIdx) -> Option<String> {
+        let Ty::CellOf { inner_ty_idx } = self.ty_by_idx(ty_idx)? else {
+            return None;
+        };
+        Some(default_value_impl(
+            self,
+            *inner_ty_idx,
+            &BTreeMap::new(),
+            &mut HashSet::new(),
+        ))
+    }
+
+    #[must_use]
+    pub fn default_value(&self, ty_idx: TyIdx) -> String {
+        default_value_impl(self, ty_idx, &BTreeMap::new(), &mut HashSet::new())
+    }
+
+    pub fn struct_fields_of(&self, ty_idx: TyIdx) -> anyhow::Result<Vec<ABIStructField>> {
+        let ty = self
+            .ty_by_idx(ty_idx)
+            .ok_or_else(|| anyhow!("ABI ty_idx {ty_idx} was not found"))?;
+        let Ty::StructRef { struct_name, .. } = ty else {
+            anyhow::bail!(
+                "expected StructRef at ty_idx={ty_idx}, got {}",
+                self.render_type(ty_idx)
+            );
+        };
+
+        if let Some(inst) = self
+            .struct_instantiations
+            .iter()
+            .find(|inst| inst.ty_idx == ty_idx)
+        {
+            let (_, fields, _) = find_struct_decl(self, struct_name)
+                .ok_or_else(|| anyhow!("Struct {struct_name} referenced by ABI was not found"))?;
+            if fields.len() != inst.monomorphic_fields_ty_idx.len() {
+                anyhow::bail!(
+                    "struct instantiation `{}` has {} monomorphic fields, expected {}",
+                    inst.struct_name,
+                    inst.monomorphic_fields_ty_idx.len(),
+                    fields.len()
+                );
+            }
+            return Ok(fields
+                .iter()
+                .zip(&inst.monomorphic_fields_ty_idx)
+                .map(|(field, &field_ty_idx)| ABIStructField {
+                    ty_idx: field_ty_idx,
+                    ..field.clone()
+                })
+                .collect());
+        }
+
+        let (_, fields, _) = find_struct_decl(self, struct_name)
+            .ok_or_else(|| anyhow!("Struct {struct_name} referenced by ABI was not found"))?;
+        Ok(fields.to_vec())
+    }
+
+    pub fn alias_target_of(&self, ty_idx: TyIdx) -> anyhow::Result<TyIdx> {
+        let ty = self
+            .ty_by_idx(ty_idx)
+            .ok_or_else(|| anyhow!("ABI ty_idx {ty_idx} was not found"))?;
+        let Ty::AliasRef { alias_name, .. } = ty else {
+            anyhow::bail!(
+                "expected AliasRef at ty_idx={ty_idx}, got {}",
+                self.render_type(ty_idx)
+            );
+        };
+
+        if let Some(inst) = self
+            .alias_instantiations
+            .iter()
+            .find(|inst| inst.ty_idx == ty_idx)
+        {
+            return Ok(inst.monomorphic_target_ty_idx);
+        }
+
+        find_alias_decl(self, alias_name)
+            .ok_or_else(|| anyhow!("Alias {alias_name} referenced by ABI was not found"))
+    }
+
     #[must_use]
     pub fn find_get_method_by_id(&self, id: i32) -> Option<&ABIGetMethod> {
         self.get_methods
@@ -271,8 +382,7 @@ impl ContractABI {
             }
 
             let matches_opcode = prefix.as_ref().is_some_and(|prefix| {
-                prefix.prefix_len == 32
-                    && parse_abi_prefix_number(&prefix.prefix_str) == Some(opcode)
+                prefix.prefix_len == 32 && prefix.prefix_num == u64::from(opcode)
             });
             matches_opcode.then_some(name.as_str())
         })
@@ -290,16 +400,15 @@ impl ContractABI {
     }
 
     pub fn resolve_storage_struct(&self) -> anyhow::Result<Option<ABIResolvedStruct>> {
-        let Some(storage_ty) = self
+        let Some(storage_ty_idx) = self
             .storage
-            .storage_at_deployment_ty
-            .as_ref()
-            .or(self.storage.storage_ty.as_ref())
+            .storage_at_deployment_ty_idx
+            .or(self.storage.storage_ty_idx)
         else {
             return Ok(None);
         };
 
-        Ok(Some(self.resolve_single_struct(storage_ty, "storage")?))
+        Ok(Some(self.resolve_single_struct(storage_ty_idx, "storage")?))
     }
 
     pub fn resolve_incoming_message_structs(&self) -> anyhow::Result<Vec<ABIResolvedStruct>> {
@@ -309,7 +418,7 @@ impl ContractABI {
         for message in &self.incoming_messages {
             collect_structs_from_type(
                 self,
-                &message.body_ty,
+                message.body_ty_idx,
                 &mut HashSet::new(),
                 &mut seen_structs,
                 &mut resolved,
@@ -321,14 +430,14 @@ impl ContractABI {
 
     pub fn resolve_single_struct(
         &self,
-        ty: &Ty,
+        ty_idx: TyIdx,
         context: &str,
     ) -> anyhow::Result<ABIResolvedStruct> {
         let mut resolved = Vec::new();
         let mut seen_structs = HashSet::new();
         collect_structs_from_type(
             self,
-            ty,
+            ty_idx,
             &mut HashSet::new(),
             &mut seen_structs,
             &mut resolved,
@@ -339,7 +448,7 @@ impl ContractABI {
             anyhow::bail!(
                 "Failed to resolve {} type {} into a concrete struct",
                 context,
-                ty.render_type()
+                self.render_type(ty_idx)
             );
         };
 
@@ -347,7 +456,7 @@ impl ContractABI {
             anyhow::bail!(
                 "{} type {} resolves to multiple structs ({}, {})",
                 context,
-                ty.render_type(),
+                self.render_type(ty_idx),
                 first.name,
                 other.name
             );
@@ -357,106 +466,70 @@ impl ContractABI {
     }
 }
 
-fn parse_abi_prefix_number(prefix: &str) -> Option<u32> {
-    let prefix = prefix.trim();
-    if prefix.is_empty() {
-        return None;
-    }
-    let parsed = if let Some(hex) = prefix
-        .strip_prefix("0x")
-        .or_else(|| prefix.strip_prefix("0X"))
-    {
-        u64::from_str_radix(hex, 16).ok()?
-    } else {
-        prefix.parse::<u64>().ok()?
-    };
-    u32::try_from(parsed).ok()
-}
-
-impl Ty {
-    #[must_use]
-    pub fn render_param_type(&self) -> String {
-        match self {
-            Ty::CellOf { inner } => inner.render_type(),
-            _ => self.render_type(),
-        }
+impl TyResolver for ContractABI {
+    fn ty_by_idx(&self, ty_idx: TyIdx) -> Option<&Ty> {
+        self.unique_types.get(ty_idx)
     }
 
-    #[must_use]
-    pub fn render_type(&self) -> String {
-        self.to_string()
+    fn struct_field_ty_indices(&self, ty_idx: TyIdx) -> Option<Vec<TyIdx>> {
+        self.struct_fields_of(ty_idx)
+            .ok()
+            .map(|fields| fields.into_iter().map(|field| field.ty_idx).collect())
     }
 
-    #[must_use]
-    pub const fn is_typed_cell(&self) -> bool {
-        matches!(self, Ty::CellOf { .. })
-    }
-
-    #[must_use]
-    pub fn typed_cell_payload_default_value(&self, abi: &ContractABI) -> Option<String> {
-        match self {
-            Ty::CellOf { inner } => Some(default_value_impl(
-                abi,
-                inner,
-                &BTreeMap::new(),
-                &mut HashSet::new(),
-            )),
-            _ => None,
-        }
-    }
-
-    #[must_use]
-    pub fn default_value(&self, abi: &ContractABI) -> String {
-        default_value_impl(abi, self, &BTreeMap::new(), &mut HashSet::new())
+    fn alias_target_ty_idx(&self, ty_idx: TyIdx) -> Option<TyIdx> {
+        self.alias_target_of(ty_idx).ok()
     }
 }
 
 fn collect_structs_from_type(
     abi: &ContractABI,
-    ty: &Ty,
-    visited_aliases: &mut HashSet<String>,
+    ty_idx: TyIdx,
+    visited_aliases: &mut HashSet<TyIdx>,
     seen_structs: &mut HashSet<String>,
     resolved: &mut Vec<ABIResolvedStruct>,
 ) -> anyhow::Result<()> {
+    let ty = abi
+        .ty_by_idx(ty_idx)
+        .ok_or_else(|| anyhow!("ABI ty_idx {ty_idx} was not found"))?;
     match ty {
         Ty::StructRef { struct_name, .. } => {
-            let (prefix, fields, overrides_client_type) = find_struct_decl(abi, struct_name)
+            let (prefix, _, overrides_client_type) = find_struct_decl(abi, struct_name)
                 .ok_or_else(|| anyhow!("Struct {struct_name} referenced by ABI was not found"))?;
+            let fields = abi.struct_fields_of(ty_idx)?;
             if seen_structs.insert(struct_name.clone()) {
                 resolved.push(to_resolved_struct(
                     struct_name,
                     prefix,
-                    fields,
+                    &fields,
                     overrides_client_type,
                 ));
             }
             Ok(())
         }
         Ty::AliasRef { alias_name, .. } => {
-            if !visited_aliases.insert(alias_name.clone()) {
+            if !visited_aliases.insert(ty_idx) {
                 anyhow::bail!("Cyclic ABI alias reference detected for {alias_name}");
             }
 
-            let result = find_alias_decl(abi, alias_name)
-                .ok_or_else(|| anyhow!("Alias {alias_name} referenced by ABI was not found"))
-                .and_then(|target_ty| {
-                    collect_structs_from_type(
-                        abi,
-                        target_ty,
-                        visited_aliases,
-                        seen_structs,
-                        resolved,
-                    )
-                });
+            let result = abi.alias_target_of(ty_idx).and_then(|target_ty_idx| {
+                collect_structs_from_type(
+                    abi,
+                    target_ty_idx,
+                    visited_aliases,
+                    seen_structs,
+                    resolved,
+                )
+            });
 
-            visited_aliases.remove(alias_name);
+            visited_aliases.remove(&ty_idx);
             result
         }
         Ty::Union { variants, .. } => {
             for variant in variants {
                 collect_structs_from_type(
                     abi,
-                    &variant.variant_ty,
+                    variant.variant_ty_idx,
                     visited_aliases,
                     seen_structs,
                     resolved,
@@ -464,12 +537,14 @@ fn collect_structs_from_type(
             }
             Ok(())
         }
-        Ty::Nullable { inner, .. } | Ty::CellOf { inner } | Ty::LispListOf { inner } => {
-            collect_structs_from_type(abi, inner, visited_aliases, seen_structs, resolved)
+        Ty::Nullable { inner_ty_idx, .. }
+        | Ty::CellOf { inner_ty_idx }
+        | Ty::LispListOf { inner_ty_idx } => {
+            collect_structs_from_type(abi, *inner_ty_idx, visited_aliases, seen_structs, resolved)
         }
         _ => anyhow::bail!(
             "Unsupported ABI type {} while resolving contract wrapper types",
-            ty.render_type()
+            abi.render_type(ty_idx)
         ),
     }
 }
@@ -492,11 +567,13 @@ fn find_struct_decl<'a>(
     })
 }
 
-fn find_alias_decl<'a>(abi: &'a ContractABI, target_name: &str) -> Option<&'a Ty> {
+fn find_alias_decl(abi: &ContractABI, target_name: &str) -> Option<TyIdx> {
     abi.declarations.iter().find_map(|decl| match decl {
         ABIDeclaration::Alias {
-            name, target_ty, ..
-        } if name == target_name => Some(target_ty),
+            name,
+            target_ty_idx,
+            ..
+        } if name == target_name => Some(*target_ty_idx),
         _ => None,
     })
 }
@@ -533,14 +610,14 @@ fn find_struct_decl_full<'a>(
 fn find_alias_decl_full<'a>(
     abi: &'a ContractABI,
     target_name: &str,
-) -> Option<(Option<&'a [String]>, &'a Ty)> {
+) -> Option<(Option<&'a [String]>, TyIdx)> {
     abi.declarations.iter().find_map(|decl| match decl {
         ABIDeclaration::Alias {
             name,
-            target_ty,
+            target_ty_idx,
             type_params,
             ..
-        } if name == target_name => Some((type_params.as_deref(), target_ty)),
+        } if name == target_name => Some((type_params.as_deref(), *target_ty_idx)),
         _ => None,
     })
 }
@@ -548,40 +625,27 @@ fn find_alias_decl_full<'a>(
 fn find_enum_decl<'a>(
     abi: &'a ContractABI,
     target_name: &str,
-) -> Option<(&'a Ty, &'a [ABIEnumMember])> {
+) -> Option<(TyIdx, &'a [ABIEnumMember])> {
     abi.declarations.iter().find_map(|decl| match decl {
         ABIDeclaration::Enum {
             name,
-            encoded_as,
+            encoded_as_ty_idx,
             members,
             ..
-        } if name == target_name => Some((encoded_as, members.as_slice())),
+        } if name == target_name => Some((*encoded_as_ty_idx, members.as_slice())),
         _ => None,
     })
 }
 
-fn render_named_type(name: &str, type_args: Option<&[Ty]>) -> String {
-    let type_args = type_args.unwrap_or(&[]);
-    if type_args.is_empty() {
-        name.to_owned()
-    } else {
-        format!(
-            "{name}<{}>",
-            type_args
-                .iter()
-                .map(Ty::render_type)
-                .collect::<Vec<_>>()
-                .join(", ")
-        )
-    }
-}
-
 fn default_value_impl(
     abi: &ContractABI,
-    ty: &Ty,
+    ty_idx: TyIdx,
     bindings: &BTreeMap<String, Ty>,
     visited_defs: &mut HashSet<String>,
 ) -> String {
+    let Some(ty) = abi.ty_by_idx(ty_idx) else {
+        return "null".to_owned();
+    };
     match ty {
         Ty::Int
         | Ty::Coins
@@ -601,35 +665,33 @@ fn default_value_impl(
         Ty::AddressOpt | Ty::NullLiteral | Ty::Nullable { .. } | Ty::Unknown => "null".to_owned(),
         Ty::BitsN { n } => format!("\"\" as bits{n}"),
         Ty::ArrayOf { .. } | Ty::LispListOf { .. } | Ty::MapKV { .. } => "[]".to_owned(),
-        Ty::Tensor { items } => format!(
+        Ty::Tensor { items_ty_idx } => format!(
             "({})",
-            items
+            items_ty_idx
                 .iter()
-                .map(|item| default_value_impl(abi, item, bindings, visited_defs))
+                .map(|&item_ty_idx| default_value_impl(abi, item_ty_idx, bindings, visited_defs))
                 .collect::<Vec<_>>()
                 .join(", ")
         ),
-        Ty::ShapedTuple { items } => format!(
+        Ty::ShapedTuple { items_ty_idx } => format!(
             "[{}]",
-            items
+            items_ty_idx
                 .iter()
-                .map(|item| default_value_impl(abi, item, bindings, visited_defs))
+                .map(|&item_ty_idx| default_value_impl(abi, item_ty_idx, bindings, visited_defs))
                 .collect::<Vec<_>>()
                 .join(", ")
         ),
         Ty::GenericT { .. } => "{}".to_owned(),
-        Ty::StructRef {
-            struct_name,
-            type_args,
-        } => default_struct_value(abi, struct_name, type_args.as_deref(), visited_defs),
+        Ty::StructRef { struct_name, .. } => {
+            default_struct_value(abi, ty_idx, struct_name, visited_defs)
+        }
         Ty::EnumRef { enum_name } => default_enum_value(abi, enum_name),
-        Ty::AliasRef {
-            alias_name,
-            type_args,
-        } => default_alias_value(abi, alias_name, type_args.as_deref(), visited_defs),
-        Ty::CellOf { inner } => format!(
+        Ty::AliasRef { alias_name, .. } => {
+            default_alias_value(abi, ty_idx, alias_name, visited_defs)
+        }
+        Ty::CellOf { inner_ty_idx } => format!(
             "{}.toCell()",
-            default_value_impl(abi, inner, bindings, visited_defs)
+            default_value_impl(abi, *inner_ty_idx, bindings, visited_defs)
         ),
         Ty::Union { variants, .. } => default_union_value(abi, variants, bindings, visited_defs),
     }
@@ -637,11 +699,11 @@ fn default_value_impl(
 
 fn default_struct_value(
     abi: &ContractABI,
+    ty_idx: TyIdx,
     struct_name: &str,
-    type_args: Option<&[Ty]>,
     visited_defs: &mut HashSet<String>,
 ) -> String {
-    let qualified_name = render_named_type(struct_name, type_args);
+    let qualified_name = abi.render_type(ty_idx);
     let visit_key = format!("struct:{qualified_name}");
     if !visited_defs.insert(visit_key.clone()) {
         return "null".to_owned();
@@ -650,8 +712,14 @@ fn default_struct_value(
     let result = find_struct_decl_full(abi, struct_name).map_or_else(
         || "null".to_owned(),
         |(type_params, fields)| {
-            if type_args.is_some_and(|args| !args.is_empty())
-                || type_params.is_some_and(|params| !params.is_empty())
+            let fields = abi
+                .struct_fields_of(ty_idx)
+                .unwrap_or_else(|_| fields.to_vec());
+            if type_params.is_some_and(|params| !params.is_empty())
+                && abi
+                    .struct_instantiations
+                    .iter()
+                    .all(|inst| inst.ty_idx != ty_idx)
             {
                 return "{}".to_owned();
             }
@@ -661,7 +729,9 @@ fn default_struct_value(
                 .map(|field| {
                     let value = match &field.default_value {
                         Some(default_value) => render_const_value(abi, default_value),
-                        None => default_value_impl(abi, &field.ty, &BTreeMap::new(), visited_defs),
+                        None => {
+                            default_value_impl(abi, field.ty_idx, &BTreeMap::new(), visited_defs)
+                        }
                     };
                     format!("{}: {}", field.name, value)
                 })
@@ -681,11 +751,11 @@ fn default_struct_value(
 
 fn default_alias_value(
     abi: &ContractABI,
+    ty_idx: TyIdx,
     alias_name: &str,
-    type_args: Option<&[Ty]>,
     visited_defs: &mut HashSet<String>,
 ) -> String {
-    let qualified_name = render_named_type(alias_name, type_args);
+    let qualified_name = abi.render_type(ty_idx);
     let visit_key = format!("alias:{qualified_name}");
     if !visited_defs.insert(visit_key.clone()) {
         return "null".to_owned();
@@ -693,14 +763,19 @@ fn default_alias_value(
 
     let result = find_alias_decl_full(abi, alias_name).map_or_else(
         || "null".to_owned(),
-        |(type_params, target_ty)| {
-            if type_args.is_some_and(|args| !args.is_empty())
-                || type_params.is_some_and(|params| !params.is_empty())
+        |(type_params, target_ty_idx)| {
+            let target_ty_idx = abi.alias_target_of(ty_idx).unwrap_or(target_ty_idx);
+            if type_params.is_some_and(|params| !params.is_empty())
+                && abi
+                    .alias_instantiations
+                    .iter()
+                    .all(|inst| inst.ty_idx != ty_idx)
             {
                 return "{}".to_owned();
             }
 
-            let target_default = default_value_impl(abi, target_ty, &BTreeMap::new(), visited_defs);
+            let target_default =
+                default_value_impl(abi, target_ty_idx, &BTreeMap::new(), visited_defs);
             if target_default == "null" {
                 target_default
             } else {
@@ -734,12 +809,12 @@ fn default_union_value(
 
     if variants
         .iter()
-        .any(|variant| matches!(variant.variant_ty, Ty::NullLiteral))
+        .any(|variant| matches!(abi.ty_by_idx(variant.variant_ty_idx), Some(Ty::NullLiteral)))
     {
         return "null".to_owned();
     }
 
-    default_value_impl(abi, &first_variant.variant_ty, bindings, visited_defs)
+    default_value_impl(abi, first_variant.variant_ty_idx, bindings, visited_defs)
 }
 
 fn render_const_value(abi: &ContractABI, value: &ABIConstValue) -> String {
@@ -775,10 +850,13 @@ fn render_const_value(abi: &ContractABI, value: &ABIConstValue) -> String {
             struct_name,
             fields,
         } => render_const_object_value(abi, struct_name, fields),
-        ABIConstValue::CastTo { inner, cast_to } => format!(
+        ABIConstValue::CastTo {
+            inner,
+            cast_to_ty_idx,
+        } => format!(
             "({} as {})",
             render_const_value(abi, inner),
-            cast_to.render_type()
+            abi.render_type(*cast_to_ty_idx)
         ),
         ABIConstValue::Null => "null".to_owned(),
     }
@@ -810,8 +888,8 @@ fn render_const_object_value(
 mod tests {
     use super::{
         ABIConstValue, ABIDeclaration, ABIEnumMember, ABIGetMethod, ABIInternalMessage, ABIOpcode,
-        ABIStorage, ABIStructField, ABIThrownError, ABIThrownErrorKind, ContractABI, Ty,
-        UnionVariant,
+        ABIStorage, ABIStructField, ABIThrownError, ABIThrownErrorKind, AliasInstantiation,
+        ContractABI, StructInstantiation, Ty, TyIdx, UnionVariant,
     };
 
     fn empty_abi() -> ContractABI {
@@ -821,14 +899,17 @@ mod tests {
             author: String::new(),
             version: String::new(),
             description: String::new(),
+            unique_types: Vec::new(),
+            struct_instantiations: Vec::new(),
+            alias_instantiations: Vec::new(),
             declarations: Vec::new(),
             incoming_messages: Vec::new(),
             incoming_external: Vec::new(),
             outgoing_messages: Vec::new(),
             emitted_events: Vec::new(),
             storage: ABIStorage {
-                storage_ty: None,
-                storage_at_deployment_ty: None,
+                storage_ty_idx: None,
+                storage_at_deployment_ty_idx: None,
                 description: String::new(),
             },
             get_methods: Vec::new(),
@@ -836,6 +917,44 @@ mod tests {
             compiler_name: "tolk".to_owned(),
             compiler_version: "test".to_owned(),
         }
+    }
+
+    fn add_ty(abi: &mut ContractABI, ty: Ty) -> TyIdx {
+        if let Some(idx) = abi.unique_types.iter().position(|existing| existing == &ty) {
+            return idx;
+        }
+        let idx = abi.unique_types.len();
+        abi.unique_types.push(ty);
+        idx
+    }
+
+    fn struct_ref(abi: &mut ContractABI, struct_name: &str) -> TyIdx {
+        add_ty(
+            abi,
+            Ty::StructRef {
+                struct_name: struct_name.to_owned(),
+                type_args_ty_idx: None,
+            },
+        )
+    }
+
+    fn alias_ref(abi: &mut ContractABI, alias_name: &str) -> TyIdx {
+        add_ty(
+            abi,
+            Ty::AliasRef {
+                alias_name: alias_name.to_owned(),
+                type_args_ty_idx: None,
+            },
+        )
+    }
+
+    fn enum_ref(abi: &mut ContractABI, enum_name: &str) -> TyIdx {
+        add_ty(
+            abi,
+            Ty::EnumRef {
+                enum_name: enum_name.to_owned(),
+            },
+        )
     }
 
     #[test]
@@ -869,10 +988,10 @@ mod tests {
                 "name": "foo",
                 "parameters": [{
                     "name": "arg",
-                    "ty": {"kind":"int"},
+                    "ty_idx": 1,
                     "default_value": {"kind":"int","v":"10"}
                 }],
-                "return_ty": {"kind":"int"}
+                "return_ty_idx": 1
             }"#,
         )
         .expect("failed to deserialize get method with parameter default value");
@@ -887,17 +1006,46 @@ mod tests {
     #[test]
     fn resolves_incoming_messages_through_alias_union_in_order() {
         let mut abi = empty_abi();
+        let msg_a_ty_idx = struct_ref(&mut abi, "MsgA");
+        let msg_b_ty_idx = struct_ref(&mut abi, "MsgB");
+        let value_ty_idx = add_ty(&mut abi, Ty::IntN { n: 32 });
+        let incoming_alias_ty_idx = alias_ref(&mut abi, "Incoming");
+        let incoming_union_ty_idx = add_ty(
+            &mut abi,
+            Ty::Union {
+                variants: vec![
+                    UnionVariant {
+                        variant_ty_idx: msg_a_ty_idx,
+                        prefix_num: 0x1,
+                        prefix_len: 32,
+                        is_prefix_implicit: None,
+                        stack_type_id: None,
+                        stack_width: None,
+                    },
+                    UnionVariant {
+                        variant_ty_idx: msg_b_ty_idx,
+                        prefix_num: 0x2,
+                        prefix_len: 32,
+                        is_prefix_implicit: None,
+                        stack_type_id: None,
+                        stack_width: None,
+                    },
+                ],
+                stack_width: None,
+            },
+        );
         abi.declarations = vec![
             ABIDeclaration::Struct {
                 name: "MsgA".to_owned(),
+                ty_idx: msg_a_ty_idx,
                 type_params: None,
                 prefix: Some(ABIOpcode {
-                    prefix_str: "0x1".to_owned(),
+                    prefix_num: 0x1,
                     prefix_len: 32,
                 }),
                 fields: vec![ABIStructField {
                     name: "value".to_owned(),
-                    ty: Ty::IntN { n: 32 },
+                    ty_idx: value_ty_idx,
                     default_value: None,
                     description: String::new(),
                 }],
@@ -906,9 +1054,10 @@ mod tests {
             },
             ABIDeclaration::Struct {
                 name: "MsgB".to_owned(),
+                ty_idx: msg_b_ty_idx,
                 type_params: None,
                 prefix: Some(ABIOpcode {
-                    prefix_str: "0x2".to_owned(),
+                    prefix_num: 0x2,
                     prefix_len: 32,
                 }),
                 fields: vec![],
@@ -917,42 +1066,14 @@ mod tests {
             },
             ABIDeclaration::Alias {
                 name: "Incoming".to_owned(),
-                target_ty: Ty::Union {
-                    variants: vec![
-                        UnionVariant {
-                            variant_ty: Ty::StructRef {
-                                struct_name: "MsgA".to_owned(),
-                                type_args: None,
-                            },
-                            prefix_str: "0x1".to_owned(),
-                            prefix_len: 32,
-                            is_prefix_implicit: None,
-                            stack_type_id: None,
-                            stack_width: None,
-                        },
-                        UnionVariant {
-                            variant_ty: Ty::StructRef {
-                                struct_name: "MsgB".to_owned(),
-                                type_args: None,
-                            },
-                            prefix_str: "0x2".to_owned(),
-                            prefix_len: 32,
-                            is_prefix_implicit: None,
-                            stack_type_id: None,
-                            stack_width: None,
-                        },
-                    ],
-                    stack_width: None,
-                },
+                ty_idx: incoming_alias_ty_idx,
+                target_ty_idx: incoming_union_ty_idx,
                 type_params: None,
                 custom_pack_unpack: None,
             },
         ];
         abi.incoming_messages = vec![ABIInternalMessage {
-            body_ty: Ty::AliasRef {
-                alias_name: "Incoming".to_owned(),
-                type_args: None,
-            },
+            body_ty_idx: incoming_alias_ty_idx,
             description: String::new(),
         }];
 
@@ -968,9 +1089,12 @@ mod tests {
     #[test]
     fn resolve_storage_struct_prefers_deployment_type() {
         let mut abi = empty_abi();
+        let storage_ty_idx = struct_ref(&mut abi, "Storage");
+        let deployment_ty_idx = struct_ref(&mut abi, "DeploymentStorage");
         abi.declarations = vec![
             ABIDeclaration::Struct {
                 name: "Storage".to_owned(),
+                ty_idx: storage_ty_idx,
                 type_params: None,
                 prefix: None,
                 fields: vec![],
@@ -979,6 +1103,7 @@ mod tests {
             },
             ABIDeclaration::Struct {
                 name: "DeploymentStorage".to_owned(),
+                ty_idx: deployment_ty_idx,
                 type_params: None,
                 prefix: None,
                 fields: vec![],
@@ -987,14 +1112,8 @@ mod tests {
             },
         ];
         abi.storage = ABIStorage {
-            storage_ty: Some(Ty::StructRef {
-                struct_name: "Storage".to_owned(),
-                type_args: None,
-            }),
-            storage_at_deployment_ty: Some(Ty::StructRef {
-                struct_name: "DeploymentStorage".to_owned(),
-                type_args: None,
-            }),
+            storage_ty_idx: Some(storage_ty_idx),
+            storage_at_deployment_ty_idx: Some(deployment_ty_idx),
             description: String::new(),
         };
 
@@ -1009,20 +1128,16 @@ mod tests {
     #[test]
     fn detects_cyclic_aliases_while_resolving_messages() {
         let mut abi = empty_abi();
+        let incoming_alias_ty_idx = alias_ref(&mut abi, "Incoming");
         abi.declarations = vec![ABIDeclaration::Alias {
             name: "Incoming".to_owned(),
-            target_ty: Ty::AliasRef {
-                alias_name: "Incoming".to_owned(),
-                type_args: None,
-            },
+            ty_idx: incoming_alias_ty_idx,
+            target_ty_idx: incoming_alias_ty_idx,
             type_params: None,
             custom_pack_unpack: None,
         }];
         abi.incoming_messages = vec![ABIInternalMessage {
-            body_ty: Ty::AliasRef {
-                alias_name: "Incoming".to_owned(),
-                type_args: None,
-            },
+            body_ty_idx: incoming_alias_ty_idx,
             description: String::new(),
         }];
 
@@ -1039,58 +1154,40 @@ mod tests {
 
     #[test]
     fn abi_type_helpers_render_and_default_values() {
-        let abi = empty_abi();
-        let ty = Ty::CellOf {
-            inner: Box::new(Ty::IntN { n: 32 }),
-        };
-        assert_eq!(ty.render_type(), "Cell<int32>");
-        assert_eq!(ty.render_param_type(), "int32");
-        assert!(ty.is_typed_cell());
+        let mut abi = empty_abi();
+        let int32_ty_idx = add_ty(&mut abi, Ty::IntN { n: 32 });
+        let cell_ty_idx = add_ty(
+            &mut abi,
+            Ty::CellOf {
+                inner_ty_idx: int32_ty_idx,
+            },
+        );
+        assert_eq!(abi.render_type(cell_ty_idx), "Cell<int32>");
+        assert_eq!(abi.render_param_type(cell_ty_idx), "int32");
+        assert!(abi.is_typed_cell(cell_ty_idx));
         assert_eq!(
-            ty.typed_cell_payload_default_value(&abi).as_deref(),
+            abi.typed_cell_payload_default_value(cell_ty_idx).as_deref(),
             Some("0")
         );
-        assert_eq!(ty.default_value(&abi), "0.toCell()");
+        assert_eq!(abi.default_value(cell_ty_idx), "0.toCell()");
 
-        let nullable_union = Ty::Union {
-            variants: vec![
-                UnionVariant {
-                    variant_ty: Ty::NullLiteral,
-                    prefix_str: String::new(),
-                    prefix_len: 0,
-                    is_prefix_implicit: None,
-                    stack_type_id: None,
-                    stack_width: None,
-                },
-                UnionVariant {
-                    variant_ty: Ty::Callable,
-                    prefix_str: String::new(),
-                    prefix_len: 0,
-                    is_prefix_implicit: None,
-                    stack_type_id: None,
-                    stack_width: None,
-                },
-            ],
-            stack_width: None,
-        };
-        assert_eq!(nullable_union.render_type(), "null | continuation");
-        assert_eq!(Ty::AddressAny.default_value(&abi), "createAddressNone()");
-        assert_eq!(Ty::BitsN { n: 32 }.default_value(&abi), "\"\" as bits32");
-        assert_eq!(Ty::Callable.default_value(&abi), "fun () {}");
-        assert_eq!(
+        let null_ty_idx = add_ty(&mut abi, Ty::NullLiteral);
+        let callable_ty_idx = add_ty(&mut abi, Ty::Callable);
+        let nullable_union_ty_idx = add_ty(
+            &mut abi,
             Ty::Union {
                 variants: vec![
                     UnionVariant {
-                        variant_ty: Ty::IntN { n: 8 },
-                        prefix_str: String::new(),
+                        variant_ty_idx: null_ty_idx,
+                        prefix_num: 0,
                         prefix_len: 0,
                         is_prefix_implicit: None,
                         stack_type_id: None,
                         stack_width: None,
                     },
                     UnionVariant {
-                        variant_ty: Ty::Bool,
-                        prefix_str: String::new(),
+                        variant_ty_idx: callable_ty_idx,
+                        prefix_num: 0,
                         prefix_len: 0,
                         is_prefix_implicit: None,
                         stack_type_id: None,
@@ -1098,26 +1195,136 @@ mod tests {
                     },
                 ],
                 stack_width: None,
-            }
-            .default_value(&abi),
-            "0"
+            },
         );
         assert_eq!(
-            Ty::LispListOf {
-                inner: Box::new(Ty::Bool),
-            }
-            .default_value(&abi),
-            "[]"
+            abi.render_type(nullable_union_ty_idx),
+            "null | continuation"
         );
+        let address_any_ty_idx = add_ty(&mut abi, Ty::AddressAny);
+        let bits32_ty_idx = add_ty(&mut abi, Ty::BitsN { n: 32 });
+        assert_eq!(abi.default_value(address_any_ty_idx), "createAddressNone()");
+        assert_eq!(abi.default_value(bits32_ty_idx), "\"\" as bits32");
+        assert_eq!(abi.default_value(callable_ty_idx), "fun () {}");
+        let int8_ty_idx = add_ty(&mut abi, Ty::IntN { n: 8 });
+        let bool_ty_idx = add_ty(&mut abi, Ty::Bool);
+        let union_ty_idx = add_ty(
+            &mut abi,
+            Ty::Union {
+                variants: vec![
+                    UnionVariant {
+                        variant_ty_idx: int8_ty_idx,
+                        prefix_num: 0,
+                        prefix_len: 0,
+                        is_prefix_implicit: None,
+                        stack_type_id: None,
+                        stack_width: None,
+                    },
+                    UnionVariant {
+                        variant_ty_idx: bool_ty_idx,
+                        prefix_num: 0,
+                        prefix_len: 0,
+                        is_prefix_implicit: None,
+                        stack_type_id: None,
+                        stack_width: None,
+                    },
+                ],
+                stack_width: None,
+            },
+        );
+        assert_eq!(abi.default_value(union_ty_idx), "0");
+        let list_ty_idx = add_ty(
+            &mut abi,
+            Ty::LispListOf {
+                inner_ty_idx: bool_ty_idx,
+            },
+        );
+        assert_eq!(abi.default_value(list_ty_idx), "[]");
     }
 
     #[test]
     fn defaults_resolve_structs_aliases_enums_and_field_defaults() {
         let mut abi = empty_abi();
+        let color_ty_idx = enum_ref(&mut abi, "Color");
+        let color_encoded_ty_idx = add_ty(&mut abi, Ty::UintN { n: 2 });
+        let generic_ty_idx = add_ty(
+            &mut abi,
+            Ty::GenericT {
+                name_t: "T".to_owned(),
+            },
+        );
+        let boxed_generic_ty_idx = add_ty(
+            &mut abi,
+            Ty::StructRef {
+                struct_name: "Boxed".to_owned(),
+                type_args_ty_idx: Some(vec![generic_ty_idx]),
+            },
+        );
+        let boxed_plain_ty_idx = struct_ref(&mut abi, "Boxed");
+        let user_id_ty_idx = alias_ref(&mut abi, "UserId");
+        let int32_ty_idx = add_ty(&mut abi, Ty::IntN { n: 32 });
+        let uint32_ty_idx = add_ty(&mut abi, Ty::UintN { n: 32 });
+        let bool_ty_idx = add_ty(&mut abi, Ty::Bool);
+        let nullable_generic_ty_idx = add_ty(
+            &mut abi,
+            Ty::Nullable {
+                inner_ty_idx: generic_ty_idx,
+                stack_type_id: None,
+                stack_width: None,
+            },
+        );
+        let nullable_bool_ty_idx = add_ty(
+            &mut abi,
+            Ty::Nullable {
+                inner_ty_idx: bool_ty_idx,
+                stack_type_id: None,
+                stack_width: None,
+            },
+        );
+        let boxed_nullable_generic_ty_idx = add_ty(
+            &mut abi,
+            Ty::StructRef {
+                struct_name: "Boxed".to_owned(),
+                type_args_ty_idx: Some(vec![nullable_generic_ty_idx]),
+            },
+        );
+        let boxed_nullable_bool_ty_idx = add_ty(
+            &mut abi,
+            Ty::StructRef {
+                struct_name: "Boxed".to_owned(),
+                type_args_ty_idx: Some(vec![nullable_bool_ty_idx]),
+            },
+        );
+        let maybe_boxed_generic_ty_idx = add_ty(
+            &mut abi,
+            Ty::AliasRef {
+                alias_name: "MaybeBoxed".to_owned(),
+                type_args_ty_idx: Some(vec![generic_ty_idx]),
+            },
+        );
+        let maybe_boxed_bool_ty_idx = add_ty(
+            &mut abi,
+            Ty::AliasRef {
+                alias_name: "MaybeBoxed".to_owned(),
+                type_args_ty_idx: Some(vec![bool_ty_idx]),
+            },
+        );
+        let storage_ty_idx = struct_ref(&mut abi, "Storage");
+        abi.struct_instantiations.push(StructInstantiation {
+            ty_idx: boxed_nullable_bool_ty_idx,
+            struct_name: "Boxed".to_owned(),
+            monomorphic_fields_ty_idx: vec![nullable_bool_ty_idx],
+        });
+        abi.alias_instantiations.push(AliasInstantiation {
+            ty_idx: maybe_boxed_bool_ty_idx,
+            alias_name: "MaybeBoxed".to_owned(),
+            monomorphic_target_ty_idx: boxed_nullable_bool_ty_idx,
+        });
         abi.declarations = vec![
             ABIDeclaration::Enum {
                 name: "Color".to_owned(),
-                encoded_as: Ty::UintN { n: 2 },
+                ty_idx: color_ty_idx,
+                encoded_as_ty_idx: color_encoded_ty_idx,
                 members: vec![
                     ABIEnumMember {
                         name: "Red".to_owned(),
@@ -1134,13 +1341,12 @@ mod tests {
             },
             ABIDeclaration::Struct {
                 name: "Boxed".to_owned(),
+                ty_idx: boxed_generic_ty_idx,
                 type_params: Some(vec!["T".to_owned()]),
                 prefix: None,
                 fields: vec![ABIStructField {
                     name: "item".to_owned(),
-                    ty: Ty::GenericT {
-                        name_t: "T".to_owned(),
-                    },
+                    ty_idx: generic_ty_idx,
                     default_value: None,
                     description: String::new(),
                 }],
@@ -1149,62 +1355,45 @@ mod tests {
             },
             ABIDeclaration::Alias {
                 name: "UserId".to_owned(),
-                target_ty: Ty::IntN { n: 32 },
+                ty_idx: user_id_ty_idx,
+                target_ty_idx: int32_ty_idx,
                 type_params: None,
                 custom_pack_unpack: None,
             },
             ABIDeclaration::Alias {
                 name: "MaybeBoxed".to_owned(),
-                target_ty: Ty::StructRef {
-                    struct_name: "Boxed".to_owned(),
-                    type_args: Some(vec![Ty::Nullable {
-                        inner: Box::new(Ty::GenericT {
-                            name_t: "T".to_owned(),
-                        }),
-                        stack_type_id: None,
-                        stack_width: None,
-                    }]),
-                },
+                ty_idx: maybe_boxed_generic_ty_idx,
+                target_ty_idx: boxed_nullable_generic_ty_idx,
                 type_params: Some(vec!["T".to_owned()]),
                 custom_pack_unpack: None,
             },
             ABIDeclaration::Struct {
                 name: "Storage".to_owned(),
+                ty_idx: storage_ty_idx,
                 type_params: None,
                 prefix: None,
                 fields: vec![
                     ABIStructField {
                         name: "owner".to_owned(),
-                        ty: Ty::AliasRef {
-                            alias_name: "UserId".to_owned(),
-                            type_args: None,
-                        },
+                        ty_idx: user_id_ty_idx,
                         default_value: None,
                         description: String::new(),
                     },
                     ABIStructField {
                         name: "color".to_owned(),
-                        ty: Ty::EnumRef {
-                            enum_name: "Color".to_owned(),
-                        },
+                        ty_idx: color_ty_idx,
                         default_value: None,
                         description: String::new(),
                     },
                     ABIStructField {
                         name: "maybeItem".to_owned(),
-                        ty: Ty::AliasRef {
-                            alias_name: "MaybeBoxed".to_owned(),
-                            type_args: Some(vec![Ty::Bool]),
-                        },
+                        ty_idx: maybe_boxed_bool_ty_idx,
                         default_value: None,
                         description: String::new(),
                     },
                     ABIStructField {
                         name: "nested".to_owned(),
-                        ty: Ty::StructRef {
-                            struct_name: "Boxed".to_owned(),
-                            type_args: None,
-                        },
+                        ty_idx: boxed_plain_ty_idx,
                         default_value: Some(ABIConstValue::Object {
                             struct_name: "Boxed".to_owned(),
                             fields: vec![ABIConstValue::Null],
@@ -1213,10 +1402,10 @@ mod tests {
                     },
                     ABIStructField {
                         name: "opcode".to_owned(),
-                        ty: Ty::UintN { n: 32 },
+                        ty_idx: uint32_ty_idx,
                         default_value: Some(ABIConstValue::CastTo {
                             inner: Box::new(ABIConstValue::Int { v: "7".to_owned() }),
-                            cast_to: Ty::UintN { n: 32 },
+                            cast_to_ty_idx: uint32_ty_idx,
                         }),
                         description: String::new(),
                     },
@@ -1226,36 +1415,27 @@ mod tests {
             },
         ];
 
-        let storage_default = Ty::StructRef {
-            struct_name: "Storage".to_owned(),
-            type_args: None,
-        }
-        .default_value(&abi);
+        let storage_default = abi.default_value(storage_ty_idx);
 
         assert_eq!(
             storage_default,
-            "Storage { owner: (0 as UserId), color: Color.Red, maybeItem: {}, nested: Boxed { item: null }, opcode: (7 as uint32) }"
+            "Storage { owner: (0 as UserId), color: Color.Red, maybeItem: (Boxed<bool?> { item: null } as MaybeBoxed<bool>), nested: Boxed { item: null }, opcode: (7 as uint32) }"
         );
     }
 
     #[test]
     fn default_value_falls_back_to_null_for_recursive_aliases() {
         let mut abi = empty_abi();
+        let loop_ty_idx = alias_ref(&mut abi, "Loop");
         abi.declarations = vec![ABIDeclaration::Alias {
             name: "Loop".to_owned(),
-            target_ty: Ty::AliasRef {
-                alias_name: "Loop".to_owned(),
-                type_args: None,
-            },
+            ty_idx: loop_ty_idx,
+            target_ty_idx: loop_ty_idx,
             type_params: None,
             custom_pack_unpack: None,
         }];
 
-        let value = Ty::AliasRef {
-            alias_name: "Loop".to_owned(),
-            type_args: None,
-        }
-        .default_value(&abi);
+        let value = abi.default_value(loop_ty_idx);
 
         assert_eq!(value, "null");
     }

--- a/crates/tolk-compiler/src/dynamic_unpack.rs
+++ b/crates/tolk-compiler/src/dynamic_unpack.rs
@@ -1,8 +1,6 @@
-use crate::abi::{ABICustomPackUnpack, Ty, UnionVariant};
-use crate::source_map::{
-    AbiAlias, AbiEnum, AbiStruct, Declaration, EnumMemberInfo, FieldInfo, PrefixInfo, SourceMap,
-};
-use crate::types_kernel::instantiate_generics;
+use crate::abi::{ABICustomPackUnpack, ABIDeclaration, ContractABI, Ty, UnionVariant};
+use crate::source_map::{Declaration, SourceMap};
+use crate::types_kernel::{TyIdx, TyResolver, render_ty};
 use anyhow::{Context, anyhow};
 use num_bigint::BigInt;
 use tycho_types::cell::{Cell, CellBuilder, CellSlice, Load};
@@ -28,19 +26,205 @@ pub enum UnpackedValue {
     },
 }
 
+#[derive(Clone, Copy)]
+struct SchemaPrefix {
+    prefix_num: u64,
+    prefix_len: i32,
+}
+
+struct SchemaStructDecl<'a> {
+    prefix: Option<SchemaPrefix>,
+    custom_pack_unpack: Option<&'a ABICustomPackUnpack>,
+}
+
+struct SchemaAliasDecl<'a> {
+    custom_pack_unpack: Option<&'a ABICustomPackUnpack>,
+}
+
+struct SchemaEnumDecl<'a> {
+    encoded_as_ty_idx: TyIdx,
+    members: Vec<SchemaEnumMember>,
+    custom_pack_unpack: Option<&'a ABICustomPackUnpack>,
+}
+
+#[derive(Clone)]
+struct SchemaField {
+    name: String,
+    ty_idx: TyIdx,
+}
+
+#[derive(Clone)]
+struct SchemaEnumMember {
+    name: String,
+    value: String,
+}
+
+trait UnpackSchema: TyResolver {
+    fn struct_decl_info(&self, target_name: &str) -> Option<SchemaStructDecl<'_>>;
+    fn alias_decl_info(&self, target_name: &str) -> Option<SchemaAliasDecl<'_>>;
+    fn enum_decl_info(&self, target_name: &str) -> Option<SchemaEnumDecl<'_>>;
+    fn struct_fields_for(&self, ty_idx: TyIdx) -> Option<Vec<SchemaField>>;
+    fn alias_target_for(&self, ty_idx: TyIdx) -> Option<TyIdx>;
+}
+
+impl UnpackSchema for SourceMap {
+    fn struct_decl_info(&self, target_name: &str) -> Option<SchemaStructDecl<'_>> {
+        self.declarations().iter().find_map(|decl| match decl {
+            Declaration::Struct(struct_decl) if struct_decl.name == target_name => {
+                Some(SchemaStructDecl {
+                    prefix: struct_decl.prefix.as_ref().map(|prefix| SchemaPrefix {
+                        prefix_num: prefix.prefix_num,
+                        prefix_len: prefix.prefix_len,
+                    }),
+                    custom_pack_unpack: struct_decl.custom_pack_unpack.as_ref(),
+                })
+            }
+            _ => None,
+        })
+    }
+
+    fn alias_decl_info(&self, target_name: &str) -> Option<SchemaAliasDecl<'_>> {
+        self.declarations().iter().find_map(|decl| match decl {
+            Declaration::Alias(alias_decl) if alias_decl.name == target_name => {
+                Some(SchemaAliasDecl {
+                    custom_pack_unpack: alias_decl.custom_pack_unpack.as_ref(),
+                })
+            }
+            _ => None,
+        })
+    }
+
+    fn enum_decl_info(&self, target_name: &str) -> Option<SchemaEnumDecl<'_>> {
+        self.declarations().iter().find_map(|decl| match decl {
+            Declaration::Enum(enum_decl) if enum_decl.name == target_name => Some(SchemaEnumDecl {
+                encoded_as_ty_idx: enum_decl.encoded_as_ty_idx,
+                members: enum_decl
+                    .members
+                    .iter()
+                    .map(|member| SchemaEnumMember {
+                        name: member.name.clone(),
+                        value: member.value.clone(),
+                    })
+                    .collect(),
+                custom_pack_unpack: enum_decl.custom_pack_unpack.as_ref(),
+            }),
+            _ => None,
+        })
+    }
+
+    fn struct_fields_for(&self, ty_idx: TyIdx) -> Option<Vec<SchemaField>> {
+        self.struct_fields_of(ty_idx).map(|fields| {
+            fields
+                .into_iter()
+                .map(|field| SchemaField {
+                    name: field.name,
+                    ty_idx: field.ty_idx,
+                })
+                .collect()
+        })
+    }
+
+    fn alias_target_for(&self, ty_idx: TyIdx) -> Option<TyIdx> {
+        self.alias_target_of(ty_idx)
+    }
+}
+
+impl UnpackSchema for ContractABI {
+    fn struct_decl_info(&self, target_name: &str) -> Option<SchemaStructDecl<'_>> {
+        self.declarations.iter().find_map(|decl| match decl {
+            ABIDeclaration::Struct {
+                name,
+                prefix,
+                custom_pack_unpack,
+                ..
+            } if name == target_name => Some(SchemaStructDecl {
+                prefix: prefix.as_ref().map(|prefix| SchemaPrefix {
+                    prefix_num: prefix.prefix_num,
+                    prefix_len: prefix.prefix_len,
+                }),
+                custom_pack_unpack: custom_pack_unpack.as_ref(),
+            }),
+            _ => None,
+        })
+    }
+
+    fn alias_decl_info(&self, target_name: &str) -> Option<SchemaAliasDecl<'_>> {
+        self.declarations.iter().find_map(|decl| match decl {
+            ABIDeclaration::Alias {
+                name,
+                custom_pack_unpack,
+                ..
+            } if name == target_name => Some(SchemaAliasDecl {
+                custom_pack_unpack: custom_pack_unpack.as_ref(),
+            }),
+            _ => None,
+        })
+    }
+
+    fn enum_decl_info(&self, target_name: &str) -> Option<SchemaEnumDecl<'_>> {
+        self.declarations.iter().find_map(|decl| match decl {
+            ABIDeclaration::Enum {
+                name,
+                encoded_as_ty_idx,
+                members,
+                custom_pack_unpack,
+                ..
+            } if name == target_name => Some(SchemaEnumDecl {
+                encoded_as_ty_idx: *encoded_as_ty_idx,
+                members: members
+                    .iter()
+                    .map(|member| SchemaEnumMember {
+                        name: member.name.clone(),
+                        value: member.value.clone(),
+                    })
+                    .collect(),
+                custom_pack_unpack: custom_pack_unpack.as_ref(),
+            }),
+            _ => None,
+        })
+    }
+
+    fn struct_fields_for(&self, ty_idx: TyIdx) -> Option<Vec<SchemaField>> {
+        self.struct_fields_of(ty_idx).ok().map(|fields| {
+            fields
+                .into_iter()
+                .map(|field| SchemaField {
+                    name: field.name,
+                    ty_idx: field.ty_idx,
+                })
+                .collect()
+        })
+    }
+
+    fn alias_target_for(&self, ty_idx: TyIdx) -> Option<TyIdx> {
+        self.alias_target_of(ty_idx).ok()
+    }
+}
+
 pub fn unpack_from_slice(
     data: &mut CellSlice<'_>,
     symbols: &SourceMap,
-    ty: &Ty,
+    ty_idx: TyIdx,
 ) -> anyhow::Result<UnpackedValue> {
-    unpack_type(data, symbols, ty)
+    unpack_type(data, symbols, ty_idx)
 }
 
-fn unpack_type(
+pub fn unpack_from_abi_slice(
     data: &mut CellSlice<'_>,
-    symbols: &SourceMap,
-    ty: &Ty,
+    abi: &ContractABI,
+    ty_idx: TyIdx,
 ) -> anyhow::Result<UnpackedValue> {
+    unpack_type(data, abi, ty_idx)
+}
+
+fn unpack_type<S: UnpackSchema + ?Sized>(
+    data: &mut CellSlice<'_>,
+    symbols: &S,
+    ty_idx: TyIdx,
+) -> anyhow::Result<UnpackedValue> {
+    let ty = symbols
+        .ty_by_idx(ty_idx)
+        .ok_or_else(|| anyhow!("ABI ty_idx {ty_idx} was not found"))?;
     match ty {
         Ty::Int => unsupported_type("int"),
         Ty::Bool => Ok(UnpackedValue::Bool(data.load_bit()?)),
@@ -87,40 +271,24 @@ fn unpack_type(
         }
         Ty::BitsN { n } => Ok(UnpackedValue::Bits(load_bits(data, *n)?)),
         Ty::ArrayOf { .. } => unsupported_type("arrayOf"),
-        Ty::Tensor { items } | Ty::ShapedTuple { items } => {
-            let mut values = Vec::with_capacity(items.len());
-            for item in items {
-                values.push(unpack_type(data, symbols, item)?);
+        Ty::Tensor { items_ty_idx } | Ty::ShapedTuple { items_ty_idx } => {
+            let mut values = Vec::with_capacity(items_ty_idx.len());
+            for &item_ty_idx in items_ty_idx {
+                values.push(unpack_type(data, symbols, item_ty_idx)?);
             }
             Ok(UnpackedValue::Array(values))
         }
         Ty::NullLiteral => Ok(UnpackedValue::Null),
         Ty::GenericT { name_t } => anyhow::bail!("unresolved generic type {name_t}"),
-        Ty::StructRef {
-            struct_name,
-            type_args,
-        } => unpack_struct(
-            data,
-            symbols,
-            struct_name,
-            type_args.as_deref().unwrap_or(&[]),
-        ),
+        Ty::StructRef { struct_name, .. } => unpack_struct(data, symbols, ty_idx, struct_name),
         Ty::EnumRef { enum_name } => unpack_enum(data, symbols, enum_name),
-        Ty::AliasRef {
-            alias_name,
-            type_args,
-        } => unpack_alias(
-            data,
-            symbols,
-            alias_name,
-            type_args.as_deref().unwrap_or(&[]),
-        ),
+        Ty::AliasRef { alias_name, .. } => unpack_alias(data, symbols, ty_idx, alias_name),
         Ty::Remaining => Ok(UnpackedValue::RemainingBitsAndRefs(remaining_as_cell(
             data,
         )?)),
-        Ty::CellOf { inner } => {
+        Ty::CellOf { inner_ty_idx } => {
             let mut ref_slice = data.load_reference_as_slice()?;
-            let value = unpack_type(&mut ref_slice, symbols, inner)?;
+            let value = unpack_type(&mut ref_slice, symbols, *inner_ty_idx)?;
             ensure_fully_consumed(&ref_slice, "Cell<T> payload")?;
             Ok(UnpackedValue::Object {
                 name: "Cell".to_owned(),
@@ -129,36 +297,41 @@ fn unpack_type(
         }
         Ty::LispListOf { .. } => unsupported_type("lispListOf"),
         Ty::Union { variants, .. } => unpack_union(data, symbols, variants),
-        Ty::Nullable { inner, .. } => {
+        Ty::Nullable { inner_ty_idx, .. } => {
             if !data.load_bit()? {
                 return Ok(UnpackedValue::Null);
             }
-            unpack_type(data, symbols, inner)
+            unpack_type(data, symbols, *inner_ty_idx)
         }
-        Ty::MapKV { k, v } => unpack_map(data, symbols, k, v),
+        Ty::MapKV {
+            key_ty_idx,
+            value_ty_idx,
+        } => unpack_map(data, symbols, *key_ty_idx, *value_ty_idx),
         Ty::Unknown => unsupported_type("unknown"),
     }
 }
 
-fn unpack_struct(
+fn unpack_struct<S: UnpackSchema + ?Sized>(
     data: &mut CellSlice<'_>,
-    symbols: &SourceMap,
+    symbols: &S,
+    ty_idx: TyIdx,
     struct_name: &str,
-    type_args: &[Ty],
 ) -> anyhow::Result<UnpackedValue> {
-    let decl = find_struct_decl(symbols, struct_name)
+    let decl = symbols
+        .struct_decl_info(struct_name)
         .ok_or_else(|| anyhow!("struct {struct_name} referenced by type was not found"))?;
     ensure_standard_layout(struct_name, decl.custom_pack_unpack)?;
 
     if let Some(prefix) = decl.prefix {
-        check_prefix(data, &prefix.prefix_str, prefix.prefix_len, struct_name)?;
+        check_prefix(data, prefix.prefix_num, prefix.prefix_len, struct_name)?;
     }
 
-    let type_params = validate_type_args(struct_name, decl.type_params, type_args)?;
-    let mut fields = Vec::with_capacity(decl.fields.len());
-    for field in decl.fields {
-        let field_ty = instantiate_generics(&field.ty, type_params, type_args);
-        let value = unpack_type(data, symbols, &field_ty)
+    let struct_fields = symbols
+        .struct_fields_for(ty_idx)
+        .ok_or_else(|| anyhow!("failed to resolve fields for {struct_name}"))?;
+    let mut fields = Vec::with_capacity(struct_fields.len());
+    for field in &struct_fields {
+        let value = unpack_type(data, symbols, field.ty_idx)
             .with_context(|| format!("failed to decode field {struct_name}.{}", field.name))?;
         fields.push((field.name.clone(), value));
     }
@@ -169,32 +342,35 @@ fn unpack_struct(
     })
 }
 
-fn unpack_alias(
+fn unpack_alias<S: UnpackSchema + ?Sized>(
     data: &mut CellSlice<'_>,
-    symbols: &SourceMap,
+    symbols: &S,
+    ty_idx: TyIdx,
     alias_name: &str,
-    type_args: &[Ty],
 ) -> anyhow::Result<UnpackedValue> {
-    let decl = find_alias_decl(symbols, alias_name)
+    let decl = symbols
+        .alias_decl_info(alias_name)
         .ok_or_else(|| anyhow!("alias {alias_name} referenced by type was not found"))?;
     ensure_standard_layout(alias_name, decl.custom_pack_unpack)?;
-    let type_params = validate_type_args(alias_name, decl.type_params, type_args)?;
-    let target_ty = instantiate_generics(decl.target_ty, type_params, type_args);
-    unpack_type(data, symbols, &target_ty)
+    let target_ty_idx = symbols
+        .alias_target_for(ty_idx)
+        .ok_or_else(|| anyhow!("failed to resolve target for alias {alias_name}"))?;
+    unpack_type(data, symbols, target_ty_idx)
 }
 
-fn unpack_enum(
+fn unpack_enum<S: UnpackSchema + ?Sized>(
     data: &mut CellSlice<'_>,
-    symbols: &SourceMap,
+    symbols: &S,
     enum_name: &str,
 ) -> anyhow::Result<UnpackedValue> {
-    let decl = find_enum_decl(symbols, enum_name)
+    let decl = symbols
+        .enum_decl_info(enum_name)
         .ok_or_else(|| anyhow!("enum {enum_name} referenced by type was not found"))?;
     ensure_standard_layout(enum_name, decl.custom_pack_unpack)?;
 
-    let encoded_ty = parse_enum_encoded_as(decl.encoded_as)?;
-    let value = unpack_type(data, symbols, encoded_ty)?;
-    let label = find_enum_member_name(&value, decl.members).map_or_else(
+    let encoded_ty_idx = parse_enum_encoded_as(symbols, decl.encoded_as_ty_idx)?;
+    let value = unpack_type(data, symbols, encoded_ty_idx)?;
+    let label = find_enum_member_name(&value, &decl.members).map_or_else(
         || format!("{enum_name}({})", format_enum_encoded_value(&value)),
         |member_name| format!("{enum_name}.{member_name}"),
     );
@@ -213,14 +389,14 @@ fn format_enum_encoded_value(value: &UnpackedValue) -> String {
     }
 }
 
-fn unpack_union(
+fn unpack_union<S: UnpackSchema + ?Sized>(
     data: &mut CellSlice<'_>,
-    symbols: &SourceMap,
+    symbols: &S,
     variants: &[UnionVariant],
 ) -> anyhow::Result<UnpackedValue> {
     let variants = resolve_union_variants(symbols, variants)?;
     for variant in variants {
-        if !matches_prefix(data, &variant.prefix_str, variant.prefix_len)? {
+        if !matches_prefix(data, variant.prefix_num, variant.prefix_len)? {
             continue;
         }
 
@@ -231,7 +407,7 @@ fn unpack_union(
             )?;
         }
 
-        let value = unpack_type(data, symbols, &variant.variant_ty)?;
+        let value = unpack_type(data, symbols, variant.variant_ty_idx)?;
         if !variant.has_value_field {
             return Ok(value);
         }
@@ -245,50 +421,27 @@ fn unpack_union(
     anyhow::bail!("none of union prefixes matched")
 }
 
-fn unpack_map(
+fn unpack_map<S: UnpackSchema + ?Sized>(
     data: &mut CellSlice<'_>,
-    symbols: &SourceMap,
-    key_ty: &Ty,
-    value_ty: &Ty,
+    symbols: &S,
+    key_ty_idx: TyIdx,
+    value_ty_idx: TyIdx,
 ) -> anyhow::Result<UnpackedValue> {
-    let key_bits = map_key_bit_len(symbols, key_ty)?;
+    let key_bits = map_key_bit_len(symbols, key_ty_idx)?;
     let dict = Option::<Cell>::load_from(data)?;
 
     let mut entries = Vec::new();
     for entry in dict::RawIter::new(&dict, key_bits) {
         let (key_data, mut value_slice) = entry?;
-        let key = unpack_type(&mut key_data.as_data_slice(), symbols, key_ty)
+        let key = unpack_type(&mut key_data.as_data_slice(), symbols, key_ty_idx)
             .context("failed to decode map key")?;
-        let value = unpack_type(&mut value_slice, symbols, value_ty)
+        let value = unpack_type(&mut value_slice, symbols, value_ty_idx)
             .context("failed to decode map value")?;
         ensure_fully_consumed(&value_slice, "map value")?;
         entries.push((key, value));
     }
 
     Ok(UnpackedValue::Map(entries))
-}
-
-fn validate_type_args<'a>(
-    type_name: &str,
-    type_params: Option<&'a [String]>,
-    type_args: &[Ty],
-) -> anyhow::Result<&'a [String]> {
-    let Some(type_params) = type_params else {
-        if type_args.is_empty() {
-            return Ok(&[]);
-        }
-        anyhow::bail!("{type_name} does not accept type arguments");
-    };
-
-    if type_params.len() != type_args.len() {
-        anyhow::bail!(
-            "{type_name} expected {} type arguments, got {}",
-            type_params.len(),
-            type_args.len()
-        );
-    }
-
-    Ok(type_params)
 }
 
 fn ensure_standard_layout(
@@ -303,16 +456,15 @@ fn ensure_standard_layout(
 
 fn check_prefix(
     data: &mut CellSlice<'_>,
-    prefix_str: &str,
+    prefix_num: u64,
     prefix_len: i32,
     type_name: &str,
 ) -> anyhow::Result<()> {
     let prefix_len = u16::try_from(prefix_len).context("negative prefix length")?;
-    let expected = parse_prefix(prefix_str)?;
     let actual = data.load_uint(prefix_len)?;
-    if actual != expected {
+    if actual != prefix_num {
         anyhow::bail!(
-            "incorrect prefix for '{type_name}': expected {prefix_str}, got 0x{actual:x}"
+            "incorrect prefix for '{type_name}': expected 0x{prefix_num:x}, got 0x{actual:x}"
         );
     }
     Ok(())
@@ -320,28 +472,14 @@ fn check_prefix(
 
 fn matches_prefix(
     data: &CellSlice<'_>,
-    prefix_str: &str,
+    prefix_num: u64,
     prefix_len: usize,
 ) -> anyhow::Result<bool> {
     let prefix_len = u16::try_from(prefix_len).context("union prefix length exceeds u16")?;
     if !data.has_remaining(prefix_len, 0) {
         return Ok(false);
     }
-    Ok(data.get_uint(0, prefix_len)? == parse_prefix(prefix_str)?)
-}
-
-fn parse_prefix(prefix_str: &str) -> anyhow::Result<u64> {
-    if let Some(hex) = prefix_str.strip_prefix("0x") {
-        return u64::from_str_radix(hex, 16)
-            .with_context(|| format!("failed to parse hex prefix {prefix_str}"));
-    }
-    if let Some(bits) = prefix_str.strip_prefix("0b") {
-        return u64::from_str_radix(bits, 2)
-            .with_context(|| format!("failed to parse binary prefix {prefix_str}"));
-    }
-    prefix_str
-        .parse::<u64>()
-        .with_context(|| format!("failed to parse decimal prefix {prefix_str}"))
+    Ok(data.get_uint(0, prefix_len)? == prefix_num)
 }
 
 fn varint_len_bits(n: u32) -> anyhow::Result<u16> {
@@ -376,21 +514,30 @@ fn unsupported_type(name: &str) -> anyhow::Result<UnpackedValue> {
     anyhow::bail!("cannot decode unsupported Tolk type {name}")
 }
 
-fn parse_enum_encoded_as(encoded_as: &Ty) -> anyhow::Result<&Ty> {
+fn parse_enum_encoded_as<S: UnpackSchema + ?Sized>(
+    symbols: &S,
+    encoded_as_ty_idx: TyIdx,
+) -> anyhow::Result<TyIdx> {
+    let encoded_as = symbols
+        .ty_by_idx(encoded_as_ty_idx)
+        .ok_or_else(|| anyhow!("ABI ty_idx {encoded_as_ty_idx} was not found"))?;
     match encoded_as {
         Ty::Bool
         | Ty::Coins
         | Ty::UintN { .. }
         | Ty::IntN { .. }
         | Ty::VaruintN { .. }
-        | Ty::VarintN { .. } => Ok(encoded_as),
-        other => anyhow::bail!("unsupported enum encoding {}", other.render_type()),
+        | Ty::VarintN { .. } => Ok(encoded_as_ty_idx),
+        _ => anyhow::bail!(
+            "unsupported enum encoding {}",
+            render_ty(symbols, encoded_as_ty_idx)
+        ),
     }
 }
 
 fn find_enum_member_name<'a>(
     value: &UnpackedValue,
-    members: &'a [EnumMemberInfo],
+    members: &'a [SchemaEnumMember],
 ) -> Option<&'a str> {
     members.iter().find_map(|member| match value {
         UnpackedValue::Number(number) => member
@@ -438,53 +585,57 @@ fn parse_snake_bytes_slice(parser: &mut CellSlice<'_>) -> Option<Vec<u8>> {
     Some(bytes)
 }
 
-fn map_key_bit_len(symbols: &SourceMap, ty: &Ty) -> anyhow::Result<u16> {
+fn map_key_bit_len<S: UnpackSchema + ?Sized>(symbols: &S, ty_idx: TyIdx) -> anyhow::Result<u16> {
+    let ty = symbols
+        .ty_by_idx(ty_idx)
+        .ok_or_else(|| anyhow!("ABI ty_idx {ty_idx} was not found"))?;
     match ty {
         Ty::Bool => Ok(1),
         Ty::IntN { n } | Ty::UintN { n } => u16::try_from(*n).context("map key width exceeds u16"),
         Ty::Address => Ok(StdAddr::BITS_WITHOUT_ANYCAST),
-        Ty::AliasRef {
-            alias_name,
-            type_args,
-        } => {
-            let decl = find_alias_decl(symbols, alias_name)
+        Ty::AliasRef { alias_name, .. } => {
+            let decl = symbols
+                .alias_decl_info(alias_name)
                 .ok_or_else(|| anyhow!("alias {alias_name} referenced by type was not found"))?;
             ensure_standard_layout(alias_name, decl.custom_pack_unpack)?;
-            let type_args = type_args.as_deref().unwrap_or(&[]);
-            let type_params = validate_type_args(alias_name, decl.type_params, type_args)?;
-            let target_ty = instantiate_generics(decl.target_ty, type_params, type_args);
-            map_key_bit_len(symbols, &target_ty)
+            let target_ty_idx = symbols
+                .alias_target_for(ty_idx)
+                .ok_or_else(|| anyhow!("failed to resolve target for alias {alias_name}"))?;
+            map_key_bit_len(symbols, target_ty_idx)
         }
         Ty::EnumRef { enum_name } => {
-            let decl = find_enum_decl(symbols, enum_name)
+            let decl = symbols
+                .enum_decl_info(enum_name)
                 .ok_or_else(|| anyhow!("enum {enum_name} referenced by type was not found"))?;
             ensure_standard_layout(enum_name, decl.custom_pack_unpack)?;
-            map_key_bit_len(symbols, parse_enum_encoded_as(decl.encoded_as)?)
+            map_key_bit_len(
+                symbols,
+                parse_enum_encoded_as(symbols, decl.encoded_as_ty_idx)?,
+            )
         }
-        _ => anyhow::bail!("unsupported map key type {}", ty.render_type()),
+        _ => anyhow::bail!("unsupported map key type {}", render_ty(symbols, ty_idx)),
     }
 }
 
 #[derive(Clone)]
 struct ResolvedUnionVariant {
-    variant_ty: Ty,
-    prefix_str: String,
+    variant_ty_idx: TyIdx,
+    prefix_num: u64,
     prefix_len: usize,
     prefix_eat_in_place: bool,
     label: String,
     has_value_field: bool,
 }
 
-fn resolve_union_variants(
-    symbols: &SourceMap,
+fn resolve_union_variants<S: UnpackSchema + ?Sized>(
+    symbols: &S,
     variants: &[UnionVariant],
 ) -> anyhow::Result<Vec<ResolvedUnionVariant>> {
     let mut simple_labels = Vec::with_capacity(variants.len());
     let mut concrete_variants = Vec::with_capacity(variants.len());
     for variant in variants {
-        let concrete = variant.variant_ty.clone();
-        simple_labels.push(union_label_simple(symbols, &concrete)?);
-        concrete_variants.push(concrete);
+        simple_labels.push(union_label_simple(symbols, variant.variant_ty_idx)?);
+        concrete_variants.push(variant.variant_ty_idx);
     }
 
     let has_duplicates = simple_labels
@@ -496,28 +647,34 @@ fn resolve_union_variants(
         .iter()
         .zip(concrete_variants)
         .zip(simple_labels)
-        .map(|((variant, concrete), simple_label)| {
-            let is_null = matches!(concrete, Ty::NullLiteral);
+        .map(|((variant, concrete_ty_idx), simple_label)| {
+            let is_null = matches!(symbols.ty_by_idx(concrete_ty_idx), Some(Ty::NullLiteral));
             Ok(ResolvedUnionVariant {
-                variant_ty: concrete.clone(),
-                prefix_str: variant.prefix_str.clone(),
+                variant_ty_idx: concrete_ty_idx,
+                prefix_num: variant.prefix_num,
                 prefix_len: variant.prefix_len,
                 prefix_eat_in_place: variant.is_prefix_implicit.unwrap_or(false),
                 label: if is_null {
                     String::new()
                 } else if has_duplicates {
-                    concrete.render_type()
+                    render_ty(symbols, concrete_ty_idx)
                 } else {
                     simple_label
                 },
                 has_value_field: !is_null
-                    && (has_duplicates || !type_has_own_label(symbols, &concrete)?),
+                    && (has_duplicates || !type_has_own_label(symbols, concrete_ty_idx)?),
             })
         })
         .collect()
 }
 
-fn union_label_simple(symbols: &SourceMap, ty: &Ty) -> anyhow::Result<String> {
+fn union_label_simple<S: UnpackSchema + ?Sized>(
+    symbols: &S,
+    ty_idx: TyIdx,
+) -> anyhow::Result<String> {
+    let ty = symbols
+        .ty_by_idx(ty_idx)
+        .ok_or_else(|| anyhow!("ABI ty_idx {ty_idx} was not found"))?;
     Ok(match ty {
         Ty::Int => "int".to_owned(),
         Ty::IntN { n } => format!("int{n}"),
@@ -538,28 +695,28 @@ fn union_label_simple(symbols: &SourceMap, ty: &Ty) -> anyhow::Result<String> {
         Ty::NullLiteral => "null".to_owned(),
         Ty::Callable => "callable".to_owned(),
         Ty::Void => "void".to_owned(),
-        Ty::Nullable { inner, .. } => format!("{}?", union_label_simple(symbols, inner)?),
+        Ty::Nullable { inner_ty_idx, .. } => {
+            format!("{}?", union_label_simple(symbols, *inner_ty_idx)?)
+        }
         Ty::CellOf { .. } => "Cell".to_owned(),
         Ty::Tensor { .. } | Ty::ShapedTuple { .. } => "tensor".to_owned(),
         Ty::MapKV { .. } => "map".to_owned(),
         Ty::EnumRef { enum_name } => enum_name.clone(),
         Ty::StructRef { struct_name, .. } => struct_name.clone(),
-        Ty::AliasRef {
-            alias_name,
-            type_args,
-        } => {
-            let decl = find_alias_decl(symbols, alias_name)
+        Ty::AliasRef { alias_name, .. } => {
+            let decl = symbols
+                .alias_decl_info(alias_name)
                 .ok_or_else(|| anyhow!("alias {alias_name} referenced by type was not found"))?;
             ensure_standard_layout(alias_name, decl.custom_pack_unpack)?;
-            let type_args = type_args.as_deref().unwrap_or(&[]);
-            let type_params = validate_type_args(alias_name, decl.type_params, type_args)?;
-            let target_ty = instantiate_generics(decl.target_ty, type_params, type_args);
-            union_label_simple(symbols, &target_ty)?
+            let target_ty_idx = symbols
+                .alias_target_for(ty_idx)
+                .ok_or_else(|| anyhow!("failed to resolve target for alias {alias_name}"))?;
+            union_label_simple(symbols, target_ty_idx)?
         }
         Ty::GenericT { name_t } => name_t.clone(),
         Ty::Union { variants, .. } => variants
             .iter()
-            .map(|variant| union_label_simple(symbols, &variant.variant_ty))
+            .map(|variant| union_label_simple(symbols, variant.variant_ty_idx))
             .collect::<anyhow::Result<Vec<_>>>()?
             .join("|"),
         Ty::ArrayOf { .. } => "array".to_owned(),
@@ -569,94 +726,26 @@ fn union_label_simple(symbols: &SourceMap, ty: &Ty) -> anyhow::Result<String> {
     })
 }
 
-fn type_has_own_label(symbols: &SourceMap, ty: &Ty) -> anyhow::Result<bool> {
+fn type_has_own_label<S: UnpackSchema + ?Sized>(
+    symbols: &S,
+    ty_idx: TyIdx,
+) -> anyhow::Result<bool> {
+    let ty = symbols
+        .ty_by_idx(ty_idx)
+        .ok_or_else(|| anyhow!("ABI ty_idx {ty_idx} was not found"))?;
     Ok(match ty {
         Ty::StructRef { .. } => true,
-        Ty::AliasRef {
-            alias_name,
-            type_args,
-        } => {
-            let decl = find_alias_decl(symbols, alias_name)
+        Ty::AliasRef { alias_name, .. } => {
+            let decl = symbols
+                .alias_decl_info(alias_name)
                 .ok_or_else(|| anyhow!("alias {alias_name} referenced by type was not found"))?;
             ensure_standard_layout(alias_name, decl.custom_pack_unpack)?;
-            let type_args = type_args.as_deref().unwrap_or(&[]);
-            let type_params = validate_type_args(alias_name, decl.type_params, type_args)?;
-            let target_ty = instantiate_generics(decl.target_ty, type_params, type_args);
-            type_has_own_label(symbols, &target_ty)?
+            let target_ty_idx = symbols
+                .alias_target_for(ty_idx)
+                .ok_or_else(|| anyhow!("failed to resolve target for alias {alias_name}"))?;
+            type_has_own_label(symbols, target_ty_idx)?
         }
         _ => false,
-    })
-}
-
-struct StructDeclRef<'a> {
-    type_params: Option<&'a [String]>,
-    prefix: Option<&'a PrefixInfo>,
-    fields: &'a [FieldInfo],
-    custom_pack_unpack: Option<&'a ABICustomPackUnpack>,
-}
-
-struct AliasDeclRef<'a> {
-    type_params: Option<&'a [String]>,
-    target_ty: &'a Ty,
-    custom_pack_unpack: Option<&'a ABICustomPackUnpack>,
-}
-
-struct EnumDeclRef<'a> {
-    encoded_as: &'a Ty,
-    members: &'a [EnumMemberInfo],
-    custom_pack_unpack: Option<&'a ABICustomPackUnpack>,
-}
-
-fn find_struct_decl<'a>(symbols: &'a SourceMap, target_name: &str) -> Option<StructDeclRef<'a>> {
-    symbols.declarations().iter().find_map(|decl| match decl {
-        Declaration::Struct(AbiStruct {
-            name,
-            type_params,
-            prefix,
-            fields,
-            custom_pack_unpack,
-            ..
-        }) if name == target_name => Some(StructDeclRef {
-            type_params: type_params.as_deref(),
-            prefix: prefix.as_ref(),
-            fields: fields.as_slice(),
-            custom_pack_unpack: custom_pack_unpack.as_ref(),
-        }),
-        _ => None,
-    })
-}
-
-fn find_alias_decl<'a>(symbols: &'a SourceMap, target_name: &str) -> Option<AliasDeclRef<'a>> {
-    symbols.declarations().iter().find_map(|decl| match decl {
-        Declaration::Alias(AbiAlias {
-            name,
-            target_ty,
-            type_params,
-            custom_pack_unpack,
-            ..
-        }) if name == target_name => Some(AliasDeclRef {
-            type_params: type_params.as_deref(),
-            target_ty,
-            custom_pack_unpack: custom_pack_unpack.as_ref(),
-        }),
-        _ => None,
-    })
-}
-
-fn find_enum_decl<'a>(symbols: &'a SourceMap, target_name: &str) -> Option<EnumDeclRef<'a>> {
-    symbols.declarations().iter().find_map(|decl| match decl {
-        Declaration::Enum(AbiEnum {
-            name,
-            encoded_as,
-            members,
-            custom_pack_unpack,
-            ..
-        }) if name == target_name => Some(EnumDeclRef {
-            encoded_as,
-            members: members.as_slice(),
-            custom_pack_unpack: custom_pack_unpack.as_ref(),
-        }),
-        _ => None,
     })
 }
 
@@ -665,10 +754,7 @@ mod tests {
     use super::*;
     use crate::abi::{
         ABIDeclaration, ABIEnumMember, ABIInternalMessage, ABIOpcode, ABIStorage, ABIStructField,
-        ContractABI, UnionVariant,
-    };
-    use crate::source_map::{
-        AbiAlias, AbiEnum, AbiStruct, Declaration, EnumMemberInfo, FieldInfo, PrefixInfo, SrcRange,
+        ContractABI, StructInstantiation, UnionVariant,
     };
     use tycho_types::cell::{CellBuilder, CellFamily, Store};
     use tycho_types::models::{AnyAddr, ExtAddr, StdAddr};
@@ -680,14 +766,17 @@ mod tests {
             author: String::new(),
             version: String::new(),
             description: String::new(),
+            unique_types: Vec::new(),
+            struct_instantiations: Vec::new(),
+            alias_instantiations: Vec::new(),
             declarations: Vec::new(),
             incoming_messages: Vec::new(),
             incoming_external: Vec::new(),
             outgoing_messages: Vec::new(),
             emitted_events: Vec::new(),
             storage: ABIStorage {
-                storage_ty: None,
-                storage_at_deployment_ty: None,
+                storage_ty_idx: None,
+                storage_at_deployment_ty_idx: None,
                 description: String::new(),
             },
             get_methods: Vec::new(),
@@ -697,79 +786,32 @@ mod tests {
         }
     }
 
-    fn symbols_from_abi(abi: &ContractABI) -> SourceMap {
-        let declarations = abi
-            .declarations
-            .iter()
-            .map(|decl| match decl {
-                ABIDeclaration::Struct {
-                    name,
-                    type_params,
-                    prefix,
-                    fields,
-                    custom_pack_unpack,
-                    overrides_client_type: _,
-                } => Declaration::Struct(AbiStruct {
-                    name: name.clone(),
-                    ident_loc: loc(),
-                    type_params: type_params.clone(),
-                    prefix: prefix.as_ref().map(|prefix| PrefixInfo {
-                        prefix_str: prefix.prefix_str.clone(),
-                        prefix_len: prefix.prefix_len,
-                    }),
-                    fields: fields
-                        .iter()
-                        .map(|field| FieldInfo {
-                            name: field.name.clone(),
-                            ty: field.ty.clone(),
-                        })
-                        .collect(),
-                    custom_pack_unpack: custom_pack_unpack.clone(),
-                }),
-                ABIDeclaration::Alias {
-                    name,
-                    target_ty,
-                    type_params,
-                    custom_pack_unpack,
-                } => Declaration::Alias(AbiAlias {
-                    name: name.clone(),
-                    ident_loc: loc(),
-                    target_ty: target_ty.clone(),
-                    type_params: type_params.clone(),
-                    custom_pack_unpack: custom_pack_unpack.clone(),
-                }),
-                ABIDeclaration::Enum {
-                    name,
-                    encoded_as,
-                    members,
-                    custom_pack_unpack,
-                } => Declaration::Enum(AbiEnum {
-                    name: name.clone(),
-                    ident_loc: loc(),
-                    encoded_as: encoded_as.clone(),
-                    members: members
-                        .iter()
-                        .map(|member| EnumMemberInfo {
-                            name: member.name.clone(),
-                            value: member.value.clone(),
-                        })
-                        .collect(),
-                    custom_pack_unpack: custom_pack_unpack.clone(),
-                }),
-            })
-            .collect::<Vec<_>>();
-
-        serde_json::from_value(serde_json::json!({
-            "files": [],
-            "declarations": declarations,
-            "unique_ty": [],
-            "functions": [],
-        }))
-        .unwrap()
+    fn add_ty(abi: &mut ContractABI, ty: Ty) -> TyIdx {
+        if let Some(idx) = abi.unique_types.iter().position(|existing| existing == &ty) {
+            return idx;
+        }
+        let idx = abi.unique_types.len();
+        abi.unique_types.push(ty);
+        idx
     }
 
-    fn loc() -> SrcRange {
-        SrcRange(vec![0, 0, 0, 0, 0])
+    fn struct_ref(abi: &mut ContractABI, struct_name: &str) -> TyIdx {
+        add_ty(
+            abi,
+            Ty::StructRef {
+                struct_name: struct_name.to_owned(),
+                type_args_ty_idx: None,
+            },
+        )
+    }
+
+    fn enum_ref(abi: &mut ContractABI, enum_name: &str) -> TyIdx {
+        add_ty(
+            abi,
+            Ty::EnumRef {
+                enum_name: enum_name.to_owned(),
+            },
+        )
     }
 
     fn build_snake_bytes_cell(bytes: &[u8]) -> Cell {
@@ -804,23 +846,27 @@ mod tests {
     #[test]
     fn decodes_struct_with_prefix_and_fields() {
         let mut abi = empty_abi();
+        let body_ty_idx = struct_ref(&mut abi, "MyMessage");
+        let query_ty_idx = add_ty(&mut abi, Ty::UintN { n: 64 });
+        let flag_ty_idx = add_ty(&mut abi, Ty::Bool);
         abi.declarations = vec![ABIDeclaration::Struct {
             name: "MyMessage".to_owned(),
+            ty_idx: body_ty_idx,
             type_params: None,
             prefix: Some(ABIOpcode {
-                prefix_str: "0x12345678".to_owned(),
+                prefix_num: 0x12345678,
                 prefix_len: 32,
             }),
             fields: vec![
                 ABIStructField {
                     name: "queryId".to_owned(),
-                    ty: Ty::UintN { n: 64 },
+                    ty_idx: query_ty_idx,
                     default_value: None,
                     description: String::new(),
                 },
                 ABIStructField {
                     name: "flag".to_owned(),
-                    ty: Ty::Bool,
+                    ty_idx: flag_ty_idx,
                     default_value: None,
                     description: String::new(),
                 },
@@ -829,10 +875,7 @@ mod tests {
             overrides_client_type: false,
         }];
         abi.incoming_messages = vec![ABIInternalMessage {
-            body_ty: Ty::StructRef {
-                struct_name: "MyMessage".to_owned(),
-                type_args: None,
-            },
+            body_ty_idx,
             description: String::new(),
         }];
 
@@ -842,17 +885,8 @@ mod tests {
         builder.store_bit(true).unwrap();
         let cell = builder.build().unwrap();
         let mut slice = cell.as_slice_allow_exotic();
-        let symbols = symbols_from_abi(&abi);
 
-        let data = unpack_from_slice(
-            &mut slice,
-            &symbols,
-            &Ty::StructRef {
-                struct_name: "MyMessage".to_owned(),
-                type_args: None,
-            },
-        )
-        .unwrap();
+        let data = unpack_from_abi_slice(&mut slice, &abi, body_ty_idx).unwrap();
 
         let UnpackedValue::Object { name, fields } = data else {
             panic!("expected object");
@@ -869,23 +903,32 @@ mod tests {
     #[test]
     fn decodes_address_any_and_map() {
         let mut abi = empty_abi();
+        let payload_ty_idx = struct_ref(&mut abi, "Payload");
+        let owner_ty_idx = add_ty(&mut abi, Ty::AddressAny);
+        let key_ty_idx = add_ty(&mut abi, Ty::UintN { n: 8 });
+        let value_ty_idx = add_ty(&mut abi, Ty::Bool);
+        let map_ty_idx = add_ty(
+            &mut abi,
+            Ty::MapKV {
+                key_ty_idx,
+                value_ty_idx,
+            },
+        );
         abi.declarations = vec![ABIDeclaration::Struct {
             name: "Payload".to_owned(),
+            ty_idx: payload_ty_idx,
             type_params: None,
             prefix: None,
             fields: vec![
                 ABIStructField {
                     name: "owner".to_owned(),
-                    ty: Ty::AddressAny,
+                    ty_idx: owner_ty_idx,
                     default_value: None,
                     description: String::new(),
                 },
                 ABIStructField {
                     name: "items".to_owned(),
-                    ty: Ty::MapKV {
-                        k: Box::new(Ty::UintN { n: 8 }),
-                        v: Box::new(Ty::Bool),
-                    },
+                    ty_idx: map_ty_idx,
                     default_value: None,
                     description: String::new(),
                 },
@@ -906,47 +949,32 @@ mod tests {
         map.store_into(&mut builder, Cell::empty_context()).unwrap();
         let cell = builder.build().unwrap();
         let mut slice = cell.as_slice_allow_exotic();
-        let symbols = symbols_from_abi(&abi);
 
-        let data = unpack_from_slice(
-            &mut slice,
-            &symbols,
-            &Ty::StructRef {
-                struct_name: "Payload".to_owned(),
-                type_args: None,
-            },
-        )
-        .unwrap();
+        let data = unpack_from_abi_slice(&mut slice, &abi, payload_ty_idx).unwrap();
 
         assert!(matches!(data, UnpackedValue::Object { .. }));
     }
 
     #[test]
     fn decodes_auto_prefixed_union() {
-        let abi = empty_abi();
-        let mut builder = CellBuilder::new();
-        builder.store_bit(true).unwrap();
-        builder.store_uint(99, 16).unwrap();
-        let cell = builder.build().unwrap();
-        let mut slice = cell.as_slice_allow_exotic();
-        let symbols = symbols_from_abi(&abi);
-
-        let data = unpack_from_slice(
-            &mut slice,
-            &symbols,
-            &Ty::Union {
+        let mut abi = empty_abi();
+        let uint8_ty_idx = add_ty(&mut abi, Ty::UintN { n: 8 });
+        let uint16_ty_idx = add_ty(&mut abi, Ty::UintN { n: 16 });
+        let union_ty_idx = add_ty(
+            &mut abi,
+            Ty::Union {
                 variants: vec![
                     UnionVariant {
-                        variant_ty: Ty::UintN { n: 8 },
-                        prefix_str: "0".to_owned(),
+                        variant_ty_idx: uint8_ty_idx,
+                        prefix_num: 0,
                         prefix_len: 1,
                         is_prefix_implicit: Some(true),
                         stack_type_id: None,
                         stack_width: None,
                     },
                     UnionVariant {
-                        variant_ty: Ty::UintN { n: 16 },
-                        prefix_str: "1".to_owned(),
+                        variant_ty_idx: uint16_ty_idx,
+                        prefix_num: 1,
                         prefix_len: 1,
                         is_prefix_implicit: Some(true),
                         stack_type_id: None,
@@ -955,8 +983,14 @@ mod tests {
                 ],
                 stack_width: None,
             },
-        )
-        .unwrap();
+        );
+        let mut builder = CellBuilder::new();
+        builder.store_bit(true).unwrap();
+        builder.store_uint(99, 16).unwrap();
+        let cell = builder.build().unwrap();
+        let mut slice = cell.as_slice_allow_exotic();
+
+        let data = unpack_from_abi_slice(&mut slice, &abi, union_ty_idx).unwrap();
 
         let UnpackedValue::Object { name, fields } = data else {
             panic!("expected object");
@@ -970,15 +1004,40 @@ mod tests {
     #[test]
     fn decodes_generic_struct_fields_with_instantiated_types() {
         let mut abi = empty_abi();
+        let generic_ty_idx = add_ty(
+            &mut abi,
+            Ty::GenericT {
+                name_t: "T".to_owned(),
+            },
+        );
+        let boxed_generic_ty_idx = add_ty(
+            &mut abi,
+            Ty::StructRef {
+                struct_name: "Boxed".to_owned(),
+                type_args_ty_idx: Some(vec![generic_ty_idx]),
+            },
+        );
+        let value_ty_idx = add_ty(&mut abi, Ty::UintN { n: 32 });
+        let boxed_uint_ty_idx = add_ty(
+            &mut abi,
+            Ty::StructRef {
+                struct_name: "Boxed".to_owned(),
+                type_args_ty_idx: Some(vec![value_ty_idx]),
+            },
+        );
+        abi.struct_instantiations.push(StructInstantiation {
+            ty_idx: boxed_uint_ty_idx,
+            struct_name: "Boxed".to_owned(),
+            monomorphic_fields_ty_idx: vec![value_ty_idx],
+        });
         abi.declarations = vec![ABIDeclaration::Struct {
             name: "Boxed".to_owned(),
+            ty_idx: boxed_generic_ty_idx,
             type_params: Some(vec!["T".to_owned()]),
             prefix: None,
             fields: vec![ABIStructField {
                 name: "value".to_owned(),
-                ty: Ty::GenericT {
-                    name_t: "T".to_owned(),
-                },
+                ty_idx: generic_ty_idx,
                 default_value: None,
                 description: String::new(),
             }],
@@ -990,17 +1049,8 @@ mod tests {
         builder.store_uint(7, 32).unwrap();
         let cell = builder.build().unwrap();
         let mut slice = cell.as_slice_allow_exotic();
-        let symbols = symbols_from_abi(&abi);
 
-        let data = unpack_from_slice(
-            &mut slice,
-            &symbols,
-            &Ty::StructRef {
-                struct_name: "Boxed".to_owned(),
-                type_args: Some(vec![Ty::UintN { n: 32 }]),
-            },
-        )
-        .unwrap();
+        let data = unpack_from_abi_slice(&mut slice, &abi, boxed_uint_ty_idx).unwrap();
 
         let UnpackedValue::Object { name, fields } = data else {
             panic!("expected object");
@@ -1014,9 +1064,12 @@ mod tests {
     #[test]
     fn decodes_enum_to_object_with_raw_value() {
         let mut abi = empty_abi();
+        let enum_ty_idx = enum_ref(&mut abi, "Color");
+        let encoded_as_ty_idx = add_ty(&mut abi, Ty::UintN { n: 8 });
         abi.declarations = vec![ABIDeclaration::Enum {
             name: "Color".to_owned(),
-            encoded_as: Ty::UintN { n: 8 },
+            ty_idx: enum_ty_idx,
+            encoded_as_ty_idx,
             members: vec![
                 ABIEnumMember {
                     name: "Red".to_owned(),
@@ -1036,16 +1089,8 @@ mod tests {
         builder.store_uint(2, 8).unwrap();
         let cell = builder.build().unwrap();
         let mut slice = cell.as_slice_allow_exotic();
-        let symbols = symbols_from_abi(&abi);
 
-        let data = unpack_from_slice(
-            &mut slice,
-            &symbols,
-            &Ty::EnumRef {
-                enum_name: "Color".to_owned(),
-            },
-        )
-        .unwrap();
+        let data = unpack_from_abi_slice(&mut slice, &abi, enum_ty_idx).unwrap();
 
         let UnpackedValue::Object { name, fields } = data else {
             panic!("expected object");
@@ -1059,9 +1104,12 @@ mod tests {
     #[test]
     fn decodes_bool_encoded_enum_to_object_with_raw_value() {
         let mut abi = empty_abi();
+        let enum_ty_idx = enum_ref(&mut abi, "Toggle");
+        let encoded_as_ty_idx = add_ty(&mut abi, Ty::Bool);
         abi.declarations = vec![ABIDeclaration::Enum {
             name: "Toggle".to_owned(),
-            encoded_as: Ty::Bool,
+            ty_idx: enum_ty_idx,
+            encoded_as_ty_idx,
             members: vec![
                 ABIEnumMember {
                     name: "Off".to_owned(),
@@ -1081,16 +1129,8 @@ mod tests {
         builder.store_bit(true).unwrap();
         let cell = builder.build().unwrap();
         let mut slice = cell.as_slice_allow_exotic();
-        let symbols = symbols_from_abi(&abi);
 
-        let data = unpack_from_slice(
-            &mut slice,
-            &symbols,
-            &Ty::EnumRef {
-                enum_name: "Toggle".to_owned(),
-            },
-        )
-        .unwrap();
+        let data = unpack_from_abi_slice(&mut slice, &abi, enum_ty_idx).unwrap();
 
         let UnpackedValue::Object { name, fields } = data else {
             panic!("expected object");
@@ -1103,20 +1143,21 @@ mod tests {
 
     #[test]
     fn decodes_address_opt_none() {
-        let abi = empty_abi();
+        let mut abi = empty_abi();
+        let ty_idx = add_ty(&mut abi, Ty::AddressOpt);
         let mut builder = CellBuilder::new();
         builder.store_uint(0, 2).unwrap();
         let cell = builder.build().unwrap();
         let mut slice = cell.as_slice_allow_exotic();
 
-        let symbols = symbols_from_abi(&abi);
-        let data = unpack_from_slice(&mut slice, &symbols, &Ty::AddressOpt).unwrap();
+        let data = unpack_from_abi_slice(&mut slice, &abi, ty_idx).unwrap();
         assert!(matches!(data, UnpackedValue::Null));
     }
 
     #[test]
     fn decodes_internal_address_any() {
-        let abi = empty_abi();
+        let mut abi = empty_abi();
+        let ty_idx = add_ty(&mut abi, Ty::AddressAny);
         let mut builder = CellBuilder::new();
         StdAddr::new(0, Default::default())
             .store_into(&mut builder, Cell::empty_context())
@@ -1124,14 +1165,14 @@ mod tests {
         let cell = builder.build().unwrap();
         let mut slice = cell.as_slice_allow_exotic();
 
-        let symbols = symbols_from_abi(&abi);
-        let data = unpack_from_slice(&mut slice, &symbols, &Ty::AddressAny).unwrap();
+        let data = unpack_from_abi_slice(&mut slice, &abi, ty_idx).unwrap();
         assert!(matches!(data, UnpackedValue::Address(_)));
     }
 
     #[test]
     fn decodes_string_from_ref_cell() {
-        let abi = empty_abi();
+        let mut abi = empty_abi();
+        let ty_idx = add_ty(&mut abi, Ty::String);
         let string_cell = build_snake_bytes_cell(b"hello");
 
         let mut builder = CellBuilder::new();
@@ -1139,8 +1180,7 @@ mod tests {
         let cell = builder.build().unwrap();
         let mut slice = cell.as_slice_allow_exotic();
 
-        let symbols = symbols_from_abi(&abi);
-        let data = unpack_from_slice(&mut slice, &symbols, &Ty::String).unwrap();
+        let data = unpack_from_abi_slice(&mut slice, &abi, ty_idx).unwrap();
         assert!(matches!(data, UnpackedValue::String(value) if value == "hello"));
     }
 }

--- a/crates/tolk-compiler/src/source_map.rs
+++ b/crates/tolk-compiler/src/source_map.rs
@@ -4,7 +4,7 @@
 
 use crate::abi::ABICustomPackUnpack;
 use crate::debug_marks_dict::DebugMarksDict;
-use crate::types_kernel::Ty;
+use crate::types_kernel::{AliasInstantiation, StructInstantiation, Ty, TyIdx, TyResolver};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fmt;
@@ -19,8 +19,10 @@ type BigintAsString = String;
 #[derive(Clone, Serialize, Deserialize, Debug, Default)]
 pub struct SourceMap {
     files: Vec<SrcFileInfo>,
+    unique_types: Vec<Ty>,
+    struct_instantiations: Vec<StructInstantiation>,
+    alias_instantiations: Vec<AliasInstantiation>,
     declarations: Vec<Declaration>,
-    unique_ty: Vec<UniqueTy>,
     functions: Vec<FunctionInfo>,
 
     #[serde(default)]
@@ -35,8 +37,10 @@ pub struct SourceMap {
 #[derive(Clone, Serialize, Deserialize, Debug, Default)]
 pub struct SymbolTypesJson {
     files: Vec<SrcFileInfo>,
+    unique_types: Vec<Ty>,
+    struct_instantiations: Vec<StructInstantiation>,
+    alias_instantiations: Vec<AliasInstantiation>,
     declarations: Vec<Declaration>,
-    unique_ty: Vec<UniqueTy>,
     functions: Vec<FunctionInfo>,
 }
 
@@ -50,7 +54,9 @@ impl SourceMap {
         SourceMap {
             files: symbol_types.files,
             declarations: symbol_types.declarations,
-            unique_ty: symbol_types.unique_ty,
+            unique_types: symbol_types.unique_types,
+            struct_instantiations: symbol_types.struct_instantiations,
+            alias_instantiations: symbol_types.alias_instantiations,
             functions: symbol_types.functions,
             debug_marks,
             marks_dict,
@@ -144,7 +150,7 @@ impl SourceMap {
             }
 
             let matches_opcode = struct_decl.prefix.as_ref().is_some_and(|prefix| {
-                prefix.prefix_len == 32 && parse_prefix_number(&prefix.prefix_str) == Some(opcode)
+                prefix.prefix_len == 32 && prefix.prefix_num == u64::from(opcode)
             });
             matches_opcode.then_some(struct_decl.name.as_str())
         })
@@ -190,6 +196,46 @@ impl SourceMap {
     }
 
     #[must_use]
+    pub fn struct_fields_of(&self, ty_idx: TyIdx) -> Option<Vec<FieldInfo>> {
+        let Ty::StructRef { struct_name, .. } = self.ty_by_idx(ty_idx)? else {
+            return None;
+        };
+        if let Some(inst) = self
+            .struct_instantiations
+            .iter()
+            .find(|inst| inst.ty_idx == ty_idx)
+        {
+            let fields = &self.get_struct(struct_name).fields;
+            if fields.len() != inst.monomorphic_fields_ty_idx.len() {
+                return None;
+            }
+            return Some(
+                fields
+                    .iter()
+                    .zip(&inst.monomorphic_fields_ty_idx)
+                    .map(|(field, &field_ty_idx)| FieldInfo {
+                        ty_idx: field_ty_idx,
+                        ..field.clone()
+                    })
+                    .collect(),
+            );
+        }
+        Some(self.get_struct(struct_name).fields.clone())
+    }
+
+    #[must_use]
+    pub fn alias_target_of(&self, ty_idx: TyIdx) -> Option<TyIdx> {
+        let Ty::AliasRef { alias_name, .. } = self.ty_by_idx(ty_idx)? else {
+            return None;
+        };
+        self.alias_instantiations
+            .iter()
+            .find(|inst| inst.ty_idx == ty_idx)
+            .map(|inst| inst.monomorphic_target_ty_idx)
+            .or_else(|| Some(self.get_alias(alias_name).target_ty_idx))
+    }
+
+    #[must_use]
     pub fn resolve_file_name(&self, file_id: usize) -> &str {
         for f in &self.files {
             if f.file_id == file_id {
@@ -223,11 +269,8 @@ impl SourceMap {
     }
 
     #[must_use]
-    pub fn resolve_ty(&self, ty_idx: usize) -> Option<&Ty> {
-        self.unique_ty
-            .iter()
-            .find(|u| u.ty_idx == ty_idx)
-            .map(|u| &u.ty)
+    pub fn ty_by_idx(&self, ty_idx: TyIdx) -> Option<&Ty> {
+        self.unique_types.get(ty_idx)
     }
 
     /// Collect all source lines that have a stoppable debug mark (LOC,
@@ -357,6 +400,21 @@ impl SourceMap {
     }
 }
 
+impl TyResolver for SourceMap {
+    fn ty_by_idx(&self, ty_idx: TyIdx) -> Option<&Ty> {
+        SourceMap::ty_by_idx(self, ty_idx)
+    }
+
+    fn struct_field_ty_indices(&self, ty_idx: TyIdx) -> Option<Vec<TyIdx>> {
+        self.struct_fields_of(ty_idx)
+            .map(|fields| fields.into_iter().map(|field| field.ty_idx).collect())
+    }
+
+    fn alias_target_ty_idx(&self, ty_idx: TyIdx) -> Option<TyIdx> {
+        self.alias_target_of(ty_idx)
+    }
+}
+
 #[derive(Clone, Debug, Default)]
 struct DeclarationIndex {
     structs: HashMap<String, usize>,
@@ -430,6 +488,7 @@ pub struct SrcFileInfo {
 #[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct AbiStruct {
     pub name: String,
+    pub ty_idx: TyIdx,
     pub ident_loc: SrcRange,
     #[serde(default)]
     pub type_params: Option<Vec<String>>,
@@ -443,8 +502,9 @@ pub struct AbiStruct {
 #[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct AbiAlias {
     pub name: String,
+    pub ty_idx: TyIdx,
     pub ident_loc: SrcRange,
-    pub target_ty: Ty,
+    pub target_ty_idx: TyIdx,
     #[serde(default)]
     pub type_params: Option<Vec<String>>,
     #[serde(default)]
@@ -454,8 +514,9 @@ pub struct AbiAlias {
 #[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct AbiEnum {
     pub name: String,
+    pub ty_idx: TyIdx,
     pub ident_loc: SrcRange,
-    pub encoded_as: Ty,
+    pub encoded_as_ty_idx: TyIdx,
     pub members: Vec<EnumMemberInfo>,
     #[serde(default)]
     pub custom_pack_unpack: Option<ABICustomPackUnpack>,
@@ -474,46 +535,20 @@ pub enum Declaration {
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct PrefixInfo {
-    pub prefix_str: String,
+    pub prefix_num: u64,
     pub prefix_len: i32,
-}
-
-fn parse_prefix_number(prefix: &str) -> Option<u32> {
-    let prefix = prefix.trim();
-    if prefix.is_empty() {
-        return None;
-    }
-    let parsed = if let Some(hex) = prefix
-        .strip_prefix("0x")
-        .or_else(|| prefix.strip_prefix("0X"))
-    {
-        u64::from_str_radix(hex, 16).ok()?
-    } else {
-        prefix.parse::<u64>().ok()?
-    };
-    u32::try_from(parsed).ok()
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct FieldInfo {
     pub name: String,
-    pub ty: Ty,
+    pub ty_idx: TyIdx,
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct EnumMemberInfo {
     pub name: String,
     pub value: BigintAsString,
-}
-
-// ---------------------------------------------------------------------------
-// Unique type table (ty_idx -> Ty)
-// ---------------------------------------------------------------------------
-
-#[derive(Clone, Serialize, Deserialize, Debug)]
-pub struct UniqueTy {
-    pub ty_idx: usize,
-    pub ty: Ty,
 }
 
 // ---------------------------------------------------------------------------
@@ -524,7 +559,7 @@ pub struct UniqueTy {
 pub struct FunctionInfo {
     pub f_idx: usize,
     pub name: String,
-    pub return_ty_idx: usize,
+    pub return_ty_idx: TyIdx,
     pub num_params: usize,
     pub ident_loc: SrcRange,
     pub end_loc: SrcRange,
@@ -566,7 +601,7 @@ pub enum DebugMark {
         mark_id: usize,
         var_name: String,
         is_parameter: bool,
-        ty_idx: usize,
+        ty_idx: TyIdx,
         ir_slots: Vec<usize>,
         #[serde(default)]
         ir_lazy_slice: Option<usize>,
@@ -579,14 +614,14 @@ pub enum DebugMark {
     SmartCast {
         mark_id: usize,
         var_name: String,
-        ty_idx: usize,
+        ty_idx: TyIdx,
         ir_slots: Vec<usize>,
     },
     #[serde(rename = "set_glob")]
     SetGlob {
         mark_id: usize,
         glob_name: String,
-        ty_idx: usize,
+        ty_idx: TyIdx,
         ir_slots: Vec<usize>,
     },
 }

--- a/crates/tolk-compiler/src/types_kernel.rs
+++ b/crates/tolk-compiler/src/types_kernel.rs
@@ -1,6 +1,8 @@
-use crate::source_map::SourceMap;
 use serde::{Deserialize, Serialize};
-use std::fmt;
+
+/// ABI and symbol-types JSON contain a flat `unique_types` table.
+/// Other entities reference table entries by `TyIdx`.
+pub type TyIdx = usize;
 
 /// ABI type that fully reflects the type system in Tolk.
 /// Mirrors TypeScript implementation `abi-types.ts`.
@@ -54,22 +56,27 @@ pub enum Ty {
     // compound types
     #[serde(rename = "nullable")]
     Nullable {
-        inner: Box<Ty>,
+        inner_ty_idx: TyIdx,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         stack_type_id: Option<usize>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         stack_width: Option<usize>,
     },
     #[serde(rename = "cellOf")]
-    CellOf { inner: Box<Ty> },
+    CellOf { inner_ty_idx: TyIdx },
     #[serde(rename = "arrayOf")]
-    ArrayOf { inner: Box<Ty> },
+    ArrayOf { inner_ty_idx: TyIdx },
     #[serde(rename = "lispListOf")]
-    LispListOf { inner: Box<Ty> },
+    LispListOf { inner_ty_idx: TyIdx },
     #[serde(rename = "tensor")]
-    Tensor { items: Vec<Ty> },
+    Tensor { items_ty_idx: Vec<TyIdx> },
     #[serde(rename = "shapedTuple")]
-    ShapedTuple { items: Vec<Ty> },
+    ShapedTuple { items_ty_idx: Vec<TyIdx> },
     #[serde(rename = "mapKV")]
-    MapKV { k: Box<Ty>, v: Box<Ty> },
+    MapKV {
+        key_ty_idx: TyIdx,
+        value_ty_idx: TyIdx,
+    },
 
     // references to user-defined types
     #[serde(rename = "EnumRef")]
@@ -77,201 +84,213 @@ pub enum Ty {
     #[serde(rename = "StructRef")]
     StructRef {
         struct_name: String,
-        type_args: Option<Vec<Ty>>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        type_args_ty_idx: Option<Vec<TyIdx>>,
     },
     #[serde(rename = "AliasRef")]
     AliasRef {
         alias_name: String,
-        type_args: Option<Vec<Ty>>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        type_args_ty_idx: Option<Vec<TyIdx>>,
     },
     #[serde(rename = "genericT")]
     GenericT { name_t: String },
     #[serde(rename = "union")]
     Union {
         variants: Vec<UnionVariant>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         stack_width: Option<usize>,
     },
 }
 
-impl fmt::Display for Ty {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Ty::Int => write!(f, "int"),
-            Ty::IntN { n } => write!(f, "int{n}"),
-            Ty::UintN { n } => write!(f, "uint{n}"),
-            Ty::VarintN { n } => write!(f, "varint{n}"),
-            Ty::VaruintN { n } => write!(f, "varuint{n}"),
-            Ty::Coins => write!(f, "coins"),
-            Ty::Bool => write!(f, "bool"),
-            Ty::Cell => write!(f, "cell"),
-            Ty::Builder => write!(f, "builder"),
-            Ty::Slice => write!(f, "slice"),
-            Ty::String => write!(f, "string"),
-            Ty::Remaining => write!(f, "RemainingBitsAndRefs"),
-            Ty::Address => write!(f, "address"),
-            Ty::AddressOpt => write!(f, "address?"),
-            Ty::AddressExt => write!(f, "ext_address"),
-            Ty::AddressAny => write!(f, "any_address"),
-            Ty::BitsN { n } => write!(f, "bits{n}"),
-            Ty::NullLiteral => write!(f, "null"),
-            Ty::Callable => write!(f, "continuation"),
-            Ty::Void => write!(f, "void"),
-            Ty::Unknown => write!(f, "unknown"),
-            Ty::Nullable { inner, .. } => write!(f, "{inner}?"),
-            Ty::CellOf { inner } => write!(f, "Cell<{inner}>"),
-            Ty::ArrayOf { inner } => write!(f, "array<{inner}>"),
-            Ty::LispListOf { inner } => write!(f, "lisp_list<{inner}>"),
-            Ty::Tensor { items } => {
-                write!(f, "(")?;
-                for (i, item) in items.iter().enumerate() {
-                    if i > 0 {
-                        write!(f, ", ")?;
-                    }
-                    write!(f, "{item}")?;
-                }
-                write!(f, ")")
-            }
-            Ty::ShapedTuple { items } => {
-                write!(f, "[")?;
-                for (i, item) in items.iter().enumerate() {
-                    if i > 0 {
-                        write!(f, ", ")?;
-                    }
-                    write!(f, "{item}")?;
-                }
-                write!(f, "]")
-            }
-            Ty::MapKV { k, v } => write!(f, "map<{k}, {v}>"),
-            Ty::EnumRef { enum_name } => write!(f, "{enum_name}"),
-            Ty::StructRef {
-                struct_name,
-                type_args,
-            } => {
-                write!(f, "{struct_name}")?;
-                if let Some(type_args) = type_args {
-                    write!(f, "<")?;
-                    for (i, item) in type_args.iter().enumerate() {
-                        if i > 0 {
-                            write!(f, ", ")?;
-                        }
-                        write!(f, "{item}")?;
-                    }
-                    write!(f, ">")?;
-                }
-                Ok(())
-            }
-            Ty::AliasRef {
-                alias_name,
-                type_args,
-            } => {
-                write!(f, "{alias_name}")?;
-                if let Some(type_args) = type_args {
-                    write!(f, "<")?;
-                    for (i, item) in type_args.iter().enumerate() {
-                        if i > 0 {
-                            write!(f, ", ")?;
-                        }
-                        write!(f, "{item}")?;
-                    }
-                    write!(f, ">")?;
-                }
-                Ok(())
-            }
-            Ty::GenericT { name_t } => write!(f, "{name_t}"),
-            Ty::Union { variants, .. } => {
-                for (i, variant) in variants.iter().enumerate() {
-                    let variant_ty = &variant.variant_ty;
-                    if i > 0 {
-                        write!(f, " | ")?;
-                    }
-                    write!(f, "{variant_ty}")?;
-                }
-                Ok(())
-            }
-        }
-    }
-}
-
-/// `UnionVariant` exists for every `T_i` in a union type `T1 | T2 | ...`.
-///
-/// For binary serialization, a union should have a prefix tree,
-/// which is either defined explicitly with struct prefixes: `struct (0x12345678) CounterIncrement`,
-/// or auto-generated (implicit), e.g. `int8 | int16 | int32` is serialized as '00'+int8 / '01'+int16 / '10'+int32.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct UnionVariant {
-    pub variant_ty: Ty,
-    pub prefix_str: String,
+    pub variant_ty_idx: TyIdx,
+    pub prefix_num: u64,
     pub prefix_len: usize,
     pub is_prefix_implicit: Option<bool>,
     pub stack_type_id: Option<usize>,
     pub stack_width: Option<usize>,
 }
 
+#[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq, Eq)]
+pub struct StructInstantiation {
+    pub ty_idx: TyIdx,
+    pub struct_name: String,
+    pub monomorphic_fields_ty_idx: Vec<TyIdx>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq, Eq)]
+pub struct AliasInstantiation {
+    pub ty_idx: TyIdx,
+    pub alias_name: String,
+    pub monomorphic_target_ty_idx: TyIdx,
+}
+
+pub trait TyResolver {
+    fn ty_by_idx(&self, ty_idx: TyIdx) -> Option<&Ty>;
+    fn struct_field_ty_indices(&self, ty_idx: TyIdx) -> Option<Vec<TyIdx>>;
+    fn alias_target_ty_idx(&self, ty_idx: TyIdx) -> Option<TyIdx>;
+}
+
+impl Ty {
+    #[must_use]
+    pub const fn is_typed_cell(&self) -> bool {
+        matches!(self, Ty::CellOf { .. })
+    }
+}
+
+#[must_use]
+pub fn render_ty<R: TyResolver + ?Sized>(symbols: &R, ty_idx: TyIdx) -> String {
+    let Some(ty) = symbols.ty_by_idx(ty_idx) else {
+        return format!("ty#{ty_idx}");
+    };
+
+    match ty {
+        Ty::Int => "int".to_owned(),
+        Ty::IntN { n } => format!("int{n}"),
+        Ty::UintN { n } => format!("uint{n}"),
+        Ty::VarintN { n } => format!("varint{n}"),
+        Ty::VaruintN { n } => format!("varuint{n}"),
+        Ty::Coins => "coins".to_owned(),
+        Ty::Bool => "bool".to_owned(),
+        Ty::Cell => "cell".to_owned(),
+        Ty::Builder => "builder".to_owned(),
+        Ty::Slice => "slice".to_owned(),
+        Ty::String => "string".to_owned(),
+        Ty::Remaining => "RemainingBitsAndRefs".to_owned(),
+        Ty::Address => "address".to_owned(),
+        Ty::AddressOpt => "address?".to_owned(),
+        Ty::AddressExt => "ext_address".to_owned(),
+        Ty::AddressAny => "any_address".to_owned(),
+        Ty::BitsN { n } => format!("bits{n}"),
+        Ty::NullLiteral => "null".to_owned(),
+        Ty::Callable => "continuation".to_owned(),
+        Ty::Void => "void".to_owned(),
+        Ty::Unknown => "unknown".to_owned(),
+        Ty::Nullable { inner_ty_idx, .. } => format!("{}?", render_ty(symbols, *inner_ty_idx)),
+        Ty::CellOf { inner_ty_idx } => format!("Cell<{}>", render_ty(symbols, *inner_ty_idx)),
+        Ty::ArrayOf { inner_ty_idx } => format!("array<{}>", render_ty(symbols, *inner_ty_idx)),
+        Ty::LispListOf { inner_ty_idx } => {
+            format!("lisp_list<{}>", render_ty(symbols, *inner_ty_idx))
+        }
+        Ty::Tensor { items_ty_idx } => format!(
+            "({})",
+            items_ty_idx
+                .iter()
+                .map(|&idx| render_ty(symbols, idx))
+                .collect::<Vec<_>>()
+                .join(", ")
+        ),
+        Ty::ShapedTuple { items_ty_idx } => format!(
+            "[{}]",
+            items_ty_idx
+                .iter()
+                .map(|&idx| render_ty(symbols, idx))
+                .collect::<Vec<_>>()
+                .join(", ")
+        ),
+        Ty::MapKV {
+            key_ty_idx,
+            value_ty_idx,
+        } => format!(
+            "map<{}, {}>",
+            render_ty(symbols, *key_ty_idx),
+            render_ty(symbols, *value_ty_idx)
+        ),
+        Ty::EnumRef { enum_name } => enum_name.clone(),
+        Ty::StructRef {
+            struct_name,
+            type_args_ty_idx,
+        } => render_named(symbols, struct_name, type_args_ty_idx.as_deref()),
+        Ty::AliasRef {
+            alias_name,
+            type_args_ty_idx,
+        } => render_named(symbols, alias_name, type_args_ty_idx.as_deref()),
+        Ty::GenericT { name_t } => name_t.clone(),
+        Ty::Union { variants, .. } => variants
+            .iter()
+            .map(|variant| render_ty(symbols, variant.variant_ty_idx))
+            .collect::<Vec<_>>()
+            .join(" | "),
+    }
+}
+
+#[must_use]
+pub fn render_param_ty<R: TyResolver + ?Sized>(symbols: &R, ty_idx: TyIdx) -> String {
+    match symbols.ty_by_idx(ty_idx) {
+        Some(Ty::CellOf { inner_ty_idx }) => render_ty(symbols, *inner_ty_idx),
+        _ => render_ty(symbols, ty_idx),
+    }
+}
+
+fn render_named<R: TyResolver + ?Sized>(
+    symbols: &R,
+    name: &str,
+    type_args_ty_idx: Option<&[TyIdx]>,
+) -> String {
+    let Some(type_args_ty_idx) = type_args_ty_idx else {
+        return name.to_owned();
+    };
+    if type_args_ty_idx.is_empty() {
+        return name.to_owned();
+    }
+    format!(
+        "{name}<{}>",
+        type_args_ty_idx
+            .iter()
+            .map(|&idx| render_ty(symbols, idx))
+            .collect::<Vec<_>>()
+            .join(", ")
+    )
+}
+
 /// Calculate how many stack slots a type occupies.
 #[must_use]
-pub fn calc_width_on_stack(symbols: &SourceMap, ty: &Ty) -> usize {
+pub fn calc_width_on_stack<R: TyResolver + ?Sized>(symbols: &R, ty_idx: TyIdx) -> usize {
+    let Some(ty) = symbols.ty_by_idx(ty_idx) else {
+        return 1;
+    };
+
     match ty {
         Ty::Void => {
             // void is like "unit", equal to an empty tensor
             0
         }
-        Ty::Tensor { items } => {
+        Ty::Tensor { items_ty_idx } => {
             // a tensor is a sum of its elements
-            items
+            items_ty_idx
                 .iter()
-                .map(|item| calc_width_on_stack(symbols, item))
+                .map(|ty_idx| calc_width_on_stack(symbols, *ty_idx))
                 .sum()
         }
-        Ty::StructRef {
-            struct_name,
-            type_args,
-        } => {
+        Ty::StructRef { .. } => {
             // a struct is a named tensor: fields one by one;
             // if a struct is generic `Wrapper<T>`, we have type_args T=xxx, and replace T in each field
             // (it works unless `T` is used in unions)
-            let struct_ref = symbols.get_struct(struct_name);
-            struct_ref
-                .fields
+            symbols
+                .struct_field_ty_indices(ty_idx)
+                .unwrap_or_default()
                 .iter()
-                .map(|f| match type_args {
-                    Some(type_args) => {
-                        let f_ty = instantiate_generics(
-                            &f.ty,
-                            struct_ref.type_params.as_deref().unwrap_or(&[]),
-                            type_args,
-                        );
-                        calc_width_on_stack(symbols, &f_ty)
-                    }
-                    None => calc_width_on_stack(symbols, &f.ty),
-                })
+                .map(|&field_ty_idx| calc_width_on_stack(symbols, field_ty_idx))
                 .sum()
         }
-        Ty::AliasRef {
-            alias_name,
-            type_args,
-        } => {
+        Ty::AliasRef { .. } => {
             // an alias is the same as its underlying (target) type;
             // if an alias is generic `Maybe<T>`, we have typeArgs T=xxx, and replace T in its target
-            let alias_ref = symbols.get_alias(alias_name);
-            match type_args {
-                Some(type_args) => {
-                    let target_ty = instantiate_generics(
-                        &alias_ref.target_ty,
-                        alias_ref.type_params.as_deref().unwrap_or(&[]),
-                        type_args,
-                    );
-                    calc_width_on_stack(symbols, &target_ty)
-                }
-                None => calc_width_on_stack(symbols, &alias_ref.target_ty),
-            }
+            symbols
+                .alias_target_ty_idx(ty_idx)
+                .map_or(1, |target_ty_idx| {
+                    calc_width_on_stack(symbols, target_ty_idx)
+                })
         }
         Ty::Nullable { stack_width, .. } => {
             // for primitive nullables (common case), like `int?` and `address?`, it's 1 (TVM value or NULL);
-            // for non-primitive nullables, the compiler inserts stackWidth and stackTypeId
+            // for non-primitive nullables, the compiler inserts stack_width and stack_type_id
             stack_width.unwrap_or(1)
         }
         Ty::Union { stack_width, .. } => {
-            // for union types, the compiler always inserts stackWidth for simplicity (and stackTypeId for each variant)
+            // for union types, the compiler always inserts stack_width for simplicity (and stack_type_id for each variant)
             stack_width.unwrap_or(1)
         }
         Ty::GenericT { name_t } => {
@@ -286,93 +305,5 @@ pub fn calc_width_on_stack(symbols: &SourceMap, ty: &Ty) -> usize {
             // etc.
             1
         }
-    }
-}
-
-/// Replace all generic Ts (typeParams) with instantiation (typeArgs) recursively.
-/// Example: `(int, T, Wrapper<T?>)` and T=coins → `(int, coins, Wrapper<coins?>)`
-#[must_use]
-pub fn instantiate_generics(ty: &Ty, type_params: &[String], type_args: &[Ty]) -> Ty {
-    match ty {
-        Ty::Nullable {
-            inner,
-            stack_type_id,
-            stack_width,
-        } => Ty::Nullable {
-            inner: Box::new(instantiate_generics(inner, type_params, type_args)),
-            stack_type_id: *stack_type_id,
-            stack_width: *stack_width,
-        },
-        Ty::CellOf { inner } => Ty::CellOf {
-            inner: Box::new(instantiate_generics(inner, type_params, type_args)),
-        },
-        Ty::ArrayOf { inner } => Ty::ArrayOf {
-            inner: Box::new(instantiate_generics(inner, type_params, type_args)),
-        },
-        Ty::LispListOf { inner } => Ty::LispListOf {
-            inner: Box::new(instantiate_generics(inner, type_params, type_args)),
-        },
-        Ty::Tensor { items } => Ty::Tensor {
-            items: items
-                .iter()
-                .map(|i| instantiate_generics(i, type_params, type_args))
-                .collect(),
-        },
-        Ty::ShapedTuple { items } => Ty::ShapedTuple {
-            items: items
-                .iter()
-                .map(|i| instantiate_generics(i, type_params, type_args))
-                .collect(),
-        },
-        Ty::MapKV { k, v } => Ty::MapKV {
-            k: Box::new(instantiate_generics(k, type_params, type_args)),
-            v: Box::new(instantiate_generics(v, type_params, type_args)),
-        },
-        Ty::StructRef {
-            struct_name,
-            type_args: ta,
-        } => Ty::StructRef {
-            struct_name: struct_name.clone(),
-            type_args: ta.as_ref().map(|tas| {
-                tas.iter()
-                    .map(|t| instantiate_generics(t, type_params, type_args))
-                    .collect()
-            }),
-        },
-        Ty::AliasRef {
-            alias_name,
-            type_args: ta,
-        } => Ty::AliasRef {
-            alias_name: alias_name.clone(),
-            type_args: ta.as_ref().map(|tas| {
-                tas.iter()
-                    .map(|t| instantiate_generics(t, type_params, type_args))
-                    .collect()
-            }),
-        },
-        Ty::Union {
-            variants,
-            stack_width,
-        } => Ty::Union {
-            variants: variants
-                .iter()
-                .map(|v| UnionVariant {
-                    variant_ty: instantiate_generics(&v.variant_ty, type_params, type_args),
-                    ..v.clone()
-                })
-                .collect(),
-            stack_width: *stack_width,
-        },
-        Ty::GenericT { name_t } => {
-            let idx = type_params.iter().position(|p| p == name_t).unwrap_or(100);
-
-            type_args
-                .get(idx)
-                .unwrap_or_else(|| {
-                    panic!("inconsistent generics: could not find type argument for {name_t}")
-                })
-                .clone()
-        }
-        _ => ty.clone(),
     }
 }

--- a/crates/ton-objs/artifacts_manifest.toml
+++ b/crates/ton-objs/artifacts_manifest.toml
@@ -10,17 +10,17 @@
 artifact_set_revision = 1
 
 [target.aarch64-apple-darwin.sha256]
-libemulator = "baef30b06c4e79fd257d91a3b5e83d1507a4f4d17aec395ebfa19afa0806af11"
-libtolk = "94f1754dc52cd378c951c0b330561296543721a01b73816dcbcd5ce3d1db7bdb"
+libemulator = "ec84f302bab37765f705026b479c4879d0ac8aa1c30434eff810d62b40b21696"
+libtolk = "8d64338633a00064eae4933735de5f686e746abb89292bd6afdf67b57063d62c"
 
 [target.aarch64-unknown-linux-gnu.sha256]
-libemulator = "d85ae4011040ad7e9b4c87f15f210098043c91b4a40c1b3e1bc637f54e18f3b1"
-libtolk = "8432947c51bc313d7b00b425cb704115e652a3185129a5a32ede93dc79bdd610"
+libemulator = "e6e31d7ae30b5e0ec21a74451077f109ed97585edf4d75c6852122aff3cced16"
+libtolk = "0f9f0ed852ed250b1bafc9def5a12c900cf416512a748730be458c177c4743cf"
 
 [target.x86_64-apple-darwin.sha256]
-libemulator = "e7f81d60f2bdfeb4b6ce1eeeba4155c5f9fd2ffb03408ed6716de924c029a546"
-libtolk = "b899ea0a7fe03f4b99f9a99c0e45ac2e5c6cecedfbf3f223adfac77e494d9809"
+libemulator = "956eb421de6a809859f1a3d3fea584ec0eec9c647bb1a718acc8f51a64b4af71"
+libtolk = "32765d8ec32363ba7e9f184fb6075d43d823a807dd3cf9219b5e89e3af9394d0"
 
 [target.x86_64-unknown-linux-gnu.sha256]
-libemulator = "ed2b02125f579fbd04213b596ee3b329cfbe575b43f88cadad6fd7ba43c13181"
-libtolk = "db4c382d8cfda76fc092744c8e1d632c112e749fca82122cfd80ee4d7823bb18"
+libemulator = "afa0675bfc87507a86f97abe54a6ff323ef1e1cd1e72e1965dd8a835e558279e"
+libtolk = "78e7532ba74d59fe506b9b484825da5b49b6e2485d1f8e6125fe41a41739fb4b"

--- a/docs/content/docs/standard_library/testing/expect.mdx
+++ b/docs/content/docs/standard_library/testing/expect.mdx
@@ -39,7 +39,7 @@ struct Expectation<T> {
     /// The value to be expected.
     private value: T
     /// The type of the value to be expected.
-    private valueType: string
+    private valueType: int
     /// The location of the expectation to be printed in the error message.
     /// This field is set by the test framework and should not be set manually.
     private location: string
@@ -60,7 +60,7 @@ expect(10).toEqual(10);
 ## `Expectation<T>.create`
 
 ```tolk
-fun Expectation<T>.create(value: T, valueType: string, location: string): Expectation<T>
+fun Expectation<T>.create(value: T, valueType: int, location: string): Expectation<T>
 ```
 
 Internal function to create a new expectation for the given value.

--- a/docs/content/docs/tolk_standard_library/reflection.mdx
+++ b/docs/content/docs/tolk_standard_library/reflection.mdx
@@ -51,25 +51,25 @@ debug.printString(reflect.typeNameOfObject(42));   // "int"
 
 <SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/crates/tolk-compiler/assets/tolk-stdlib/reflection.tolk#L27" />
 
-## `reflect.typeAbiJsonOf`
+## `reflect.typeUniqueIdxOf`
 
 ```tolk
 @pure
-fun reflect.typeAbiJsonOf<T>(): string
+fun reflect.typeUniqueIdxOf<T>(): int
 ```
 
-Get ABI-JSON type description of any T for compile-time reflection.
+Get unique ty_idx (from `out.symbolTypes.json`) of any type T.
 
 <SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/crates/tolk-compiler/assets/tolk-stdlib/reflection.tolk#L32" />
 
-## `reflect.typeAbiJsonOfObject`
+## `reflect.typeUniqueIdxOfObject`
 
 ```tolk
 @pure
-fun reflect.typeAbiJsonOfObject<T>(anyVariable: T): string
+fun reflect.typeUniqueIdxOfObject<T>(anyVariable: T): int
 ```
 
-Get ABI-JSON type description of any object for compile-time reflection.
+Get unique ty_idx (from `out.symbolTypes.json`) of any object.
 
 <SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/crates/tolk-compiler/assets/tolk-stdlib/reflection.tolk#L37" />
 

--- a/lib/fmt.tolk
+++ b/lib/fmt.tolk
@@ -71,15 +71,15 @@ fun format<T1 = void, T2 = void, T3 = void, T4 = void, T5 = void>(
 ): string {
     return ffi.format(
         fmt,
-        reflect.typeAbiJsonOfObject(arg1),
+        reflect.typeUniqueIdxOfObject(arg1),
         arg1.toTuple(),
-        reflect.typeAbiJsonOfObject(arg2),
+        reflect.typeUniqueIdxOfObject(arg2),
         arg2.toTuple(),
-        reflect.typeAbiJsonOfObject(arg3),
+        reflect.typeUniqueIdxOfObject(arg3),
         arg3.toTuple(),
-        reflect.typeAbiJsonOfObject(arg4),
+        reflect.typeUniqueIdxOfObject(arg4),
         arg4.toTuple(),
-        reflect.typeAbiJsonOfObject(arg5),
+        reflect.typeUniqueIdxOfObject(arg5),
         arg5.toTuple(),
     );
 }
@@ -132,15 +132,15 @@ fun parseCellFromHex(cellHex: string): cell {
 
 fun ffi.format(
     fmt: string,
-    type1: string,
+    type1: int,
     arg1: tuple,
-    type2: string,
+    type2: int,
     arg2: tuple,
-    type3: string,
+    type3: int,
     arg3: tuple,
-    type4: string,
+    type4: int,
     arg4: tuple,
-    type5: string,
+    type5: int,
     arg5: tuple,
 ): string
     asm "200 EXTCALL"

--- a/lib/io.tolk
+++ b/lib/io.tolk
@@ -76,17 +76,17 @@ fun println<
     value6: T6,
 ): void {
     ffi.println(
-        reflect.typeAbiJsonOfObject(value1),
+        reflect.typeUniqueIdxOfObject(value1),
         value1.toTuple(),
-        reflect.typeAbiJsonOfObject(value2),
+        reflect.typeUniqueIdxOfObject(value2),
         value2.toTuple(),
-        reflect.typeAbiJsonOfObject(value3),
+        reflect.typeUniqueIdxOfObject(value3),
         value3.toTuple(),
-        reflect.typeAbiJsonOfObject(value4),
+        reflect.typeUniqueIdxOfObject(value4),
         value4.toTuple(),
-        reflect.typeAbiJsonOfObject(value5),
+        reflect.typeUniqueIdxOfObject(value5),
         value5.toTuple(),
-        reflect.typeAbiJsonOfObject(value6),
+        reflect.typeUniqueIdxOfObject(value6),
         value6.toTuple(),
     );
 }
@@ -102,17 +102,17 @@ fun eprintln(str: string): void {
 }
 
 fun ffi.println(
-    type1: string,
+    type1: int,
     arg1: tuple,
-    type2: string,
+    type2: int,
     arg2: tuple,
-    type3: string,
+    type3: int,
     arg3: tuple,
-    type4: string,
+    type4: int,
     arg4: tuple,
-    type5: string,
+    type5: int,
     arg5: tuple,
-    type6: string,
+    type6: int,
     arg6: tuple,
 ): void
     asm "1 EXTCALL"

--- a/lib/testing/assert.tolk
+++ b/lib/testing/assert.tolk
@@ -155,9 +155,9 @@ fun Assert.equalDecimal<T>(
 
 fun ffi.assertBin<V1, V2>(
     op: string,
-    leftTyJson: string,
+    leftTyIdx: int,
     left: V1,
-    rightTyJson: string,
+    rightTyIdx: int,
     right: V2,
     message: string,
     location: string,
@@ -174,9 +174,9 @@ fun ffi.assertComparison<V1, V2>(
     assert (
         ffi.assertBin(
             op,
-            reflect.typeAbiJsonOfObject(left),
+            reflect.typeUniqueIdxOfObject(left),
             left.toTuple(),
-            reflect.typeAbiJsonOfObject(right),
+            reflect.typeUniqueIdxOfObject(right),
             right.toTuple(),
             message,
             location,

--- a/lib/testing/expect.tolk
+++ b/lib/testing/expect.tolk
@@ -39,7 +39,7 @@ struct Expectation<T> {
     /// The value to be expected.
     private value: T
     /// The type of the value to be expected.
-    private valueType: string
+    private valueType: int
     /// The location of the expectation to be printed in the error message.
     /// This field is set by the test framework and should not be set manually.
     private location: string
@@ -53,7 +53,7 @@ struct Expectation<T> {
 /// ```tolk
 /// expect(10).toEqual(10);
 /// ```
-fun Expectation<T>.create(value: T, valueType: string, location: string): Expectation<T> {
+fun Expectation<T>.create(value: T, valueType: int, location: string): Expectation<T> {
     return Expectation<T> { value, valueType, location };
 }
 
@@ -642,7 +642,7 @@ fun Expectation<map<K, V>>.toHaveLength(self, length: int): void {
 fun expect<T>(value: T, loc: string = reflect.sourceLocationAsString()): Expectation<T> {
     return Expectation<T>.create(
         value,
-        reflect.typeAbiJsonOfObject(value),
+        reflect.typeUniqueIdxOfObject(value),
         loc,
     );
 }

--- a/src/commands/new/templates/counter-app/wrappers-ts/Counter.gen.ts
+++ b/src/commands/new/templates/counter-app/wrappers-ts/Counter.gen.ts
@@ -126,6 +126,49 @@ type uint32 = bigint
 type uint256 = bigint
 
 /**
+ > struct Storage {
+ >     id: uint32
+ >     owner: address
+ >     counter: uint32
+ > }
+ */
+export interface Storage {
+    readonly $: 'Storage'
+    id: uint32
+    owner: c.Address
+    counter: uint32
+}
+
+export const Storage = {
+    create(args: {
+        id: uint32
+        owner: c.Address
+        counter: uint32
+    }): Storage {
+        return {
+            $: 'Storage',
+            ...args
+        }
+    },
+    fromSlice(s: c.Slice): Storage {
+        return {
+            $: 'Storage',
+            id: s.loadUintBig(32),
+            owner: s.loadAddress(),
+            counter: s.loadUintBig(32),
+        }
+    },
+    store(self: Storage, b: c.Builder): void {
+        b.storeUint(self.id, 32);
+        b.storeAddress(self.owner);
+        b.storeUint(self.counter, 32);
+    },
+    toCell(self: Storage): c.Cell {
+        return makeCellFrom<Storage>(self, Storage.store);
+    }
+}
+
+/**
  > struct (0x7e8764ef) IncreaseCounter {
  >     increaseBy: uint32
  > }
@@ -226,49 +269,6 @@ export const ResetCounter = {
     },
     toCell(self: ResetCounter): c.Cell {
         return makeCellFrom<ResetCounter>(self, ResetCounter.store);
-    }
-}
-
-/**
- > struct Storage {
- >     id: uint32
- >     owner: address
- >     counter: uint32
- > }
- */
-export interface Storage {
-    readonly $: 'Storage'
-    id: uint32
-    owner: c.Address
-    counter: uint32
-}
-
-export const Storage = {
-    create(args: {
-        id: uint32
-        owner: c.Address
-        counter: uint32
-    }): Storage {
-        return {
-            $: 'Storage',
-            ...args
-        }
-    },
-    fromSlice(s: c.Slice): Storage {
-        return {
-            $: 'Storage',
-            id: s.loadUintBig(32),
-            owner: s.loadAddress(),
-            counter: s.loadUintBig(32),
-        }
-    },
-    store(self: Storage, b: c.Builder): void {
-        b.storeUint(self.id, 32);
-        b.storeAddress(self.owner);
-        b.storeUint(self.counter, 32);
-    },
-    toCell(self: Storage): c.Cell {
-        return makeCellFrom<Storage>(self, Storage.store);
     }
 }
 

--- a/src/commands/new/templates/empty-app/wrappers-ts/Empty.gen.ts
+++ b/src/commands/new/templates/empty-app/wrappers-ts/Empty.gen.ts
@@ -126,43 +126,6 @@ type uint32 = bigint
 type uint256 = bigint
 
 /**
- > struct (0x2ce05111) ChangeOwner {
- >     newOwner: address
- > }
- */
-export interface ChangeOwner {
-    readonly $: 'ChangeOwner'
-    newOwner: c.Address
-}
-
-export const ChangeOwner = {
-    PREFIX: 0x2ce05111,
-
-    create(args: {
-        newOwner: c.Address
-    }): ChangeOwner {
-        return {
-            $: 'ChangeOwner',
-            ...args
-        }
-    },
-    fromSlice(s: c.Slice): ChangeOwner {
-        loadAndCheckPrefix32(s, 0x2ce05111, 'ChangeOwner');
-        return {
-            $: 'ChangeOwner',
-            newOwner: s.loadAddress(),
-        }
-    },
-    store(self: ChangeOwner, b: c.Builder): void {
-        b.storeUint(0x2ce05111, 32);
-        b.storeAddress(self.newOwner);
-    },
-    toCell(self: ChangeOwner): c.Cell {
-        return makeCellFrom<ChangeOwner>(self, ChangeOwner.store);
-    }
-}
-
-/**
  > type AllowedMessage = ChangeOwner
  */
 export type AllowedMessage = ChangeOwner
@@ -209,6 +172,43 @@ export const Storage = {
     },
     toCell(self: Storage): c.Cell {
         return makeCellFrom<Storage>(self, Storage.store);
+    }
+}
+
+/**
+ > struct (0x2ce05111) ChangeOwner {
+ >     newOwner: address
+ > }
+ */
+export interface ChangeOwner {
+    readonly $: 'ChangeOwner'
+    newOwner: c.Address
+}
+
+export const ChangeOwner = {
+    PREFIX: 0x2ce05111,
+
+    create(args: {
+        newOwner: c.Address
+    }): ChangeOwner {
+        return {
+            $: 'ChangeOwner',
+            ...args
+        }
+    },
+    fromSlice(s: c.Slice): ChangeOwner {
+        loadAndCheckPrefix32(s, 0x2ce05111, 'ChangeOwner');
+        return {
+            $: 'ChangeOwner',
+            newOwner: s.loadAddress(),
+        }
+    },
+    store(self: ChangeOwner, b: c.Builder): void {
+        b.storeUint(0x2ce05111, 32);
+        b.storeAddress(self.newOwner);
+    },
+    toCell(self: ChangeOwner): c.Cell {
+        return makeCellFrom<ChangeOwner>(self, ChangeOwner.store);
     }
 }
 

--- a/src/commands/new/templates/jetton-app/wrappers-ts/JettonMinter.gen.ts
+++ b/src/commands/new/templates/jetton-app/wrappers-ts/JettonMinter.gen.ts
@@ -257,54 +257,39 @@ export const InternalTransferStep = {
 }
 
 /**
- > struct (0x642b7d07) MintNewJettons {
+ > struct (0xd53276db) ReturnExcessesBack {
  >     queryId: uint64
- >     mintRecipient: address
- >     tonAmount: coins
- >     internalTransferMsg: Cell<InternalTransferStep>
  > }
  */
-export interface MintNewJettons {
-    readonly $: 'MintNewJettons'
+export interface ReturnExcessesBack {
+    readonly $: 'ReturnExcessesBack'
     queryId: uint64
-    mintRecipient: c.Address
-    tonAmount: coins
-    internalTransferMsg: CellRef<InternalTransferStep>
 }
 
-export const MintNewJettons = {
-    PREFIX: 0x642b7d07,
+export const ReturnExcessesBack = {
+    PREFIX: 0xd53276db,
 
     create(args: {
         queryId: uint64
-        mintRecipient: c.Address
-        tonAmount: coins
-        internalTransferMsg: CellRef<InternalTransferStep>
-    }): MintNewJettons {
+    }): ReturnExcessesBack {
         return {
-            $: 'MintNewJettons',
+            $: 'ReturnExcessesBack',
             ...args
         }
     },
-    fromSlice(s: c.Slice): MintNewJettons {
-        loadAndCheckPrefix32(s, 0x642b7d07, 'MintNewJettons');
+    fromSlice(s: c.Slice): ReturnExcessesBack {
+        loadAndCheckPrefix32(s, 0xd53276db, 'ReturnExcessesBack');
         return {
-            $: 'MintNewJettons',
+            $: 'ReturnExcessesBack',
             queryId: s.loadUintBig(64),
-            mintRecipient: s.loadAddress(),
-            tonAmount: s.loadCoins(),
-            internalTransferMsg: loadCellRef<InternalTransferStep>(s, InternalTransferStep.fromSlice),
         }
     },
-    store(self: MintNewJettons, b: c.Builder): void {
-        b.storeUint(0x642b7d07, 32);
+    store(self: ReturnExcessesBack, b: c.Builder): void {
+        b.storeUint(0xd53276db, 32);
         b.storeUint(self.queryId, 64);
-        b.storeAddress(self.mintRecipient);
-        b.storeCoins(self.tonAmount);
-        storeCellRef<InternalTransferStep>(self.internalTransferMsg, b, InternalTransferStep.store);
     },
-    toCell(self: MintNewJettons): c.Cell {
-        return makeCellFrom<MintNewJettons>(self, MintNewJettons.store);
+    toCell(self: ReturnExcessesBack): c.Cell {
+        return makeCellFrom<ReturnExcessesBack>(self, ReturnExcessesBack.store);
     }
 }
 
@@ -404,6 +389,111 @@ export const RequestWalletAddress = {
     },
     toCell(self: RequestWalletAddress): c.Cell {
         return makeCellFrom<RequestWalletAddress>(self, RequestWalletAddress.store);
+    }
+}
+
+/**
+ > struct (0xd1735400) ResponseWalletAddress {
+ >     queryId: uint64
+ >     jettonWalletAddress: address?
+ >     ownerAddress: Cell<address>?
+ > }
+ */
+export interface ResponseWalletAddress {
+    readonly $: 'ResponseWalletAddress'
+    queryId: uint64
+    jettonWalletAddress: c.Address | null
+    ownerAddress: CellRef<c.Address> | null
+}
+
+export const ResponseWalletAddress = {
+    PREFIX: 0xd1735400,
+
+    create(args: {
+        queryId: uint64
+        jettonWalletAddress: c.Address | null
+        ownerAddress: CellRef<c.Address> | null
+    }): ResponseWalletAddress {
+        return {
+            $: 'ResponseWalletAddress',
+            ...args
+        }
+    },
+    fromSlice(s: c.Slice): ResponseWalletAddress {
+        loadAndCheckPrefix32(s, 0xd1735400, 'ResponseWalletAddress');
+        return {
+            $: 'ResponseWalletAddress',
+            queryId: s.loadUintBig(64),
+            jettonWalletAddress: s.loadMaybeAddress(),
+            ownerAddress: s.loadBoolean() ? loadCellRef<c.Address>(s,
+                (s) => s.loadAddress()
+            ) : null,
+        }
+    },
+    store(self: ResponseWalletAddress, b: c.Builder): void {
+        b.storeUint(0xd1735400, 32);
+        b.storeUint(self.queryId, 64);
+        b.storeAddress(self.jettonWalletAddress);
+        storeTolkNullable<CellRef<c.Address>>(self.ownerAddress, b,
+            (v,b) => { storeCellRef<c.Address>(v, b,
+                (v,b) => b.storeAddress(v)
+            ); }
+        );
+    },
+    toCell(self: ResponseWalletAddress): c.Cell {
+        return makeCellFrom<ResponseWalletAddress>(self, ResponseWalletAddress.store);
+    }
+}
+
+/**
+ > struct (0x642b7d07) MintNewJettons {
+ >     queryId: uint64
+ >     mintRecipient: address
+ >     tonAmount: coins
+ >     internalTransferMsg: Cell<InternalTransferStep>
+ > }
+ */
+export interface MintNewJettons {
+    readonly $: 'MintNewJettons'
+    queryId: uint64
+    mintRecipient: c.Address
+    tonAmount: coins
+    internalTransferMsg: CellRef<InternalTransferStep>
+}
+
+export const MintNewJettons = {
+    PREFIX: 0x642b7d07,
+
+    create(args: {
+        queryId: uint64
+        mintRecipient: c.Address
+        tonAmount: coins
+        internalTransferMsg: CellRef<InternalTransferStep>
+    }): MintNewJettons {
+        return {
+            $: 'MintNewJettons',
+            ...args
+        }
+    },
+    fromSlice(s: c.Slice): MintNewJettons {
+        loadAndCheckPrefix32(s, 0x642b7d07, 'MintNewJettons');
+        return {
+            $: 'MintNewJettons',
+            queryId: s.loadUintBig(64),
+            mintRecipient: s.loadAddress(),
+            tonAmount: s.loadCoins(),
+            internalTransferMsg: loadCellRef<InternalTransferStep>(s, InternalTransferStep.fromSlice),
+        }
+    },
+    store(self: MintNewJettons, b: c.Builder): void {
+        b.storeUint(0x642b7d07, 32);
+        b.storeUint(self.queryId, 64);
+        b.storeAddress(self.mintRecipient);
+        b.storeCoins(self.tonAmount);
+        storeCellRef<InternalTransferStep>(self.internalTransferMsg, b, InternalTransferStep.store);
+    },
+    toCell(self: MintNewJettons): c.Cell {
+        return makeCellFrom<MintNewJettons>(self, MintNewJettons.store);
     }
 }
 
@@ -524,48 +614,6 @@ export const DropMinterAdmin = {
 }
 
 /**
- > struct (0xcb862902) ChangeMinterMetadata {
- >     queryId: uint64
- >     newMetadata: cell
- > }
- */
-export interface ChangeMinterMetadata {
-    readonly $: 'ChangeMinterMetadata'
-    queryId: uint64
-    newMetadata: c.Cell
-}
-
-export const ChangeMinterMetadata = {
-    PREFIX: 0xcb862902,
-
-    create(args: {
-        queryId: uint64
-        newMetadata: c.Cell
-    }): ChangeMinterMetadata {
-        return {
-            $: 'ChangeMinterMetadata',
-            ...args
-        }
-    },
-    fromSlice(s: c.Slice): ChangeMinterMetadata {
-        loadAndCheckPrefix32(s, 0xcb862902, 'ChangeMinterMetadata');
-        return {
-            $: 'ChangeMinterMetadata',
-            queryId: s.loadUintBig(64),
-            newMetadata: s.loadRef(),
-        }
-    },
-    store(self: ChangeMinterMetadata, b: c.Builder): void {
-        b.storeUint(0xcb862902, 32);
-        b.storeUint(self.queryId, 64);
-        b.storeRef(self.newMetadata);
-    },
-    toCell(self: ChangeMinterMetadata): c.Cell {
-        return makeCellFrom<ChangeMinterMetadata>(self, ChangeMinterMetadata.store);
-    }
-}
-
-/**
  > struct (0x2508d66a) UpgradeMinterCode {
  >     queryId: uint64
  >     newData: cell
@@ -609,6 +657,48 @@ export const UpgradeMinterCode = {
     },
     toCell(self: UpgradeMinterCode): c.Cell {
         return makeCellFrom<UpgradeMinterCode>(self, UpgradeMinterCode.store);
+    }
+}
+
+/**
+ > struct (0xcb862902) ChangeMinterMetadata {
+ >     queryId: uint64
+ >     newMetadata: cell
+ > }
+ */
+export interface ChangeMinterMetadata {
+    readonly $: 'ChangeMinterMetadata'
+    queryId: uint64
+    newMetadata: c.Cell
+}
+
+export const ChangeMinterMetadata = {
+    PREFIX: 0xcb862902,
+
+    create(args: {
+        queryId: uint64
+        newMetadata: c.Cell
+    }): ChangeMinterMetadata {
+        return {
+            $: 'ChangeMinterMetadata',
+            ...args
+        }
+    },
+    fromSlice(s: c.Slice): ChangeMinterMetadata {
+        loadAndCheckPrefix32(s, 0xcb862902, 'ChangeMinterMetadata');
+        return {
+            $: 'ChangeMinterMetadata',
+            queryId: s.loadUintBig(64),
+            newMetadata: s.loadRef(),
+        }
+    },
+    store(self: ChangeMinterMetadata, b: c.Builder): void {
+        b.storeUint(0xcb862902, 32);
+        b.storeUint(self.queryId, 64);
+        b.storeRef(self.newMetadata);
+    },
+    toCell(self: ChangeMinterMetadata): c.Cell {
+        return makeCellFrom<ChangeMinterMetadata>(self, ChangeMinterMetadata.store);
     }
 }
 
@@ -691,109 +781,44 @@ export const MinterStorage = {
 }
 
 /**
- > struct (0xd53276db) ReturnExcessesBack {
- >     queryId: uint64
+ > struct JettonDataReply {
+ >     totalSupply: int
+ >     mintable: bool
+ >     adminAddress: address?
+ >     jettonContent: Cell<OnchainMetadataReply>
+ >     jettonWalletCode: cell
  > }
  */
-export interface ReturnExcessesBack {
-    readonly $: 'ReturnExcessesBack'
-    queryId: uint64
+export interface JettonDataReply {
+    readonly $: 'JettonDataReply'
+    totalSupply: bigint
+    mintable: boolean
+    adminAddress: c.Address | null
+    jettonContent: CellRef<OnchainMetadataReply>
+    jettonWalletCode: c.Cell
 }
 
-export const ReturnExcessesBack = {
-    PREFIX: 0xd53276db,
-
+export const JettonDataReply = {
     create(args: {
-        queryId: uint64
-    }): ReturnExcessesBack {
+        totalSupply: bigint
+        mintable: boolean
+        adminAddress: c.Address | null
+        jettonContent: CellRef<OnchainMetadataReply>
+        jettonWalletCode: c.Cell
+    }): JettonDataReply {
         return {
-            $: 'ReturnExcessesBack',
+            $: 'JettonDataReply',
             ...args
         }
     },
-    fromSlice(s: c.Slice): ReturnExcessesBack {
-        loadAndCheckPrefix32(s, 0xd53276db, 'ReturnExcessesBack');
-        return {
-            $: 'ReturnExcessesBack',
-            queryId: s.loadUintBig(64),
-        }
+    fromSlice(s: c.Slice): JettonDataReply {
+        throw new Error(`Can't unpack 'JettonDataReply' from cell, because 'JettonDataReply.totalSupply' is 'int' (not int32/uint64/etc.)`);
     },
-    store(self: ReturnExcessesBack, b: c.Builder): void {
-        b.storeUint(0xd53276db, 32);
-        b.storeUint(self.queryId, 64);
+    store(self: JettonDataReply, b: c.Builder): void {
+        throw new Error(`Can't pack 'JettonDataReply' to cell, because 'self.totalSupply' is 'int' (not int32/uint64/etc.)`);
     },
-    toCell(self: ReturnExcessesBack): c.Cell {
-        return makeCellFrom<ReturnExcessesBack>(self, ReturnExcessesBack.store);
-    }
-}
-
-/**
- > struct (0xd1735400) ResponseWalletAddress {
- >     queryId: uint64
- >     jettonWalletAddress: address?
- >     ownerAddress: Cell<address>?
- > }
- */
-export interface ResponseWalletAddress {
-    readonly $: 'ResponseWalletAddress'
-    queryId: uint64
-    jettonWalletAddress: c.Address | null
-    ownerAddress: CellRef<c.Address> | null
-}
-
-export const ResponseWalletAddress = {
-    PREFIX: 0xd1735400,
-
-    create(args: {
-        queryId: uint64
-        jettonWalletAddress: c.Address | null
-        ownerAddress: CellRef<c.Address> | null
-    }): ResponseWalletAddress {
-        return {
-            $: 'ResponseWalletAddress',
-            ...args
-        }
-    },
-    fromSlice(s: c.Slice): ResponseWalletAddress {
-        loadAndCheckPrefix32(s, 0xd1735400, 'ResponseWalletAddress');
-        return {
-            $: 'ResponseWalletAddress',
-            queryId: s.loadUintBig(64),
-            jettonWalletAddress: s.loadMaybeAddress(),
-            ownerAddress: s.loadBoolean() ? loadCellRef<c.Address>(s,
-                (s) => s.loadAddress()
-            ) : null,
-        }
-    },
-    store(self: ResponseWalletAddress, b: c.Builder): void {
-        b.storeUint(0xd1735400, 32);
-        b.storeUint(self.queryId, 64);
-        b.storeAddress(self.jettonWalletAddress);
-        storeTolkNullable<CellRef<c.Address>>(self.ownerAddress, b,
-            (v,b) => { storeCellRef<c.Address>(v, b,
-                (v,b) => b.storeAddress(v)
-            ); }
-        );
-    },
-    toCell(self: ResponseWalletAddress): c.Cell {
-        return makeCellFrom<ResponseWalletAddress>(self, ResponseWalletAddress.store);
-    }
-}
-
-/**
- > type string_prefixed0x = string
- */
-export type string_prefixed0x = string
-
-export const string_prefixed0x = {
-    fromSlice(s: c.Slice): string_prefixed0x {
-        return s.loadStringRefTail();
-    },
-    store(self: string_prefixed0x, b: c.Builder): void {
-        b.storeStringRefTail(self);
-    },
-    toCell(self: string_prefixed0x): c.Cell {
-        return makeCellFrom<string_prefixed0x>(self, string_prefixed0x.store);
+    toCell(self: JettonDataReply): c.Cell {
+        return makeCellFrom<JettonDataReply>(self, JettonDataReply.store);
     }
 }
 
@@ -835,44 +860,19 @@ export const OnchainMetadataReply = {
 }
 
 /**
- > struct JettonDataReply {
- >     totalSupply: int
- >     mintable: bool
- >     adminAddress: address?
- >     jettonContent: Cell<OnchainMetadataReply>
- >     jettonWalletCode: cell
- > }
+ > type string_prefixed0x = string
  */
-export interface JettonDataReply {
-    readonly $: 'JettonDataReply'
-    totalSupply: bigint
-    mintable: boolean
-    adminAddress: c.Address | null
-    jettonContent: CellRef<OnchainMetadataReply>
-    jettonWalletCode: c.Cell
-}
+export type string_prefixed0x = string
 
-export const JettonDataReply = {
-    create(args: {
-        totalSupply: bigint
-        mintable: boolean
-        adminAddress: c.Address | null
-        jettonContent: CellRef<OnchainMetadataReply>
-        jettonWalletCode: c.Cell
-    }): JettonDataReply {
-        return {
-            $: 'JettonDataReply',
-            ...args
-        }
+export const string_prefixed0x = {
+    fromSlice(s: c.Slice): string_prefixed0x {
+        return s.loadStringRefTail();
     },
-    fromSlice(s: c.Slice): JettonDataReply {
-        throw new Error(`Can't unpack 'JettonDataReply' from cell, because 'JettonDataReply.totalSupply' is 'int' (not int32/uint64/etc.)`);
+    store(self: string_prefixed0x, b: c.Builder): void {
+        b.storeStringRefTail(self);
     },
-    store(self: JettonDataReply, b: c.Builder): void {
-        throw new Error(`Can't pack 'JettonDataReply' to cell, because 'self.totalSupply' is 'int' (not int32/uint64/etc.)`);
-    },
-    toCell(self: JettonDataReply): c.Cell {
-        return makeCellFrom<JettonDataReply>(self, JettonDataReply.store);
+    toCell(self: string_prefixed0x): c.Cell {
+        return makeCellFrom<string_prefixed0x>(self, string_prefixed0x.store);
     }
 }
 

--- a/src/commands/new/templates/jetton-app/wrappers-ts/JettonWallet.gen.ts
+++ b/src/commands/new/templates/jetton-app/wrappers-ts/JettonWallet.gen.ts
@@ -228,56 +228,54 @@ export const AskToTransfer = {
 }
 
 /**
- > struct (0x595f07bc) AskToBurn {
+ > struct (0x7362d09c) TransferNotificationForRecipient {
  >     queryId: uint64
  >     jettonAmount: coins
- >     sendExcessesTo: address?
- >     customPayload: cell?
+ >     transferInitiator: address?
+ >     forwardPayload: ForwardPayloadRemainder
  > }
  */
-export interface AskToBurn {
-    readonly $: 'AskToBurn'
+export interface TransferNotificationForRecipient {
+    readonly $: 'TransferNotificationForRecipient'
     queryId: uint64
     jettonAmount: coins
-    sendExcessesTo: c.Address | null
-    customPayload: c.Cell | null
+    transferInitiator: c.Address | null
+    forwardPayload: ForwardPayloadRemainder
 }
 
-export const AskToBurn = {
-    PREFIX: 0x595f07bc,
+export const TransferNotificationForRecipient = {
+    PREFIX: 0x7362d09c,
 
     create(args: {
         queryId: uint64
         jettonAmount: coins
-        sendExcessesTo: c.Address | null
-        customPayload: c.Cell | null
-    }): AskToBurn {
+        transferInitiator: c.Address | null
+        forwardPayload: ForwardPayloadRemainder
+    }): TransferNotificationForRecipient {
         return {
-            $: 'AskToBurn',
+            $: 'TransferNotificationForRecipient',
             ...args
         }
     },
-    fromSlice(s: c.Slice): AskToBurn {
-        loadAndCheckPrefix32(s, 0x595f07bc, 'AskToBurn');
+    fromSlice(s: c.Slice): TransferNotificationForRecipient {
+        loadAndCheckPrefix32(s, 0x7362d09c, 'TransferNotificationForRecipient');
         return {
-            $: 'AskToBurn',
+            $: 'TransferNotificationForRecipient',
             queryId: s.loadUintBig(64),
             jettonAmount: s.loadCoins(),
-            sendExcessesTo: s.loadMaybeAddress(),
-            customPayload: s.loadBoolean() ? s.loadRef() : null,
+            transferInitiator: s.loadMaybeAddress(),
+            forwardPayload: ForwardPayloadRemainder.fromSlice(s),
         }
     },
-    store(self: AskToBurn, b: c.Builder): void {
-        b.storeUint(0x595f07bc, 32);
+    store(self: TransferNotificationForRecipient, b: c.Builder): void {
+        b.storeUint(0x7362d09c, 32);
         b.storeUint(self.queryId, 64);
         b.storeCoins(self.jettonAmount);
-        b.storeAddress(self.sendExcessesTo);
-        storeTolkNullable<c.Cell>(self.customPayload, b,
-            (v,b) => b.storeRef(v)
-        );
+        b.storeAddress(self.transferInitiator);
+        ForwardPayloadRemainder.store(self.forwardPayload, b);
     },
-    toCell(self: AskToBurn): c.Cell {
-        return makeCellFrom<AskToBurn>(self, AskToBurn.store);
+    toCell(self: TransferNotificationForRecipient): c.Cell {
+        return makeCellFrom<TransferNotificationForRecipient>(self, TransferNotificationForRecipient.store);
     }
 }
 
@@ -340,6 +338,149 @@ export const InternalTransferStep = {
     },
     toCell(self: InternalTransferStep): c.Cell {
         return makeCellFrom<InternalTransferStep>(self, InternalTransferStep.store);
+    }
+}
+
+/**
+ > struct (0xd53276db) ReturnExcessesBack {
+ >     queryId: uint64
+ > }
+ */
+export interface ReturnExcessesBack {
+    readonly $: 'ReturnExcessesBack'
+    queryId: uint64
+}
+
+export const ReturnExcessesBack = {
+    PREFIX: 0xd53276db,
+
+    create(args: {
+        queryId: uint64
+    }): ReturnExcessesBack {
+        return {
+            $: 'ReturnExcessesBack',
+            ...args
+        }
+    },
+    fromSlice(s: c.Slice): ReturnExcessesBack {
+        loadAndCheckPrefix32(s, 0xd53276db, 'ReturnExcessesBack');
+        return {
+            $: 'ReturnExcessesBack',
+            queryId: s.loadUintBig(64),
+        }
+    },
+    store(self: ReturnExcessesBack, b: c.Builder): void {
+        b.storeUint(0xd53276db, 32);
+        b.storeUint(self.queryId, 64);
+    },
+    toCell(self: ReturnExcessesBack): c.Cell {
+        return makeCellFrom<ReturnExcessesBack>(self, ReturnExcessesBack.store);
+    }
+}
+
+/**
+ > struct (0x595f07bc) AskToBurn {
+ >     queryId: uint64
+ >     jettonAmount: coins
+ >     sendExcessesTo: address?
+ >     customPayload: cell?
+ > }
+ */
+export interface AskToBurn {
+    readonly $: 'AskToBurn'
+    queryId: uint64
+    jettonAmount: coins
+    sendExcessesTo: c.Address | null
+    customPayload: c.Cell | null
+}
+
+export const AskToBurn = {
+    PREFIX: 0x595f07bc,
+
+    create(args: {
+        queryId: uint64
+        jettonAmount: coins
+        sendExcessesTo: c.Address | null
+        customPayload: c.Cell | null
+    }): AskToBurn {
+        return {
+            $: 'AskToBurn',
+            ...args
+        }
+    },
+    fromSlice(s: c.Slice): AskToBurn {
+        loadAndCheckPrefix32(s, 0x595f07bc, 'AskToBurn');
+        return {
+            $: 'AskToBurn',
+            queryId: s.loadUintBig(64),
+            jettonAmount: s.loadCoins(),
+            sendExcessesTo: s.loadMaybeAddress(),
+            customPayload: s.loadBoolean() ? s.loadRef() : null,
+        }
+    },
+    store(self: AskToBurn, b: c.Builder): void {
+        b.storeUint(0x595f07bc, 32);
+        b.storeUint(self.queryId, 64);
+        b.storeCoins(self.jettonAmount);
+        b.storeAddress(self.sendExcessesTo);
+        storeTolkNullable<c.Cell>(self.customPayload, b,
+            (v,b) => b.storeRef(v)
+        );
+    },
+    toCell(self: AskToBurn): c.Cell {
+        return makeCellFrom<AskToBurn>(self, AskToBurn.store);
+    }
+}
+
+/**
+ > struct (0x7bdd97de) BurnNotificationForMinter {
+ >     queryId: uint64
+ >     jettonAmount: coins
+ >     burnInitiator: address
+ >     sendExcessesTo: address?
+ > }
+ */
+export interface BurnNotificationForMinter {
+    readonly $: 'BurnNotificationForMinter'
+    queryId: uint64
+    jettonAmount: coins
+    burnInitiator: c.Address
+    sendExcessesTo: c.Address | null
+}
+
+export const BurnNotificationForMinter = {
+    PREFIX: 0x7bdd97de,
+
+    create(args: {
+        queryId: uint64
+        jettonAmount: coins
+        burnInitiator: c.Address
+        sendExcessesTo: c.Address | null
+    }): BurnNotificationForMinter {
+        return {
+            $: 'BurnNotificationForMinter',
+            ...args
+        }
+    },
+    fromSlice(s: c.Slice): BurnNotificationForMinter {
+        loadAndCheckPrefix32(s, 0x7bdd97de, 'BurnNotificationForMinter');
+        return {
+            $: 'BurnNotificationForMinter',
+            queryId: s.loadUintBig(64),
+            jettonAmount: s.loadCoins(),
+            burnInitiator: s.loadAddress(),
+            sendExcessesTo: s.loadMaybeAddress(),
+        }
+    },
+    store(self: BurnNotificationForMinter, b: c.Builder): void {
+        b.storeUint(0x7bdd97de, 32);
+        b.storeUint(self.queryId, 64);
+        b.storeCoins(self.jettonAmount);
+        b.storeAddress(self.burnInitiator);
+        b.storeAddress(self.sendExcessesTo);
+    },
+    toCell(self: BurnNotificationForMinter): c.Cell {
+        return makeCellFrom<BurnNotificationForMinter>(self, BurnNotificationForMinter.store);
     }
 }
 
@@ -413,147 +554,6 @@ export const WalletStorage = {
     },
     toCell(self: WalletStorage): c.Cell {
         return makeCellFrom<WalletStorage>(self, WalletStorage.store);
-    }
-}
-
-/**
- > struct (0x7362d09c) TransferNotificationForRecipient {
- >     queryId: uint64
- >     jettonAmount: coins
- >     transferInitiator: address?
- >     forwardPayload: ForwardPayloadRemainder
- > }
- */
-export interface TransferNotificationForRecipient {
-    readonly $: 'TransferNotificationForRecipient'
-    queryId: uint64
-    jettonAmount: coins
-    transferInitiator: c.Address | null
-    forwardPayload: ForwardPayloadRemainder
-}
-
-export const TransferNotificationForRecipient = {
-    PREFIX: 0x7362d09c,
-
-    create(args: {
-        queryId: uint64
-        jettonAmount: coins
-        transferInitiator: c.Address | null
-        forwardPayload: ForwardPayloadRemainder
-    }): TransferNotificationForRecipient {
-        return {
-            $: 'TransferNotificationForRecipient',
-            ...args
-        }
-    },
-    fromSlice(s: c.Slice): TransferNotificationForRecipient {
-        loadAndCheckPrefix32(s, 0x7362d09c, 'TransferNotificationForRecipient');
-        return {
-            $: 'TransferNotificationForRecipient',
-            queryId: s.loadUintBig(64),
-            jettonAmount: s.loadCoins(),
-            transferInitiator: s.loadMaybeAddress(),
-            forwardPayload: ForwardPayloadRemainder.fromSlice(s),
-        }
-    },
-    store(self: TransferNotificationForRecipient, b: c.Builder): void {
-        b.storeUint(0x7362d09c, 32);
-        b.storeUint(self.queryId, 64);
-        b.storeCoins(self.jettonAmount);
-        b.storeAddress(self.transferInitiator);
-        ForwardPayloadRemainder.store(self.forwardPayload, b);
-    },
-    toCell(self: TransferNotificationForRecipient): c.Cell {
-        return makeCellFrom<TransferNotificationForRecipient>(self, TransferNotificationForRecipient.store);
-    }
-}
-
-/**
- > struct (0xd53276db) ReturnExcessesBack {
- >     queryId: uint64
- > }
- */
-export interface ReturnExcessesBack {
-    readonly $: 'ReturnExcessesBack'
-    queryId: uint64
-}
-
-export const ReturnExcessesBack = {
-    PREFIX: 0xd53276db,
-
-    create(args: {
-        queryId: uint64
-    }): ReturnExcessesBack {
-        return {
-            $: 'ReturnExcessesBack',
-            ...args
-        }
-    },
-    fromSlice(s: c.Slice): ReturnExcessesBack {
-        loadAndCheckPrefix32(s, 0xd53276db, 'ReturnExcessesBack');
-        return {
-            $: 'ReturnExcessesBack',
-            queryId: s.loadUintBig(64),
-        }
-    },
-    store(self: ReturnExcessesBack, b: c.Builder): void {
-        b.storeUint(0xd53276db, 32);
-        b.storeUint(self.queryId, 64);
-    },
-    toCell(self: ReturnExcessesBack): c.Cell {
-        return makeCellFrom<ReturnExcessesBack>(self, ReturnExcessesBack.store);
-    }
-}
-
-/**
- > struct (0x7bdd97de) BurnNotificationForMinter {
- >     queryId: uint64
- >     jettonAmount: coins
- >     burnInitiator: address
- >     sendExcessesTo: address?
- > }
- */
-export interface BurnNotificationForMinter {
-    readonly $: 'BurnNotificationForMinter'
-    queryId: uint64
-    jettonAmount: coins
-    burnInitiator: c.Address
-    sendExcessesTo: c.Address | null
-}
-
-export const BurnNotificationForMinter = {
-    PREFIX: 0x7bdd97de,
-
-    create(args: {
-        queryId: uint64
-        jettonAmount: coins
-        burnInitiator: c.Address
-        sendExcessesTo: c.Address | null
-    }): BurnNotificationForMinter {
-        return {
-            $: 'BurnNotificationForMinter',
-            ...args
-        }
-    },
-    fromSlice(s: c.Slice): BurnNotificationForMinter {
-        loadAndCheckPrefix32(s, 0x7bdd97de, 'BurnNotificationForMinter');
-        return {
-            $: 'BurnNotificationForMinter',
-            queryId: s.loadUintBig(64),
-            jettonAmount: s.loadCoins(),
-            burnInitiator: s.loadAddress(),
-            sendExcessesTo: s.loadMaybeAddress(),
-        }
-    },
-    store(self: BurnNotificationForMinter, b: c.Builder): void {
-        b.storeUint(0x7bdd97de, 32);
-        b.storeUint(self.queryId, 64);
-        b.storeCoins(self.jettonAmount);
-        b.storeAddress(self.burnInitiator);
-        b.storeAddress(self.sendExcessesTo);
-    },
-    toCell(self: BurnNotificationForMinter): c.Cell {
-        return makeCellFrom<BurnNotificationForMinter>(self, BurnNotificationForMinter.store);
     }
 }
 

--- a/src/commands/new/templates/nft-app/wrappers-ts/NftCollection.gen.ts
+++ b/src/commands/new/templates/nft-app/wrappers-ts/NftCollection.gen.ts
@@ -155,6 +155,44 @@ type uint64 = bigint
 type uint256 = bigint
 
 /**
+ > struct NftItemInitAtDeployment {
+ >     ownerAddress: address
+ >     content: string
+ > }
+ */
+export interface NftItemInitAtDeployment {
+    readonly $: 'NftItemInitAtDeployment'
+    ownerAddress: c.Address
+    content: string
+}
+
+export const NftItemInitAtDeployment = {
+    create(args: {
+        ownerAddress: c.Address
+        content: string
+    }): NftItemInitAtDeployment {
+        return {
+            $: 'NftItemInitAtDeployment',
+            ...args
+        }
+    },
+    fromSlice(s: c.Slice): NftItemInitAtDeployment {
+        return {
+            $: 'NftItemInitAtDeployment',
+            ownerAddress: s.loadAddress(),
+            content: s.loadStringRefTail(),
+        }
+    },
+    store(self: NftItemInitAtDeployment, b: c.Builder): void {
+        b.storeAddress(self.ownerAddress);
+        b.storeStringRefTail(self.content);
+    },
+    toCell(self: NftItemInitAtDeployment): c.Cell {
+        return makeCellFrom<NftItemInitAtDeployment>(self, NftItemInitAtDeployment.store);
+    }
+}
+
+/**
  > struct (0x693d3950) RequestRoyaltyParams {
  >     queryId: uint64
  > }
@@ -192,40 +230,44 @@ export const RequestRoyaltyParams = {
 }
 
 /**
- > struct NftItemInitAtDeployment {
- >     ownerAddress: address
- >     content: string
+ > struct (0xa8cb00ad) ResponseRoyaltyParams {
+ >     queryId: uint64
+ >     royaltyParams: RoyaltyParams
  > }
  */
-export interface NftItemInitAtDeployment {
-    readonly $: 'NftItemInitAtDeployment'
-    ownerAddress: c.Address
-    content: string
+export interface ResponseRoyaltyParams {
+    readonly $: 'ResponseRoyaltyParams'
+    queryId: uint64
+    royaltyParams: RoyaltyParams
 }
 
-export const NftItemInitAtDeployment = {
+export const ResponseRoyaltyParams = {
+    PREFIX: 0xa8cb00ad,
+
     create(args: {
-        ownerAddress: c.Address
-        content: string
-    }): NftItemInitAtDeployment {
+        queryId: uint64
+        royaltyParams: RoyaltyParams
+    }): ResponseRoyaltyParams {
         return {
-            $: 'NftItemInitAtDeployment',
+            $: 'ResponseRoyaltyParams',
             ...args
         }
     },
-    fromSlice(s: c.Slice): NftItemInitAtDeployment {
+    fromSlice(s: c.Slice): ResponseRoyaltyParams {
+        loadAndCheckPrefix32(s, 0xa8cb00ad, 'ResponseRoyaltyParams');
         return {
-            $: 'NftItemInitAtDeployment',
-            ownerAddress: s.loadAddress(),
-            content: s.loadStringRefTail(),
+            $: 'ResponseRoyaltyParams',
+            queryId: s.loadUintBig(64),
+            royaltyParams: RoyaltyParams.fromSlice(s),
         }
     },
-    store(self: NftItemInitAtDeployment, b: c.Builder): void {
-        b.storeAddress(self.ownerAddress);
-        b.storeStringRefTail(self.content);
+    store(self: ResponseRoyaltyParams, b: c.Builder): void {
+        b.storeUint(0xa8cb00ad, 32);
+        b.storeUint(self.queryId, 64);
+        RoyaltyParams.store(self.royaltyParams, b);
     },
-    toCell(self: NftItemInitAtDeployment): c.Cell {
-        return makeCellFrom<NftItemInitAtDeployment>(self, NftItemInitAtDeployment.store);
+    toCell(self: ResponseRoyaltyParams): c.Cell {
+        return makeCellFrom<ResponseRoyaltyParams>(self, ResponseRoyaltyParams.store);
     }
 }
 
@@ -282,44 +324,6 @@ export const DeployNft = {
 }
 
 /**
- > struct BatchDeployDictItem {
- >     attachTonAmount: coins
- >     initParams: Cell<NftItemInitAtDeployment>
- > }
- */
-export interface BatchDeployDictItem {
-    readonly $: 'BatchDeployDictItem'
-    attachTonAmount: coins
-    initParams: CellRef<NftItemInitAtDeployment>
-}
-
-export const BatchDeployDictItem = {
-    create(args: {
-        attachTonAmount: coins
-        initParams: CellRef<NftItemInitAtDeployment>
-    }): BatchDeployDictItem {
-        return {
-            $: 'BatchDeployDictItem',
-            ...args
-        }
-    },
-    fromSlice(s: c.Slice): BatchDeployDictItem {
-        return {
-            $: 'BatchDeployDictItem',
-            attachTonAmount: s.loadCoins(),
-            initParams: loadCellRef<NftItemInitAtDeployment>(s, NftItemInitAtDeployment.fromSlice),
-        }
-    },
-    store(self: BatchDeployDictItem, b: c.Builder): void {
-        b.storeCoins(self.attachTonAmount);
-        storeCellRef<NftItemInitAtDeployment>(self.initParams, b, NftItemInitAtDeployment.store);
-    },
-    toCell(self: BatchDeployDictItem): c.Cell {
-        return makeCellFrom<BatchDeployDictItem>(self, BatchDeployDictItem.store);
-    }
-}
-
-/**
  > struct (0x00000002) BatchDeployNfts {
  >     queryId: uint64
  >     deployList: map<uint64, BatchDeployDictItem>
@@ -362,6 +366,44 @@ export const BatchDeployNfts = {
 }
 
 /**
+ > struct BatchDeployDictItem {
+ >     attachTonAmount: coins
+ >     initParams: Cell<NftItemInitAtDeployment>
+ > }
+ */
+export interface BatchDeployDictItem {
+    readonly $: 'BatchDeployDictItem'
+    attachTonAmount: coins
+    initParams: CellRef<NftItemInitAtDeployment>
+}
+
+export const BatchDeployDictItem = {
+    create(args: {
+        attachTonAmount: coins
+        initParams: CellRef<NftItemInitAtDeployment>
+    }): BatchDeployDictItem {
+        return {
+            $: 'BatchDeployDictItem',
+            ...args
+        }
+    },
+    fromSlice(s: c.Slice): BatchDeployDictItem {
+        return {
+            $: 'BatchDeployDictItem',
+            attachTonAmount: s.loadCoins(),
+            initParams: loadCellRef<NftItemInitAtDeployment>(s, NftItemInitAtDeployment.fromSlice),
+        }
+    },
+    store(self: BatchDeployDictItem, b: c.Builder): void {
+        b.storeCoins(self.attachTonAmount);
+        storeCellRef<NftItemInitAtDeployment>(self.initParams, b, NftItemInitAtDeployment.store);
+    },
+    toCell(self: BatchDeployDictItem): c.Cell {
+        return makeCellFrom<BatchDeployDictItem>(self, BatchDeployDictItem.store);
+    }
+}
+
+/**
  > struct (0x00000003) ChangeCollectionAdmin {
  >     queryId: uint64
  >     newAdminAddress: address
@@ -400,44 +442,6 @@ export const ChangeCollectionAdmin = {
     },
     toCell(self: ChangeCollectionAdmin): c.Cell {
         return makeCellFrom<ChangeCollectionAdmin>(self, ChangeCollectionAdmin.store);
-    }
-}
-
-/**
- > struct CollectionContent {
- >     collectionMetadata: cell
- >     commonContent: string
- > }
- */
-export interface CollectionContent {
-    readonly $: 'CollectionContent'
-    collectionMetadata: c.Cell
-    commonContent: string
-}
-
-export const CollectionContent = {
-    create(args: {
-        collectionMetadata: c.Cell
-        commonContent: string
-    }): CollectionContent {
-        return {
-            $: 'CollectionContent',
-            ...args
-        }
-    },
-    fromSlice(s: c.Slice): CollectionContent {
-        return {
-            $: 'CollectionContent',
-            collectionMetadata: s.loadRef(),
-            commonContent: s.loadStringRefTail(),
-        }
-    },
-    store(self: CollectionContent, b: c.Builder): void {
-        b.storeRef(self.collectionMetadata);
-        b.storeStringRefTail(self.commonContent);
-    },
-    toCell(self: CollectionContent): c.Cell {
-        return makeCellFrom<CollectionContent>(self, CollectionContent.store);
     }
 }
 
@@ -538,44 +542,40 @@ export const NftCollectionStorage = {
 }
 
 /**
- > struct (0xa8cb00ad) ResponseRoyaltyParams {
- >     queryId: uint64
- >     royaltyParams: RoyaltyParams
+ > struct CollectionContent {
+ >     collectionMetadata: cell
+ >     commonContent: string
  > }
  */
-export interface ResponseRoyaltyParams {
-    readonly $: 'ResponseRoyaltyParams'
-    queryId: uint64
-    royaltyParams: RoyaltyParams
+export interface CollectionContent {
+    readonly $: 'CollectionContent'
+    collectionMetadata: c.Cell
+    commonContent: string
 }
 
-export const ResponseRoyaltyParams = {
-    PREFIX: 0xa8cb00ad,
-
+export const CollectionContent = {
     create(args: {
-        queryId: uint64
-        royaltyParams: RoyaltyParams
-    }): ResponseRoyaltyParams {
+        collectionMetadata: c.Cell
+        commonContent: string
+    }): CollectionContent {
         return {
-            $: 'ResponseRoyaltyParams',
+            $: 'CollectionContent',
             ...args
         }
     },
-    fromSlice(s: c.Slice): ResponseRoyaltyParams {
-        loadAndCheckPrefix32(s, 0xa8cb00ad, 'ResponseRoyaltyParams');
+    fromSlice(s: c.Slice): CollectionContent {
         return {
-            $: 'ResponseRoyaltyParams',
-            queryId: s.loadUintBig(64),
-            royaltyParams: RoyaltyParams.fromSlice(s),
+            $: 'CollectionContent',
+            collectionMetadata: s.loadRef(),
+            commonContent: s.loadStringRefTail(),
         }
     },
-    store(self: ResponseRoyaltyParams, b: c.Builder): void {
-        b.storeUint(0xa8cb00ad, 32);
-        b.storeUint(self.queryId, 64);
-        RoyaltyParams.store(self.royaltyParams, b);
+    store(self: CollectionContent, b: c.Builder): void {
+        b.storeRef(self.collectionMetadata);
+        b.storeStringRefTail(self.commonContent);
     },
-    toCell(self: ResponseRoyaltyParams): c.Cell {
-        return makeCellFrom<ResponseRoyaltyParams>(self, ResponseRoyaltyParams.store);
+    toCell(self: CollectionContent): c.Cell {
+        return makeCellFrom<CollectionContent>(self, CollectionContent.store);
     }
 }
 

--- a/src/commands/new/templates/nft-app/wrappers-ts/NftItem.gen.ts
+++ b/src/commands/new/templates/nft-app/wrappers-ts/NftItem.gen.ts
@@ -145,20 +145,6 @@ class StackReader {
         }
         return readFn_T(this);
     }
-
-    readWideNullable<T>(stackW: number, readFn_T: (r: StackReader) => T): T | null {
-        const slotTypeId = this.tuple[stackW - 1];
-        if (slotTypeId?.type !== 'int') {
-            throw new Error(`not 'int' on a stack`);
-        }
-        if (slotTypeId.value === 0n) {
-            this.tuple = this.tuple.slice(stackW);
-            return null;
-        }
-        const valueT = readFn_T(this);
-        this.tuple.shift();
-        return valueT;
-    }
 }
 
 // ————————————————————————————————————————————
@@ -177,6 +163,90 @@ type uint16 = bigint
 type uint32 = bigint
 type uint64 = bigint
 type uint256 = bigint
+
+/**
+ > struct (0x2fcb26a2) RequestStaticData {
+ >     queryId: uint64
+ > }
+ */
+export interface RequestStaticData {
+    readonly $: 'RequestStaticData'
+    queryId: uint64
+}
+
+export const RequestStaticData = {
+    PREFIX: 0x2fcb26a2,
+
+    create(args: {
+        queryId: uint64
+    }): RequestStaticData {
+        return {
+            $: 'RequestStaticData',
+            ...args
+        }
+    },
+    fromSlice(s: c.Slice): RequestStaticData {
+        loadAndCheckPrefix32(s, 0x2fcb26a2, 'RequestStaticData');
+        return {
+            $: 'RequestStaticData',
+            queryId: s.loadUintBig(64),
+        }
+    },
+    store(self: RequestStaticData, b: c.Builder): void {
+        b.storeUint(0x2fcb26a2, 32);
+        b.storeUint(self.queryId, 64);
+    },
+    toCell(self: RequestStaticData): c.Cell {
+        return makeCellFrom<RequestStaticData>(self, RequestStaticData.store);
+    }
+}
+
+/**
+ > struct (0x8b771735) ResponseStaticData {
+ >     queryId: uint64
+ >     itemIndex: uint256
+ >     collectionAddress: address
+ > }
+ */
+export interface ResponseStaticData {
+    readonly $: 'ResponseStaticData'
+    queryId: uint64
+    itemIndex: uint256
+    collectionAddress: c.Address
+}
+
+export const ResponseStaticData = {
+    PREFIX: 0x8b771735,
+
+    create(args: {
+        queryId: uint64
+        itemIndex: uint256
+        collectionAddress: c.Address
+    }): ResponseStaticData {
+        return {
+            $: 'ResponseStaticData',
+            ...args
+        }
+    },
+    fromSlice(s: c.Slice): ResponseStaticData {
+        loadAndCheckPrefix32(s, 0x8b771735, 'ResponseStaticData');
+        return {
+            $: 'ResponseStaticData',
+            queryId: s.loadUintBig(64),
+            itemIndex: s.loadUintBig(256),
+            collectionAddress: s.loadAddress(),
+        }
+    },
+    store(self: ResponseStaticData, b: c.Builder): void {
+        b.storeUint(0x8b771735, 32);
+        b.storeUint(self.queryId, 64);
+        b.storeUint(self.itemIndex, 256);
+        b.storeAddress(self.collectionAddress);
+    },
+    toCell(self: ResponseStaticData): c.Cell {
+        return makeCellFrom<ResponseStaticData>(self, ResponseStaticData.store);
+    }
+}
 
 /**
  > struct (0b0) PayloadInline {
@@ -279,6 +349,90 @@ export const Payload = {
 }
 
 /**
+ > struct (0x05138d91) NotificationForNewOwner {
+ >     queryId: uint64
+ >     oldOwnerAddress: address
+ >     payload: Payload
+ > }
+ */
+export interface NotificationForNewOwner {
+    readonly $: 'NotificationForNewOwner'
+    queryId: uint64
+    oldOwnerAddress: c.Address
+    payload: Payload
+}
+
+export const NotificationForNewOwner = {
+    PREFIX: 0x05138d91,
+
+    create(args: {
+        queryId: uint64
+        oldOwnerAddress: c.Address
+        payload: Payload
+    }): NotificationForNewOwner {
+        return {
+            $: 'NotificationForNewOwner',
+            ...args
+        }
+    },
+    fromSlice(s: c.Slice): NotificationForNewOwner {
+        loadAndCheckPrefix32(s, 0x05138d91, 'NotificationForNewOwner');
+        return {
+            $: 'NotificationForNewOwner',
+            queryId: s.loadUintBig(64),
+            oldOwnerAddress: s.loadAddress(),
+            payload: Payload.fromSlice(s),
+        }
+    },
+    store(self: NotificationForNewOwner, b: c.Builder): void {
+        b.storeUint(0x05138d91, 32);
+        b.storeUint(self.queryId, 64);
+        b.storeAddress(self.oldOwnerAddress);
+        Payload.store(self.payload, b);
+    },
+    toCell(self: NotificationForNewOwner): c.Cell {
+        return makeCellFrom<NotificationForNewOwner>(self, NotificationForNewOwner.store);
+    }
+}
+
+/**
+ > struct (0xd53276db) ReturnExcessesBack {
+ >     queryId: uint64
+ > }
+ */
+export interface ReturnExcessesBack {
+    readonly $: 'ReturnExcessesBack'
+    queryId: uint64
+}
+
+export const ReturnExcessesBack = {
+    PREFIX: 0xd53276db,
+
+    create(args: {
+        queryId: uint64
+    }): ReturnExcessesBack {
+        return {
+            $: 'ReturnExcessesBack',
+            ...args
+        }
+    },
+    fromSlice(s: c.Slice): ReturnExcessesBack {
+        loadAndCheckPrefix32(s, 0xd53276db, 'ReturnExcessesBack');
+        return {
+            $: 'ReturnExcessesBack',
+            queryId: s.loadUintBig(64),
+        }
+    },
+    store(self: ReturnExcessesBack, b: c.Builder): void {
+        b.storeUint(0xd53276db, 32);
+        b.storeUint(self.queryId, 64);
+    },
+    toCell(self: ReturnExcessesBack): c.Cell {
+        return makeCellFrom<ReturnExcessesBack>(self, ReturnExcessesBack.store);
+    }
+}
+
+/**
  > struct (0x5fcc3d14) AskToChangeOwnership {
  >     queryId: uint64
  >     newOwnerAddress: address
@@ -339,43 +493,6 @@ export const AskToChangeOwnership = {
     },
     toCell(self: AskToChangeOwnership): c.Cell {
         return makeCellFrom<AskToChangeOwnership>(self, AskToChangeOwnership.store);
-    }
-}
-
-/**
- > struct (0x2fcb26a2) RequestStaticData {
- >     queryId: uint64
- > }
- */
-export interface RequestStaticData {
-    readonly $: 'RequestStaticData'
-    queryId: uint64
-}
-
-export const RequestStaticData = {
-    PREFIX: 0x2fcb26a2,
-
-    create(args: {
-        queryId: uint64
-    }): RequestStaticData {
-        return {
-            $: 'RequestStaticData',
-            ...args
-        }
-    },
-    fromSlice(s: c.Slice): RequestStaticData {
-        loadAndCheckPrefix32(s, 0x2fcb26a2, 'RequestStaticData');
-        return {
-            $: 'RequestStaticData',
-            queryId: s.loadUintBig(64),
-        }
-    },
-    store(self: RequestStaticData, b: c.Builder): void {
-        b.storeUint(0x2fcb26a2, 32);
-        b.storeUint(self.queryId, 64);
-    },
-    toCell(self: RequestStaticData): c.Cell {
-        return makeCellFrom<RequestStaticData>(self, RequestStaticData.store);
     }
 }
 
@@ -462,137 +579,6 @@ export const NftItemStorageNotInitialized = {
     },
     toCell(self: NftItemStorageNotInitialized): c.Cell {
         return makeCellFrom<NftItemStorageNotInitialized>(self, NftItemStorageNotInitialized.store);
-    }
-}
-
-/**
- > struct (0x05138d91) NotificationForNewOwner {
- >     queryId: uint64
- >     oldOwnerAddress: address
- >     payload: Payload
- > }
- */
-export interface NotificationForNewOwner {
-    readonly $: 'NotificationForNewOwner'
-    queryId: uint64
-    oldOwnerAddress: c.Address
-    payload: Payload
-}
-
-export const NotificationForNewOwner = {
-    PREFIX: 0x05138d91,
-
-    create(args: {
-        queryId: uint64
-        oldOwnerAddress: c.Address
-        payload: Payload
-    }): NotificationForNewOwner {
-        return {
-            $: 'NotificationForNewOwner',
-            ...args
-        }
-    },
-    fromSlice(s: c.Slice): NotificationForNewOwner {
-        loadAndCheckPrefix32(s, 0x05138d91, 'NotificationForNewOwner');
-        return {
-            $: 'NotificationForNewOwner',
-            queryId: s.loadUintBig(64),
-            oldOwnerAddress: s.loadAddress(),
-            payload: Payload.fromSlice(s),
-        }
-    },
-    store(self: NotificationForNewOwner, b: c.Builder): void {
-        b.storeUint(0x05138d91, 32);
-        b.storeUint(self.queryId, 64);
-        b.storeAddress(self.oldOwnerAddress);
-        Payload.store(self.payload, b);
-    },
-    toCell(self: NotificationForNewOwner): c.Cell {
-        return makeCellFrom<NotificationForNewOwner>(self, NotificationForNewOwner.store);
-    }
-}
-
-/**
- > struct (0xd53276db) ReturnExcessesBack {
- >     queryId: uint64
- > }
- */
-export interface ReturnExcessesBack {
-    readonly $: 'ReturnExcessesBack'
-    queryId: uint64
-}
-
-export const ReturnExcessesBack = {
-    PREFIX: 0xd53276db,
-
-    create(args: {
-        queryId: uint64
-    }): ReturnExcessesBack {
-        return {
-            $: 'ReturnExcessesBack',
-            ...args
-        }
-    },
-    fromSlice(s: c.Slice): ReturnExcessesBack {
-        loadAndCheckPrefix32(s, 0xd53276db, 'ReturnExcessesBack');
-        return {
-            $: 'ReturnExcessesBack',
-            queryId: s.loadUintBig(64),
-        }
-    },
-    store(self: ReturnExcessesBack, b: c.Builder): void {
-        b.storeUint(0xd53276db, 32);
-        b.storeUint(self.queryId, 64);
-    },
-    toCell(self: ReturnExcessesBack): c.Cell {
-        return makeCellFrom<ReturnExcessesBack>(self, ReturnExcessesBack.store);
-    }
-}
-
-/**
- > struct (0x8b771735) ResponseStaticData {
- >     queryId: uint64
- >     itemIndex: uint256
- >     collectionAddress: address
- > }
- */
-export interface ResponseStaticData {
-    readonly $: 'ResponseStaticData'
-    queryId: uint64
-    itemIndex: uint256
-    collectionAddress: c.Address
-}
-
-export const ResponseStaticData = {
-    PREFIX: 0x8b771735,
-
-    create(args: {
-        queryId: uint64
-        itemIndex: uint256
-        collectionAddress: c.Address
-    }): ResponseStaticData {
-        return {
-            $: 'ResponseStaticData',
-            ...args
-        }
-    },
-    fromSlice(s: c.Slice): ResponseStaticData {
-        loadAndCheckPrefix32(s, 0x8b771735, 'ResponseStaticData');
-        return {
-            $: 'ResponseStaticData',
-            queryId: s.loadUintBig(64),
-            itemIndex: s.loadUintBig(256),
-            collectionAddress: s.loadAddress(),
-        }
-    },
-    store(self: ResponseStaticData, b: c.Builder): void {
-        b.storeUint(0x8b771735, 32);
-        b.storeUint(self.queryId, 64);
-        b.storeUint(self.itemIndex, 256);
-        b.storeAddress(self.collectionAddress);
-    },
-    toCell(self: ResponseStaticData): c.Cell {
-        return makeCellFrom<ResponseStaticData>(self, ResponseStaticData.store);
     }
 }
 

--- a/src/commands/new/templates/w5-extension-app/wrappers-ts/SimpleExtension.gen.ts
+++ b/src/commands/new/templates/w5-extension-app/wrappers-ts/SimpleExtension.gen.ts
@@ -130,20 +130,6 @@ class StackReader {
         }
         return readFn_T(this);
     }
-
-    readWideNullable<T>(stackW: number, readFn_T: (r: StackReader) => T): T | null {
-        const slotTypeId = this.tuple[stackW - 1];
-        if (slotTypeId?.type !== 'int') {
-            throw new Error(`not 'int' on a stack`);
-        }
-        if (slotTypeId.value === 0n) {
-            this.tuple = this.tuple.slice(stackW);
-            return null;
-        }
-        const valueT = readFn_T(this);
-        this.tuple.shift();
-        return valueT;
-    }
 }
 
 // ————————————————————————————————————————————
@@ -164,99 +150,57 @@ type uint64 = bigint
 type uint256 = bigint
 
 /**
- > struct (0x43c7641f) TopUp {
+ > struct ExtensionStorage {
+ >     walletAddress: address
+ >     admin: address
+ >     subscriptionAmount: coins
+ >     lastPaymentTime: uint32?
+ >     paymentTimeInterval: uint32
  > }
  */
-export interface TopUp {
-    readonly $: 'TopUp'
+export interface ExtensionStorage {
+    readonly $: 'ExtensionStorage'
+    walletAddress: c.Address
+    admin: c.Address
+    subscriptionAmount: coins
+    lastPaymentTime: uint32 | null
+    paymentTimeInterval: uint32
 }
 
-export const TopUp = {
-    PREFIX: 0x43c7641f,
-
-    create(): TopUp {
-        return {
-            $: 'TopUp',
-        }
-    },
-    fromSlice(s: c.Slice): TopUp {
-        loadAndCheckPrefix32(s, 0x43c7641f, 'TopUp');
-        return {
-            $: 'TopUp',
-        }
-    },
-    store(self: TopUp, b: c.Builder): void {
-        b.storeUint(0x43c7641f, 32);
-    },
-    toCell(self: TopUp): c.Cell {
-        return makeCellFrom<TopUp>(self, TopUp.store);
-    }
-}
-
-/**
- > struct (0x283b4c3f) CancelSubscription {
- >     queryId: uint64
- > }
- */
-export interface CancelSubscription {
-    readonly $: 'CancelSubscription'
-    queryId: uint64
-}
-
-export const CancelSubscription = {
-    PREFIX: 0x283b4c3f,
-
+export const ExtensionStorage = {
     create(args: {
-        queryId: uint64
-    }): CancelSubscription {
+        walletAddress: c.Address
+        admin: c.Address
+        subscriptionAmount: coins
+        lastPaymentTime: uint32 | null
+        paymentTimeInterval: uint32
+    }): ExtensionStorage {
         return {
-            $: 'CancelSubscription',
+            $: 'ExtensionStorage',
             ...args
         }
     },
-    fromSlice(s: c.Slice): CancelSubscription {
-        loadAndCheckPrefix32(s, 0x283b4c3f, 'CancelSubscription');
+    fromSlice(s: c.Slice): ExtensionStorage {
         return {
-            $: 'CancelSubscription',
-            queryId: s.loadUintBig(64),
+            $: 'ExtensionStorage',
+            walletAddress: s.loadAddress(),
+            admin: s.loadAddress(),
+            subscriptionAmount: s.loadCoins(),
+            lastPaymentTime: s.loadBoolean() ? s.loadUintBig(32) : null,
+            paymentTimeInterval: s.loadUintBig(32),
         }
     },
-    store(self: CancelSubscription, b: c.Builder): void {
-        b.storeUint(0x283b4c3f, 32);
-        b.storeUint(self.queryId, 64);
+    store(self: ExtensionStorage, b: c.Builder): void {
+        b.storeAddress(self.walletAddress);
+        b.storeAddress(self.admin);
+        b.storeCoins(self.subscriptionAmount);
+        storeTolkNullable<uint32>(self.lastPaymentTime, b,
+            (v,b) => b.storeUint(v, 32)
+        );
+        b.storeUint(self.paymentTimeInterval, 32);
     },
-    toCell(self: CancelSubscription): c.Cell {
-        return makeCellFrom<CancelSubscription>(self, CancelSubscription.store);
-    }
-}
-
-/**
- > struct (0xc28364ef) ReceivePaymentFromWallet {
- > }
- */
-export interface ReceivePaymentFromWallet {
-    readonly $: 'ReceivePaymentFromWallet'
-}
-
-export const ReceivePaymentFromWallet = {
-    PREFIX: 0xc28364ef,
-
-    create(): ReceivePaymentFromWallet {
-        return {
-            $: 'ReceivePaymentFromWallet',
-        }
-    },
-    fromSlice(s: c.Slice): ReceivePaymentFromWallet {
-        loadAndCheckPrefix32(s, 0xc28364ef, 'ReceivePaymentFromWallet');
-        return {
-            $: 'ReceivePaymentFromWallet',
-        }
-    },
-    store(self: ReceivePaymentFromWallet, b: c.Builder): void {
-        b.storeUint(0xc28364ef, 32);
-    },
-    toCell(self: ReceivePaymentFromWallet): c.Cell {
-        return makeCellFrom<ReceivePaymentFromWallet>(self, ReceivePaymentFromWallet.store);
+    toCell(self: ExtensionStorage): c.Cell {
+        return makeCellFrom<ExtensionStorage>(self, ExtensionStorage.store);
     }
 }
 
@@ -328,57 +272,99 @@ export const WithdrawExtensionBalance = {
 }
 
 /**
- > struct ExtensionStorage {
- >     walletAddress: address
- >     admin: address
- >     subscriptionAmount: coins
- >     lastPaymentTime: uint32?
- >     paymentTimeInterval: uint32
+ > struct (0x283b4c3f) CancelSubscription {
+ >     queryId: uint64
  > }
  */
-export interface ExtensionStorage {
-    readonly $: 'ExtensionStorage'
-    walletAddress: c.Address
-    admin: c.Address
-    subscriptionAmount: coins
-    lastPaymentTime: uint32 | null
-    paymentTimeInterval: uint32
+export interface CancelSubscription {
+    readonly $: 'CancelSubscription'
+    queryId: uint64
 }
 
-export const ExtensionStorage = {
+export const CancelSubscription = {
+    PREFIX: 0x283b4c3f,
+
     create(args: {
-        walletAddress: c.Address
-        admin: c.Address
-        subscriptionAmount: coins
-        lastPaymentTime: uint32 | null
-        paymentTimeInterval: uint32
-    }): ExtensionStorage {
+        queryId: uint64
+    }): CancelSubscription {
         return {
-            $: 'ExtensionStorage',
+            $: 'CancelSubscription',
             ...args
         }
     },
-    fromSlice(s: c.Slice): ExtensionStorage {
+    fromSlice(s: c.Slice): CancelSubscription {
+        loadAndCheckPrefix32(s, 0x283b4c3f, 'CancelSubscription');
         return {
-            $: 'ExtensionStorage',
-            walletAddress: s.loadAddress(),
-            admin: s.loadAddress(),
-            subscriptionAmount: s.loadCoins(),
-            lastPaymentTime: s.loadBoolean() ? s.loadUintBig(32) : null,
-            paymentTimeInterval: s.loadUintBig(32),
+            $: 'CancelSubscription',
+            queryId: s.loadUintBig(64),
         }
     },
-    store(self: ExtensionStorage, b: c.Builder): void {
-        b.storeAddress(self.walletAddress);
-        b.storeAddress(self.admin);
-        b.storeCoins(self.subscriptionAmount);
-        storeTolkNullable<uint32>(self.lastPaymentTime, b,
-            (v,b) => b.storeUint(v, 32)
-        );
-        b.storeUint(self.paymentTimeInterval, 32);
+    store(self: CancelSubscription, b: c.Builder): void {
+        b.storeUint(0x283b4c3f, 32);
+        b.storeUint(self.queryId, 64);
     },
-    toCell(self: ExtensionStorage): c.Cell {
-        return makeCellFrom<ExtensionStorage>(self, ExtensionStorage.store);
+    toCell(self: CancelSubscription): c.Cell {
+        return makeCellFrom<CancelSubscription>(self, CancelSubscription.store);
+    }
+}
+
+/**
+ > struct (0xc28364ef) ReceivePaymentFromWallet {
+ > }
+ */
+export interface ReceivePaymentFromWallet {
+    readonly $: 'ReceivePaymentFromWallet'
+}
+
+export const ReceivePaymentFromWallet = {
+    PREFIX: 0xc28364ef,
+
+    create(): ReceivePaymentFromWallet {
+        return {
+            $: 'ReceivePaymentFromWallet',
+        }
+    },
+    fromSlice(s: c.Slice): ReceivePaymentFromWallet {
+        loadAndCheckPrefix32(s, 0xc28364ef, 'ReceivePaymentFromWallet');
+        return {
+            $: 'ReceivePaymentFromWallet',
+        }
+    },
+    store(self: ReceivePaymentFromWallet, b: c.Builder): void {
+        b.storeUint(0xc28364ef, 32);
+    },
+    toCell(self: ReceivePaymentFromWallet): c.Cell {
+        return makeCellFrom<ReceivePaymentFromWallet>(self, ReceivePaymentFromWallet.store);
+    }
+}
+
+/**
+ > struct (0x43c7641f) TopUp {
+ > }
+ */
+export interface TopUp {
+    readonly $: 'TopUp'
+}
+
+export const TopUp = {
+    PREFIX: 0x43c7641f,
+
+    create(): TopUp {
+        return {
+            $: 'TopUp',
+        }
+    },
+    fromSlice(s: c.Slice): TopUp {
+        loadAndCheckPrefix32(s, 0x43c7641f, 'TopUp');
+        return {
+            $: 'TopUp',
+        }
+    },
+    store(self: TopUp, b: c.Builder): void {
+        b.storeUint(0x43c7641f, 32);
+    },
+    toCell(self: TopUp): c.Cell {
+        return makeCellFrom<TopUp>(self, TopUp.store);
     }
 }
 

--- a/src/commands/rpc/mod.rs
+++ b/src/commands/rpc/mod.rs
@@ -122,12 +122,11 @@ fn rpc_info_cmd(address: &str, net: Option<String>) -> anyhow::Result<()> {
         .flatten();
 
     let decoded_storage = match (&data, matched_contract.as_ref()) {
-        (Some(data), Some(contract)) => match (&contract.abi, &contract.source_map) {
-            (Some(abi), Some(source_map)) => {
-                Some(decode_storage_json(data, source_map, abi, &network)?)
-            }
-            _ => None,
-        },
+        (Some(data), Some(contract)) => contract
+            .abi
+            .as_ref()
+            .map(|abi| decode_storage_json(data, abi, &network))
+            .transpose()?,
         _ => None,
     };
 
@@ -249,7 +248,6 @@ struct LocalContractMatch {
     contract_id: String,
     contract_name: String,
     abi: Option<Arc<ContractABI>>,
-    source_map: Option<Arc<SourceMap>>,
 }
 
 fn find_local_contract_match(
@@ -262,7 +260,6 @@ fn find_local_contract_match(
                 contract_id: candidate.contract_id,
                 contract_name: candidate.contract_name,
                 abi: candidate.abi,
-                source_map: candidate.source_map,
             }));
         }
     }
@@ -380,19 +377,17 @@ fn load_local_contract_candidate(
 
 fn decode_storage_json(
     data: &Cell,
-    source_map: &SourceMap,
     abi: &ContractABI,
     network: &Network,
 ) -> anyhow::Result<serde_json::Value> {
-    let storage_ty = abi
+    let storage_ty_idx = abi
         .storage
-        .storage_at_deployment_ty
-        .as_ref()
-        .or(abi.storage.storage_ty.as_ref())
+        .storage_at_deployment_ty_idx
+        .or(abi.storage.storage_ty_idx)
         .ok_or_else(|| anyhow!("Contract ABI does not declare storage"))?;
     let mut parser = data.as_slice_allow_exotic();
-    let decoded = dynamic_unpack::unpack_from_slice(&mut parser, source_map, storage_ty)
-        .context("Failed to decode storage with compiler symbols")?;
+    let decoded = dynamic_unpack::unpack_from_abi_slice(&mut parser, abi, storage_ty_idx)
+        .context("Failed to decode storage with compiler ABI")?;
     if parser.size_bits() != 0 || parser.size_refs() != 0 {
         anyhow::bail!(
             "Storage cell has {} extra bits and {} extra refs after type decode",

--- a/src/commands/script/mod.rs
+++ b/src/commands/script/mod.rs
@@ -31,6 +31,7 @@ use std::sync::Arc;
 use std::time::UNIX_EPOCH;
 use tolk_compiler::SourceMap;
 use tolk_compiler::abi::{ABIFunctionParameter, ContractABI, Ty};
+use tolk_compiler::types_kernel::TyIdx;
 use tolk_syntax::ast::expressions::parse_tolk_int_literal;
 use ton_api::Network;
 use ton_emulator::emulator::Emulator;
@@ -607,21 +608,25 @@ fn parse_script_stack_args(abi: Option<&ContractABI>, args: &[String]) -> anyhow
 
     let mut items = Vec::with_capacity(args.len());
     for (param, arg) in main.parameters.iter().zip(args) {
-        items.push(parse_script_parameter(param, arg)?);
+        items.push(parse_script_parameter(abi, param, arg)?);
     }
 
     Ok(Tuple(items))
 }
 
-fn parse_script_parameter(param: &ABIFunctionParameter, raw: &str) -> anyhow::Result<TupleItem> {
-    validate_script_arg_ty(&param.ty)
-        .and_then(|()| parse_script_value(&param.ty, raw))
+fn parse_script_parameter(
+    abi: &ContractABI,
+    param: &ABIFunctionParameter,
+    raw: &str,
+) -> anyhow::Result<TupleItem> {
+    validate_script_arg_ty(abi, param.ty_idx)
+        .and_then(|()| parse_script_value(abi, param.ty_idx, raw))
         .map_err(|err| match err {
             ScriptArgParseError::Invalid => {
                 anyhow!(
                     "Cannot parse argument {} as {}: {}",
                     param.name.yellow(),
-                    param.ty.to_string().yellow(),
+                    abi.render_type(param.ty_idx).yellow(),
                     format_arg_value(raw).yellow()
                 )
             }
@@ -651,9 +656,17 @@ enum ScriptArgParseError {
     Unsupported { kind: &'static str, ty: String },
 }
 
-fn validate_script_arg_ty(ty: &Ty) -> Result<(), ScriptArgParseError> {
+fn validate_script_arg_ty(abi: &ContractABI, ty_idx: TyIdx) -> Result<(), ScriptArgParseError> {
+    let Some(ty) = abi.ty_by_idx(ty_idx) else {
+        return Err(ScriptArgParseError::Unsupported {
+            kind: "argument",
+            ty: format!("ty#{ty_idx}"),
+        });
+    };
     match ty {
-        Ty::Nullable { inner, .. } | Ty::ArrayOf { inner } => validate_script_arg_ty(inner),
+        Ty::Nullable { inner_ty_idx, .. } | Ty::ArrayOf { inner_ty_idx } => {
+            validate_script_arg_ty(abi, *inner_ty_idx)
+        }
         Ty::Int
         | Ty::IntN { .. }
         | Ty::UintN { .. }
@@ -670,19 +683,29 @@ fn validate_script_arg_ty(ty: &Ty) -> Result<(), ScriptArgParseError> {
         | Ty::AddressExt
         | Ty::AddressOpt
         | Ty::NullLiteral => Ok(()),
-        _ => Err(unsupported_ty(ty)),
+        _ => Err(unsupported_ty(abi, ty_idx)),
     }
 }
 
-fn parse_script_value(ty: &Ty, raw: &str) -> Result<TupleItem, ScriptArgParseError> {
+fn parse_script_value(
+    abi: &ContractABI,
+    ty_idx: TyIdx,
+    raw: &str,
+) -> Result<TupleItem, ScriptArgParseError> {
+    let Some(ty) = abi.ty_by_idx(ty_idx) else {
+        return Err(ScriptArgParseError::Unsupported {
+            kind: "argument",
+            ty: format!("ty#{ty_idx}"),
+        });
+    };
     let trimmed = raw.trim();
     match ty {
         Ty::String if !trimmed.starts_with('"') => string_tuple_item(raw),
         Ty::Nullable { .. } if trimmed == "null" => Ok(TupleItem::Null),
-        Ty::Nullable { inner, .. } => parse_script_value(inner, raw),
+        Ty::Nullable { inner_ty_idx, .. } => parse_script_value(abi, *inner_ty_idx, raw),
         _ => {
-            let mut parser = ScriptArgParser::new(raw);
-            let item = parser.parse_value(ty)?;
+            let mut parser = ScriptArgParser::new(abi, raw);
+            let item = parser.parse_value(ty_idx)?;
             parser.skip_ws();
             if parser.is_eof() {
                 Ok(item)
@@ -694,13 +717,14 @@ fn parse_script_value(ty: &Ty, raw: &str) -> Result<TupleItem, ScriptArgParseErr
 }
 
 struct ScriptArgParser<'a> {
+    abi: &'a ContractABI,
     input: &'a str,
     pos: usize,
 }
 
 impl<'a> ScriptArgParser<'a> {
-    const fn new(input: &'a str) -> Self {
-        Self { input, pos: 0 }
+    const fn new(abi: &'a ContractABI, input: &'a str) -> Self {
+        Self { abi, input, pos: 0 }
     }
 
     const fn is_eof(&self) -> bool {
@@ -728,8 +752,14 @@ impl<'a> ScriptArgParser<'a> {
         }
     }
 
-    fn parse_value(&mut self, ty: &Ty) -> Result<TupleItem, ScriptArgParseError> {
+    fn parse_value(&mut self, ty_idx: TyIdx) -> Result<TupleItem, ScriptArgParseError> {
         self.skip_ws();
+        let Some(ty) = self.abi.ty_by_idx(ty_idx) else {
+            return Err(ScriptArgParseError::Unsupported {
+                kind: "argument",
+                ty: format!("ty#{ty_idx}"),
+            });
+        };
         match ty {
             Ty::Int
             | Ty::IntN { .. }
@@ -756,8 +786,8 @@ impl<'a> ScriptArgParser<'a> {
                     Err(ScriptArgParseError::Invalid)
                 }
             }
-            Ty::ArrayOf { inner } => self.parse_array(inner),
-            _ => Err(unsupported_ty(ty)),
+            Ty::ArrayOf { inner_ty_idx } => self.parse_array(*inner_ty_idx),
+            _ => Err(unsupported_ty(self.abi, ty_idx)),
         }
     }
 
@@ -799,7 +829,7 @@ impl<'a> ScriptArgParser<'a> {
         address_tuple_item(token)
     }
 
-    fn parse_array(&mut self, inner: &Ty) -> Result<TupleItem, ScriptArgParseError> {
+    fn parse_array(&mut self, inner_ty_idx: TyIdx) -> Result<TupleItem, ScriptArgParseError> {
         if !self.consume_byte(b'[') {
             return Err(ScriptArgParseError::Invalid);
         }
@@ -814,7 +844,7 @@ impl<'a> ScriptArgParser<'a> {
                 return Err(ScriptArgParseError::Invalid);
             }
 
-            items.push(self.parse_value(inner)?);
+            items.push(self.parse_value(inner_ty_idx)?);
 
             self.skip_ws();
             self.consume_byte(b',');
@@ -918,10 +948,12 @@ fn address_tuple_item(value: &str) -> Result<TupleItem, ScriptArgParseError> {
         .map_err(|_| ScriptArgParseError::Invalid)
 }
 
-fn unsupported_ty(ty: &Ty) -> ScriptArgParseError {
+fn unsupported_ty(abi: &ContractABI, ty_idx: TyIdx) -> ScriptArgParseError {
     ScriptArgParseError::Unsupported {
-        kind: unsupported_ty_kind(ty),
-        ty: ty.to_string(),
+        kind: abi
+            .ty_by_idx(ty_idx)
+            .map_or("argument", unsupported_ty_kind),
+        ty: abi.render_type(ty_idx),
     }
 }
 

--- a/src/commands/test/fuzz.rs
+++ b/src/commands/test/fuzz.rs
@@ -8,6 +8,7 @@ use rand::{Rng, RngCore, SeedableRng};
 use std::sync::Arc;
 use tolk_compiler::SourceMap;
 use tolk_compiler::abi::{ABIFunctionParameter, ContractABI, Ty};
+use tolk_compiler::types_kernel::TyIdx;
 use tvm_ffi::stack::{Tuple, TupleItem};
 use tycho_types::cell::{Cell, HashBytes};
 use tycho_types::models::{Base64StdAddrFlags, DisplayBase64StdAddr, StdAddr};
@@ -373,16 +374,20 @@ pub(super) fn attach_test_parameter_metadata(
     mut tests: Vec<TestDescriptor>,
     abi: Option<&ContractABI>,
 ) -> Vec<TestDescriptor> {
+    let Some(abi) = abi else {
+        return tests;
+    };
+
     for test in &mut tests {
-        if let Some(method) = abi.and_then(|abi| {
-            abi.get_methods
-                .iter()
-                .find(|method| method.tvm_method_id == test.id || method.name == test.name.as_ref())
-        }) {
+        if let Some(method) = abi
+            .get_methods
+            .iter()
+            .find(|method| method.tvm_method_id == test.id || method.name == test.name.as_ref())
+        {
             test.parameters = method
                 .parameters
                 .iter()
-                .map(map_compiler_parameter)
+                .map(|parameter| map_compiler_parameter(abi, parameter))
                 .collect();
         }
     }
@@ -390,15 +395,18 @@ pub(super) fn attach_test_parameter_metadata(
     tests
 }
 
-fn map_compiler_parameter(parameter: &ABIFunctionParameter) -> FuzzParameter {
+fn map_compiler_parameter(abi: &ContractABI, parameter: &ABIFunctionParameter) -> FuzzParameter {
     FuzzParameter {
         name: parameter.name.clone(),
-        type_name: parameter.ty.render_type(),
-        kind: map_compiler_type(&parameter.ty),
+        type_name: abi.render_type(parameter.ty_idx),
+        kind: map_compiler_type(abi, parameter.ty_idx),
     }
 }
 
-fn map_compiler_type(ty: &Ty) -> FuzzParameterKind {
+fn map_compiler_type(abi: &ContractABI, ty_idx: TyIdx) -> FuzzParameterKind {
+    let Some(ty) = abi.ty_by_idx(ty_idx) else {
+        return FuzzParameterKind::Unsupported;
+    };
     match ty {
         Ty::Int => FuzzParameterKind::Int {
             signed: true,
@@ -435,7 +443,7 @@ fn map_compiler_type(ty: &Ty) -> FuzzParameterKind {
         Ty::Address => FuzzParameterKind::Address,
         Ty::AddressAny => FuzzParameterKind::AnyAddress,
         Ty::AddressOpt => FuzzParameterKind::Nullable(Box::new(FuzzParameterKind::Address)),
-        Ty::Nullable { inner, .. } => match map_compiler_type(inner) {
+        Ty::Nullable { inner_ty_idx, .. } => match map_compiler_type(abi, *inner_ty_idx) {
             FuzzParameterKind::Unsupported => FuzzParameterKind::Unsupported,
             inner => FuzzParameterKind::Nullable(Box::new(inner)),
         },

--- a/src/commands/test/reporting/console.rs
+++ b/src/commands/test/reporting/console.rs
@@ -440,8 +440,8 @@ fn process_assert_failure(failure: &AssertFailure, _test: &TestReport, fmt: &For
         let diff_output = fmt.format_tuple_diff(
             &failure.left,
             &failure.right,
-            &failure.left_ty,
-            &failure.right_ty,
+            failure.left_ty_idx,
+            failure.right_ty_idx,
             &failure.source_map,
         );
 
@@ -453,7 +453,8 @@ fn process_assert_failure(failure: &AssertFailure, _test: &TestReport, fmt: &For
     if let AssertFailure::Bin(failure) = &failure
         && failure.operator == "!="
     {
-        let value = fmt.format_tuple_value(&failure.left, &failure.left_ty, &failure.source_map, 8);
+        let value =
+            fmt.format_tuple_value(&failure.left, failure.left_ty_idx, &failure.source_map, 8);
         println!("       Values are equal but expected to be different:");
         println!("         {}", value.dimmed());
     }
@@ -461,9 +462,10 @@ fn process_assert_failure(failure: &AssertFailure, _test: &TestReport, fmt: &For
     if let AssertFailure::Bin(failure) = &failure
         && failure.is_ord()
     {
-        let left = fmt.format_tuple_value(&failure.left, &failure.left_ty, &failure.source_map, 8);
+        let left =
+            fmt.format_tuple_value(&failure.left, failure.left_ty_idx, &failure.source_map, 8);
         let right =
-            fmt.format_tuple_value(&failure.right, &failure.right_ty, &failure.source_map, 8);
+            fmt.format_tuple_value(&failure.right, failure.right_ty_idx, &failure.source_map, 8);
 
         println!("        Actual:   {}", left.red());
         println!("        Expected: {}", right.green());

--- a/src/commands/test/reporting/teamcity.rs
+++ b/src/commands/test/reporting/teamcity.rs
@@ -48,13 +48,13 @@ impl TeamCityReporter {
                         if let Some(formatter) = &formatter {
                             expected = Some(formatter.format_tuple_value(
                                 &bin_failure.right,
-                                &bin_failure.right_ty,
+                                bin_failure.right_ty_idx,
                                 &bin_failure.source_map,
                                 0,
                             ));
                             actual = Some(formatter.format_tuple_value(
                                 &bin_failure.left,
-                                &bin_failure.left_ty,
+                                bin_failure.left_ty_idx,
                                 &bin_failure.source_map,
                                 0,
                             ));
@@ -65,13 +65,13 @@ impl TeamCityReporter {
                         if let Some(formatter) = &formatter {
                             expected = Some(formatter.format_tuple_value(
                                 &bin_failure.right,
-                                &bin_failure.right_ty,
+                                bin_failure.right_ty_idx,
                                 &bin_failure.source_map,
                                 0,
                             ));
                             actual = Some(formatter.format_tuple_value(
                                 &bin_failure.left,
-                                &bin_failure.left_ty,
+                                bin_failure.left_ty_idx,
                                 &bin_failure.source_map,
                                 0,
                             ));

--- a/src/commands/wrapper/mod.rs
+++ b/src/commands/wrapper/mod.rs
@@ -10,11 +10,11 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use tempfile::TempDir;
-use tolk_compiler::abi::{ABIGetMethod, ABIResolvedStruct, ContractABI};
+use tolk_compiler::abi::{ABIGetMethod, ABIOpcode, ABIResolvedStruct, ContractABI};
 use tolk_compiler::source_map::Declaration;
 use tolk_compiler::{CompilerResult, SourceMap};
 
-const TYPESCRIPT_WRAPPER_PACKAGE: &str = "gen-typescript-from-tolk-dev@0.2.4";
+const TYPESCRIPT_WRAPPER_PACKAGE: &str = "gen-typescript-from-tolk-dev@0.3.1";
 const DEFAULT_TOLK_WRAPPER_DIR: &str = "wrappers";
 const DEFAULT_TYPESCRIPT_WRAPPER_DIR: &str = "wrappers-ts";
 
@@ -38,7 +38,6 @@ struct WrapperModel {
 struct TypescriptGeneratorAbi {
     #[serde(flatten)]
     abi: ContractABI,
-    #[serde(rename = "codeBoc64")]
     code_boc64: String,
 }
 
@@ -586,7 +585,7 @@ fn generate_wrapper(model: &WrapperModel) -> String {
     code.push('\n');
 
     for message in &model.incoming_messages {
-        code.push_str(&generate_send_method(contract, message));
+        code.push_str(&generate_send_method(contract, &model.abi, message));
         code.push('\n');
     }
 
@@ -594,7 +593,7 @@ fn generate_wrapper(model: &WrapperModel) -> String {
     code.push('\n');
 
     for get_method in &model.abi.get_methods {
-        code.push_str(&generate_get_method(contract, get_method));
+        code.push_str(&generate_get_method(contract, &model.abi, get_method));
         code.push('\n');
     }
 
@@ -685,7 +684,11 @@ fn generate_deploy(contract_name: &str) -> String {
     code
 }
 
-fn generate_send_method(contract_name: &str, message_type: &ABIResolvedStruct) -> String {
+fn generate_send_method(
+    contract_name: &str,
+    abi: &ContractABI,
+    message_type: &ABIResolvedStruct,
+) -> String {
     let mut code = String::new();
     let method_name = format!("send{}", message_type.name);
 
@@ -694,7 +697,7 @@ fn generate_send_method(contract_name: &str, message_type: &ABIResolvedStruct) -
     let params = fields
         .iter()
         .map(|f| {
-            let type_name = f.ty.render_param_type();
+            let type_name = abi.render_param_type(f.ty_idx);
             let name = normalize_param_name(&f.name);
             format!("{name}: {type_name}")
         })
@@ -722,12 +725,13 @@ fn generate_send_method(contract_name: &str, message_type: &ABIResolvedStruct) -
         if let Some(prefix) = prefix {
             chain.push(format!(
                 ".storeUint({}, {})",
-                prefix.prefix_str, prefix.prefix_len
+                format_prefix_literal(prefix),
+                prefix.prefix_len
             ));
         }
         for field in &fields {
             let param_name = normalize_param_name(&field.name);
-            let value = if field.ty.is_typed_cell() {
+            let value = if abi.is_typed_cell(field.ty_idx) {
                 format!("{param_name}.toCell()")
             } else {
                 param_name
@@ -765,7 +769,7 @@ fn generate_send_method(contract_name: &str, message_type: &ABIResolvedStruct) -
             for field in &fields {
                 let param_name = normalize_param_name(&field.name);
 
-                if field.ty.is_typed_cell() {
+                if abi.is_typed_cell(field.ty_idx) {
                     let _ = writeln!(code, "            {}: {}.toCell(),", field.name, param_name);
                 } else if field.name == param_name {
                     let _ = writeln!(code, "            {},", field.name);
@@ -782,6 +786,15 @@ fn generate_send_method(contract_name: &str, message_type: &ABIResolvedStruct) -
     code.push_str("}\n");
 
     code
+}
+
+fn format_prefix_literal(prefix: &ABIOpcode) -> String {
+    let prefix_len = usize::try_from(prefix.prefix_len.max(0)).unwrap_or(0);
+    if prefix_len % 4 == 0 {
+        format!("0x{:0width$x}", prefix.prefix_num, width = prefix_len / 4)
+    } else {
+        format!("0b{:0width$b}", prefix.prefix_num, width = prefix_len)
+    }
 }
 
 fn normalize_param_name(name: &str) -> String {
@@ -812,7 +825,11 @@ fn generate_send_any_method(contract_name: &str) -> String {
     code
 }
 
-fn generate_get_method(contract_name: &str, get_method: &ABIGetMethod) -> String {
+fn generate_get_method(
+    contract_name: &str,
+    abi: &ContractABI,
+    get_method: &ABIGetMethod,
+) -> String {
     let mut code = String::new();
     let method_name = normalize_get_method_name(&get_method.name);
     let tvm_method_name = &get_method.name;
@@ -820,7 +837,7 @@ fn generate_get_method(contract_name: &str, get_method: &ABIGetMethod) -> String
         .parameters
         .iter()
         .map(|p| {
-            let type_name = p.ty.render_param_type();
+            let type_name = abi.render_param_type(p.ty_idx);
             let param_name = normalize_get_param_name(&p.name);
             format!("{param_name}: {type_name}")
         })
@@ -832,7 +849,7 @@ fn generate_get_method(contract_name: &str, get_method: &ABIGetMethod) -> String
         .iter()
         .map(|p| {
             let param_name = normalize_get_param_name(&p.name);
-            if p.ty.is_typed_cell() {
+            if abi.is_typed_cell(p.ty_idx) {
                 format!("{param_name}.toCell()")
             } else {
                 param_name
@@ -840,7 +857,7 @@ fn generate_get_method(contract_name: &str, get_method: &ABIGetMethod) -> String
         })
         .collect::<Vec<_>>();
 
-    let return_type = get_method.return_ty.render_type();
+    let return_type = abi.render_type(get_method.return_ty_idx);
 
     if params.is_empty() {
         let _ = writeln!(
@@ -1042,10 +1059,10 @@ fn generate_setup_test(
             .fields
             .iter()
             .map(|f| {
-                if let Some(default_value) = f.ty.typed_cell_payload_default_value(abi) {
+                if let Some(default_value) = abi.typed_cell_payload_default_value(f.ty_idx) {
                     format!(" {}: {default_value}.toCell()", f.name)
                 } else {
-                    format!(" {}: {}", f.name, f.ty.default_value(abi))
+                    format!(" {}: {}", f.name, abi.default_value(f.ty_idx))
                 }
             })
             .collect::<Vec<_>>()

--- a/src/context.rs
+++ b/src/context.rs
@@ -13,7 +13,8 @@ use std::collections::VecDeque;
 use std::path::{Component, Path, PathBuf};
 use std::sync::Arc;
 use tolk_compiler::SourceMap;
-use tolk_compiler::abi::{ContractABI, Ty};
+use tolk_compiler::abi::ContractABI;
+use tolk_compiler::types_kernel::TyIdx;
 use ton::ton_wallet::TonWallet;
 use ton_api::{Network, TonApiClient};
 use ton_emulator::emulator::{Emulator, SendMessageResult, SendMessageResultSuccess};
@@ -46,9 +47,9 @@ pub fn is_debug_stop_requested(err: &anyhow::Error) -> bool {
 pub struct AssertBinFailure {
     pub operator: String,
     pub left: Tuple,
-    pub left_ty: Ty,
+    pub left_ty_idx: TyIdx,
     pub right: Tuple,
-    pub right_ty: Ty,
+    pub right_ty_idx: TyIdx,
     pub source_map: Arc<SourceMap>,
     pub message: Option<String>,
     pub location: Option<SourceLocation>,

--- a/src/ffi/assert.rs
+++ b/src/ffi/assert.rs
@@ -3,10 +3,9 @@ use crate::context::{
     TransactionGenericAssertFailure, TransactionNotFoundParams, WalletNotFoundFailure,
 };
 use acton_debug::{RenderedValue, render_tuple_as_tolk_type};
-use anyhow::Context as ErrorContext;
+use anyhow::{Context as ErrorContext, anyhow};
 use num_bigint::BigInt;
 use num_traits::ToPrimitive;
-use tolk_compiler::abi::Ty;
 use ton_emulator::{extension, register_ext_methods};
 use ton_executor::BaseExecutor;
 use ton_source_map::SourceLocation;
@@ -45,7 +44,7 @@ fn assume_reject_impl(
     Ok(())
 }
 
-extension!(assert_bin in (Context) with (location: String, message: String, right: Tuple, right_ty_json: String, left: Tuple, left_ty_json: String, operator: String) using assert_bin_impl);
+extension!(assert_bin in (Context) with (location: String, message: String, right: Tuple, right_ty_idx: BigInt, left: Tuple, left_ty_idx: BigInt, operator: String) using assert_bin_impl);
 #[allow(clippy::too_many_arguments)]
 fn assert_bin_impl(
     ctx: &mut Context,
@@ -53,21 +52,24 @@ fn assert_bin_impl(
     location: String,
     message: String,
     right: Tuple,
-    right_ty_json: String,
+    right_ty_idx: BigInt,
     left: Tuple,
-    left_ty_json: String,
+    left_ty_idx: BigInt,
     operator: String,
 ) -> anyhow::Result<()> {
     let left = left.unwrap_single();
     let right = right.unwrap_single();
-    let left_ty: Ty = serde_json::from_str(&left_ty_json)?;
-    let right_ty: Ty = serde_json::from_str(&right_ty_json)?;
+    let source_map = ctx.env.source_map.clone();
+    let left_ty_idx = left_ty_idx
+        .to_usize()
+        .ok_or_else(|| anyhow!("ty_idx=`{left_ty_idx}` does not fit into usize"))?;
+    let right_ty_idx = right_ty_idx
+        .to_usize()
+        .ok_or_else(|| anyhow!("ty_idx=`{right_ty_idx}` does not fit into usize"))?;
 
     if operator == "==" || operator == "!=" {
-        let source_map = &ctx.env.source_map;
-
-        let left_rendered = render_tuple_as_tolk_type(source_map, &left, &left_ty);
-        let right_rendered = render_tuple_as_tolk_type(source_map, &right, &right_ty);
+        let left_rendered = render_tuple_as_tolk_type(&source_map, &left, left_ty_idx);
+        let right_rendered = render_tuple_as_tolk_type(&source_map, &right, right_ty_idx);
         let values_equal = rendered_values_equal(&left_rendered, &right_rendered);
 
         if operator == "==" && values_equal {
@@ -96,9 +98,9 @@ fn assert_bin_impl(
         operator,
         left,
         right,
-        left_ty,
-        right_ty,
-        source_map: ctx.env.source_map.clone(),
+        left_ty_idx,
+        right_ty_idx,
+        source_map,
         message: Some(message),
         location: SourceLocation::parse(&location)?,
     }));

--- a/src/ffi/io.rs
+++ b/src/ffi/io.rs
@@ -3,7 +3,7 @@ use crate::context::{BuildCache, Context, to_cell};
 use crate::ffi::emulation::{compilation_result_for_code, normalize_address_input};
 use crate::formatter::FormatterContext;
 use acton_debug::render_tuple_item_as_tolk_type;
-use anyhow::{Context as AnyhowContext, bail};
+use anyhow::{Context as AnyhowContext, anyhow, bail};
 use inquire::validator::{ErrorMessage, Validation};
 use inquire::{Confirm, Select, Text};
 use num_bigint::BigInt;
@@ -13,41 +13,46 @@ use std::collections::HashSet;
 use std::io::{IsTerminal, stdin};
 use tolk_compiler::SourceMap;
 use tolk_compiler::abi::Ty;
+use tolk_compiler::types_kernel::{TyIdx, render_ty};
 use ton_emulator::{extension, register_ext_methods};
 use ton_executor::BaseExecutor;
 use tvm_ffi::from_stack::FromStack;
 use tvm_ffi::stack::{Tuple, TupleItem};
 use tycho_types::models::{StdAddr, StdAddrFormat};
 
-extension!(println in (Context) with (arg6: TupleItem, type6: String, arg5: TupleItem, type5: String, arg4: TupleItem, type4: String, arg3: TupleItem, type3: String, arg2: TupleItem, type2: String, arg1: TupleItem, type1: String) using println_impl);
+extension!(println in (Context) with (arg6: TupleItem, type6: BigInt, arg5: TupleItem, type5: BigInt, arg4: TupleItem, type4: BigInt, arg3: TupleItem, type3: BigInt, arg2: TupleItem, type2: BigInt, arg1: TupleItem, type1: BigInt) using println_impl);
 #[allow(clippy::too_many_arguments)]
 fn println_impl(
     ctx: &mut Context,
     _stack: &mut Tuple,
     arg6: TupleItem,
-    type6: String,
+    type6: BigInt,
     arg5: TupleItem,
-    type5: String,
+    type5: BigInt,
     arg4: TupleItem,
-    type4: String,
+    type4: BigInt,
     arg3: TupleItem,
-    type3: String,
+    type3: BigInt,
     arg2: TupleItem,
-    type2: String,
+    type2: BigInt,
     arg1: TupleItem,
-    type1: String,
+    type1: BigInt,
 ) -> anyhow::Result<()> {
-    let args = collect_non_void_args([
-        (type1, arg1),
-        (type2, arg2),
-        (type3, arg3),
-        (type4, arg4),
-        (type5, arg5),
-        (type6, arg6),
-    ])?;
+    let args = collect_non_void_args(
+        ctx,
+        [
+            (type1, arg1),
+            (type2, arg2),
+            (type3, arg3),
+            (type4, arg4),
+            (type5, arg5),
+            (type6, arg6),
+        ],
+    )?;
     let formatter = FormatterContext::from_context(ctx);
+    let source_map = ctx.env.source_map.as_ref();
     let (mut formatted, tail) = if let Some(arg) = args.first()
-        && is_string_type(&arg.ty)
+        && is_top_level_string_ty_idx(source_map, arg.ty_idx)
         && let Ok(fmt) = String::from_item(arg.arg.clone().unwrap_single())
         && let Ok((rendered, consumed)) = format_args(ctx, &formatter, &fmt, &args[1..], true)
     {
@@ -83,30 +88,33 @@ fn eprintln_impl(ctx: &mut Context, _stack: &mut Tuple, s: String) -> anyhow::Re
     Ok(())
 }
 
-extension!(format in (Context) with (arg5: TupleItem, type5: String, arg4: TupleItem, type4: String, arg3: TupleItem, type3: String, arg2: TupleItem, type2: String, arg1: TupleItem, type1: String, fmt: String) using format_impl);
+extension!(format in (Context) with (arg5: TupleItem, type5: BigInt, arg4: TupleItem, type4: BigInt, arg3: TupleItem, type3: BigInt, arg2: TupleItem, type2: BigInt, arg1: TupleItem, type1: BigInt, fmt: String) using format_impl);
 #[allow(clippy::too_many_arguments)]
 fn format_impl(
     ctx: &mut Context,
     stack: &mut Tuple,
     arg5: TupleItem,
-    type5: String,
+    type5: BigInt,
     arg4: TupleItem,
-    type4: String,
+    type4: BigInt,
     arg3: TupleItem,
-    type3: String,
+    type3: BigInt,
     arg2: TupleItem,
-    type2: String,
+    type2: BigInt,
     arg1: TupleItem,
-    type1: String,
+    type1: BigInt,
     fmt: String,
 ) -> anyhow::Result<()> {
-    let args = collect_non_void_args([
-        (type1, arg1),
-        (type2, arg2),
-        (type3, arg3),
-        (type4, arg4),
-        (type5, arg5),
-    ])?;
+    let args = collect_non_void_args(
+        ctx,
+        [
+            (type1, arg1),
+            (type2, arg2),
+            (type3, arg3),
+            (type4, arg4),
+            (type5, arg5),
+        ],
+    )?;
     let formatter = FormatterContext::from_context(ctx);
     let (result, _) = format_args(ctx, &formatter, &fmt, &args, false)?;
     stack.push_string(&result);
@@ -115,7 +123,7 @@ fn format_impl(
 
 #[derive(Clone)]
 struct ReflectedArg {
-    ty: Ty,
+    ty_idx: TyIdx,
     arg: TupleItem,
 }
 
@@ -222,26 +230,18 @@ fn parse_format(fmt: &str) -> anyhow::Result<Vec<FormatToken>> {
 fn format_default(
     ctx: &Context<'_>,
     formatter: &FormatterContext<'_>,
-    ty: &Ty,
+    ty_idx: TyIdx,
     arg: TupleItem,
     colorize: bool,
 ) -> anyhow::Result<String> {
-    format_reflected_arg(
-        ctx,
-        formatter,
-        &ReflectedArg {
-            ty: ty.clone(),
-            arg,
-        },
-        colorize,
-    )
+    format_reflected_arg(ctx, formatter, &ReflectedArg { ty_idx, arg }, colorize)
 }
 
 fn format_single_arg(
     ctx: &Context<'_>,
     formatter: &FormatterContext<'_>,
     kind: PlaceholderKind,
-    ty: &Ty,
+    ty_idx: TyIdx,
     arg: TupleItem,
     colorize: bool,
 ) -> anyhow::Result<String> {
@@ -253,7 +253,7 @@ fn format_single_arg(
             {
                 return Ok(format!("{value:x}"));
             }
-            format_default(ctx, formatter, ty, arg, colorize)
+            format_default(ctx, formatter, ty_idx, arg, colorize)
         }
         PlaceholderKind::Ton => {
             if let TupleItem::Tuple(items) = &arg
@@ -263,22 +263,29 @@ fn format_single_arg(
                 let amount = value.to_f64().unwrap_or(0.0) / 1e9;
                 return Ok(format!("{amount} TON"));
             }
-            format_default(ctx, formatter, ty, arg, colorize)
+            format_default(ctx, formatter, ty_idx, arg, colorize)
         }
-        PlaceholderKind::Plain => format_default(ctx, formatter, ty, arg, colorize),
+        PlaceholderKind::Plain => format_default(ctx, formatter, ty_idx, arg, colorize),
     }
 }
 
 fn collect_non_void_args<const N: usize>(
-    args: [(String, TupleItem); N],
+    ctx: &Context<'_>,
+    args: [(BigInt, TupleItem); N],
 ) -> anyhow::Result<Vec<ReflectedArg>> {
     let mut collected = Vec::with_capacity(N);
-    for (type_desc, arg) in args {
-        let ty: Ty = serde_json::from_str(&type_desc)?;
+    let source_map = ctx.env.source_map.as_ref();
+    for (type_idx, arg) in args {
+        let ty_idx = type_idx
+            .to_usize()
+            .ok_or_else(|| anyhow!("ty_idx=`{type_idx}` does not fit into usize"))?;
+        let Some(ty) = source_map.ty_by_idx(ty_idx) else {
+            continue;
+        };
         if matches!(ty, Ty::Void) {
             break;
         }
-        collected.push(ReflectedArg { ty, arg });
+        collected.push(ReflectedArg { ty_idx, arg });
     }
     Ok(collected)
 }
@@ -342,7 +349,7 @@ fn format_args(
                         ctx,
                         formatter,
                         kind,
-                        &arg.ty,
+                        arg.ty_idx,
                         arg.arg.clone(),
                         colorize,
                     )?;
@@ -358,18 +365,6 @@ fn format_args(
     Ok((out, consumed))
 }
 
-const fn is_string_type(ty: &Ty) -> bool {
-    matches!(ty, Ty::String)
-}
-
-fn is_top_level_string_type(ty: &Ty) -> bool {
-    match ty {
-        Ty::String => true,
-        Ty::Nullable { inner, .. } => is_top_level_string_type(inner),
-        _ => false,
-    }
-}
-
 fn format_reflected_arg(
     ctx: &Context<'_>,
     formatter: &FormatterContext<'_>,
@@ -377,21 +372,23 @@ fn format_reflected_arg(
     colorize: bool,
 ) -> anyhow::Result<String> {
     let item = arg.arg.clone().unwrap_single();
-    if is_top_level_string_type(&arg.ty)
+    let source_map = ctx.env.source_map.as_ref();
+
+    if is_top_level_string_ty_idx(source_map, arg.ty_idx)
         && let Ok(value) = String::from_item(item.clone())
     {
         return Ok(value);
     }
 
-    if is_send_result_list_type(&arg.ty) {
+    if is_send_result_list_type(source_map, arg.ty_idx) {
         return Ok(format_send_result_list(ctx, formatter, &item));
     }
 
     Ok(render_with_source_map(
-        &ctx.env.source_map,
+        ctx.env.source_map.as_ref(),
         formatter,
         &item,
-        &arg.ty,
+        arg.ty_idx,
         colorize,
     ))
 }
@@ -400,7 +397,7 @@ fn render_with_source_map(
     symbols: &SourceMap,
     formatter: &FormatterContext<'_>,
     item: &TupleItem,
-    ty: &Ty,
+    ty_idx: TyIdx,
     colorize: bool,
 ) -> String {
     let options = if colorize {
@@ -408,31 +405,42 @@ fn render_with_source_map(
     } else {
         formatter.pretty_render_options()
     };
-    render_tuple_item_as_tolk_type(symbols, item, ty).to_pretty_string(options)
+    render_tuple_item_as_tolk_type(symbols, item, ty_idx).to_pretty_string(options)
 }
 
-fn is_send_result_list_type(ty: &Ty) -> bool {
-    match ty {
-        Ty::AliasRef {
-            alias_name,
-            type_args: _,
-        } if alias_name == "SendResultList" => true,
-        Ty::AliasRef {
-            alias_name,
-            type_args: Some(type_args),
-        } if alias_name == "BigArray" => type_args.first().is_some_and(is_send_result_type),
-        Ty::Nullable { inner, .. } => is_send_result_list_type(inner),
-        _ => ty.to_string() == "SendResultList",
+fn is_top_level_string_ty_idx(source_map: &SourceMap, ty_idx: TyIdx) -> bool {
+    match source_map.ty_by_idx(ty_idx) {
+        Some(Ty::String) => true,
+        Some(Ty::Nullable { inner_ty_idx, .. }) => {
+            is_top_level_string_ty_idx(source_map, *inner_ty_idx)
+        }
+        _ => false,
     }
 }
 
-fn is_send_result_type(ty: &Ty) -> bool {
+fn is_send_result_list_type(source_map: &SourceMap, ty_idx: TyIdx) -> bool {
+    match source_map.ty_by_idx(ty_idx) {
+        Some(Ty::AliasRef { alias_name, .. }) if alias_name == "SendResultList" => true,
+        Some(Ty::AliasRef {
+            alias_name,
+            type_args_ty_idx: Some(type_args),
+        }) if alias_name == "BigArray" => type_args
+            .first()
+            .is_some_and(|&item_ty_idx| is_send_result_type(source_map, item_ty_idx)),
+        Some(Ty::Nullable { inner_ty_idx, .. }) => {
+            is_send_result_list_type(source_map, *inner_ty_idx)
+        }
+        _ => render_ty(source_map, ty_idx) == "SendResultList",
+    }
+}
+
+fn is_send_result_type(source_map: &SourceMap, ty_idx: TyIdx) -> bool {
     matches!(
-        ty,
-        Ty::StructRef {
+        source_map.ty_by_idx(ty_idx),
+        Some(Ty::StructRef {
             struct_name,
-            type_args: _
-        } if struct_name == "SendResult"
+            ..
+        }) if struct_name == "SendResult"
     )
 }
 

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -24,6 +24,7 @@ use std::sync::Arc;
 use tolk_compiler::SourceMap;
 use tolk_compiler::abi::{ABIDeclaration, ContractABI, Ty};
 use tolk_compiler::dynamic_unpack::{self, UnpackedValue};
+use tolk_compiler::types_kernel::TyIdx;
 use ton_api::Network;
 use ton_source_map::SourceLocation;
 use tvm_ffi::stack::{Tuple, TupleItem};
@@ -974,8 +975,10 @@ See https://ton-blockchain.github.io/acton/docs/tutorial/setup-wallets for more 
         let abi = build.abi.as_ref()?;
         self.try_decode_message_body_types(
             in_msg.body,
-            build.source_map.as_ref(),
-            abi.incoming_external.iter().map(|message| &message.body_ty),
+            abi,
+            abi.incoming_external
+                .iter()
+                .map(|message| message.body_ty_idx),
             0,
         )
     }
@@ -989,8 +992,8 @@ See https://ton-blockchain.github.io/acton/docs/tutorial/setup-wallets for more 
         let abi = build.abi.as_ref()?;
         self.try_decode_message_body_types(
             msg.body,
-            build.source_map.as_ref(),
-            abi.emitted_events.iter().map(|message| &message.body_ty),
+            abi,
+            abi.emitted_events.iter().map(|message| message.body_ty_idx),
             0,
         )
     }
@@ -1066,8 +1069,8 @@ See https://ton-blockchain.github.io/acton/docs/tutorial/setup-wallets for more 
             let candidates = Self::compiler_message_candidates(abi, direction, opcode);
             if let Some(decoded) = self.try_decode_message_body_types(
                 body,
-                build.source_map.as_ref(),
-                candidates.iter(),
+                abi,
+                candidates,
                 if bounced { 32 } else { 0 },
             ) {
                 return Some(decoded);
@@ -1081,7 +1084,7 @@ See https://ton-blockchain.github.io/acton/docs/tutorial/setup-wallets for more 
         abi: &ContractABI,
         direction: MessageBodyDirection,
         opcode: Option<u32>,
-    ) -> Vec<Ty> {
+    ) -> Vec<TyIdx> {
         let mut candidates = Vec::new();
         let mut seen = HashSet::new();
 
@@ -1091,7 +1094,7 @@ See https://ton-blockchain.github.io/acton/docs/tutorial/setup-wallets for more 
                     Self::push_compiler_message_candidate(
                         &mut candidates,
                         &mut seen,
-                        message.body_ty.clone(),
+                        message.body_ty_idx,
                     );
                 }
             }
@@ -1100,7 +1103,7 @@ See https://ton-blockchain.github.io/acton/docs/tutorial/setup-wallets for more 
                     Self::push_compiler_message_candidate(
                         &mut candidates,
                         &mut seen,
-                        message.body_ty.clone(),
+                        message.body_ty_idx,
                     );
                 }
             }
@@ -1114,21 +1117,22 @@ See https://ton-blockchain.github.io/acton/docs/tutorial/setup-wallets for more 
     }
 
     fn push_compiler_message_candidate(
-        candidates: &mut Vec<Ty>,
-        seen: &mut HashSet<String>,
-        candidate: Ty,
+        candidates: &mut Vec<TyIdx>,
+        seen: &mut HashSet<TyIdx>,
+        candidate: TyIdx,
     ) {
-        if seen.insert(Self::compiler_body_type_key(&candidate)) {
+        if seen.insert(candidate) {
             candidates.push(candidate);
         }
     }
 
-    fn declaration_message_candidates(abi: &ContractABI, opcode: Option<u32>) -> Vec<(u8, Ty)> {
+    fn declaration_message_candidates(abi: &ContractABI, opcode: Option<u32>) -> Vec<(u8, TyIdx)> {
         let mut candidates = Vec::new();
         for declaration in &abi.declarations {
             match declaration {
                 ABIDeclaration::Struct {
-                    name,
+                    name: _,
+                    ty_idx,
                     type_params,
                     prefix,
                     ..
@@ -1142,8 +1146,7 @@ See https://ton-blockchain.github.io/acton/docs/tutorial/setup-wallets for more 
 
                     let matches_opcode = opcode.is_some_and(|opcode| {
                         prefix.as_ref().is_some_and(|prefix| {
-                            prefix.prefix_len == 32
-                                && Self::parse_abi_prefix_number(&prefix.prefix_str) == Some(opcode)
+                            prefix.prefix_len == 32 && prefix.prefix_num == u64::from(opcode)
                         })
                     });
                     let priority = if matches_opcode {
@@ -1153,16 +1156,12 @@ See https://ton-blockchain.github.io/acton/docs/tutorial/setup-wallets for more 
                     } else {
                         2
                     };
-                    candidates.push((
-                        priority,
-                        Ty::StructRef {
-                            struct_name: name.clone(),
-                            type_args: None,
-                        },
-                    ));
+                    candidates.push((priority, *ty_idx));
                 }
                 ABIDeclaration::Alias {
-                    name, type_params, ..
+                    ty_idx,
+                    type_params,
+                    ..
                 } => {
                     if type_params
                         .as_ref()
@@ -1171,42 +1170,15 @@ See https://ton-blockchain.github.io/acton/docs/tutorial/setup-wallets for more 
                         continue;
                     }
 
-                    candidates.push((
-                        3,
-                        Ty::AliasRef {
-                            alias_name: name.clone(),
-                            type_args: None,
-                        },
-                    ));
+                    candidates.push((3, *ty_idx));
                 }
-                ABIDeclaration::Enum { name, .. } => {
-                    candidates.push((
-                        4,
-                        Ty::EnumRef {
-                            enum_name: name.clone(),
-                        },
-                    ));
+                ABIDeclaration::Enum { ty_idx, .. } => {
+                    candidates.push((4, *ty_idx));
                 }
             }
         }
         candidates.sort_by_key(|(priority, _)| *priority);
         candidates
-    }
-
-    fn parse_abi_prefix_number(prefix: &str) -> Option<u32> {
-        let prefix = prefix.trim();
-        if prefix.is_empty() {
-            return None;
-        }
-        let parsed = if let Some(hex) = prefix
-            .strip_prefix("0x")
-            .or_else(|| prefix.strip_prefix("0X"))
-        {
-            u64::from_str_radix(hex, 16).ok()?
-        } else {
-            prefix.parse::<u64>().ok()?
-        };
-        u32::try_from(parsed).ok()
     }
 
     fn opcode_after_bounce_prefix(body: CellSlice<'_>, bounced: bool) -> Option<u32> {
@@ -1217,23 +1189,24 @@ See https://ton-blockchain.github.io/acton/docs/tutorial/setup-wallets for more 
         parser.load_u32().ok()
     }
 
-    fn try_decode_message_body_types<'ty, I>(
+    fn try_decode_message_body_types<I>(
         &self,
         body: CellSlice<'_>,
-        symbols: &SourceMap,
+        abi: &ContractABI,
         candidates: I,
         prefix_to_skip: u16,
     ) -> Option<DecodedMessageBody>
     where
-        I: IntoIterator<Item = &'ty Ty>,
+        I: IntoIterator<Item = TyIdx>,
     {
-        for body_ty in candidates {
+        for body_ty_idx in candidates {
             let mut parser = body;
             if prefix_to_skip > 0 && parser.skip_first(prefix_to_skip, 0).is_err() {
                 continue;
             }
 
-            let Ok(data) = dynamic_unpack::unpack_from_slice(&mut parser, symbols, body_ty) else {
+            let Ok(data) = dynamic_unpack::unpack_from_abi_slice(&mut parser, abi, body_ty_idx)
+            else {
                 continue;
             };
             if parser.size_bits() != 0 || parser.size_refs() != 0 {
@@ -1241,7 +1214,7 @@ See https://ton-blockchain.github.io/acton/docs/tutorial/setup-wallets for more 
             }
 
             return Some(DecodedMessageBody {
-                name: Self::compiler_body_type_name(body_ty),
+                name: Self::compiler_body_type_name(abi, body_ty_idx),
                 data,
             });
         }
@@ -1249,21 +1222,15 @@ See https://ton-blockchain.github.io/acton/docs/tutorial/setup-wallets for more 
         None
     }
 
-    fn compiler_body_type_name(body_ty: &Ty) -> String {
-        match body_ty {
-            Ty::StructRef { struct_name, .. } => struct_name.clone(),
-            Ty::AliasRef { alias_name, .. } => alias_name.clone(),
-            Ty::EnumRef { enum_name } => enum_name.clone(),
-            _ => body_ty.render_type(),
-        }
-    }
-
-    fn compiler_body_type_key(body_ty: &Ty) -> String {
-        match body_ty {
-            Ty::StructRef { struct_name, .. } => format!("StructRef:{struct_name}"),
-            Ty::AliasRef { alias_name, .. } => format!("AliasRef:{alias_name}"),
-            Ty::EnumRef { enum_name } => format!("EnumRef:{enum_name}"),
-            _ => body_ty.render_type(),
+    fn compiler_body_type_name(abi: &ContractABI, body_ty_idx: TyIdx) -> String {
+        match abi.ty_by_idx(body_ty_idx) {
+            Some(body_ty) => match body_ty {
+                Ty::StructRef { struct_name, .. } => struct_name.clone(),
+                Ty::AliasRef { alias_name, .. } => alias_name.clone(),
+                Ty::EnumRef { enum_name } => enum_name.clone(),
+                _ => abi.render_type(body_ty_idx),
+            },
+            None => format!("ty#{body_ty_idx}"),
         }
     }
 
@@ -2269,12 +2236,15 @@ See https://ton-blockchain.github.io/acton/docs/tutorial/setup-wallets for more 
     pub fn format_tuple_value(
         &self,
         tuple: &Tuple,
-        ty: &Ty,
+        ty_idx: TyIdx,
         source_map: &SourceMap,
         indent: usize,
     ) -> String {
-        let rendered = render_tuple_as_tolk_type(source_map, tuple, ty);
-        let formatted = self.format_rendered_assert_value(&rendered, Some(ty));
+        let rendered = self.render_assert_value(tuple, ty_idx, source_map);
+        let formatted = self.format_rendered_assert_value(
+            &rendered,
+            Self::is_string_like_ty_idx(source_map, ty_idx),
+        );
 
         if !formatted.contains('\n') {
             // Fast path for values with single line
@@ -2287,25 +2257,30 @@ See https://ton-blockchain.github.io/acton/docs/tutorial/setup-wallets for more 
         result
     }
 
+    fn render_assert_value(
+        &self,
+        tuple: &Tuple,
+        ty_idx: TyIdx,
+        source_map: &SourceMap,
+    ) -> RenderedValue {
+        render_tuple_as_tolk_type(source_map, tuple, ty_idx)
+    }
+
     fn format_rendered_assert_value(
         &self,
         value: &RenderedValue,
-        top_level_ty: Option<&Ty>,
+        top_level_is_string: bool,
     ) -> String {
         let formatted = value.to_pretty_string(self.pretty_render_options());
-        if top_level_ty.is_some_and(Self::is_string_like_ty) {
+        if top_level_is_string {
             Self::strip_top_level_string_quotes(formatted)
         } else {
             formatted
         }
     }
 
-    fn is_string_like_ty(ty: &Ty) -> bool {
-        match ty {
-            Ty::String => true,
-            Ty::Nullable { inner, .. } => Self::is_string_like_ty(inner),
-            _ => false,
-        }
+    fn is_string_like_ty_idx(source_map: &SourceMap, ty_idx: TyIdx) -> bool {
+        matches!(source_map.ty_by_idx(ty_idx), Some(Ty::String))
     }
 
     fn strip_top_level_string_quotes(formatted: String) -> String {
@@ -2387,32 +2362,39 @@ impl FormatterContext<'_> {
         &self,
         left: &Tuple,
         right: &Tuple,
-        left_ty: &Ty,
-        right_ty: &Ty,
+        left_ty_idx: TyIdx,
+        right_ty_idx: TyIdx,
         source_map: &SourceMap,
     ) -> String {
-        let left_rendered = render_tuple_as_tolk_type(source_map, left, left_ty);
-        let right_rendered = render_tuple_as_tolk_type(source_map, right, right_ty);
+        let left_rendered = self.render_assert_value(left, left_ty_idx, source_map);
+        let right_rendered = self.render_assert_value(right, right_ty_idx, source_map);
+        let left_is_string = Self::is_string_like_ty_idx(source_map, left_ty_idx);
+        let right_is_string = Self::is_string_like_ty_idx(source_map, right_ty_idx);
 
-        if left_ty != right_ty {
+        if left_ty_idx != right_ty_idx {
             return format!(
                 "{} != {}",
-                self.format_rendered_assert_value(&left_rendered, Some(left_ty)),
-                self.format_rendered_assert_value(&right_rendered, Some(right_ty))
+                self.format_rendered_assert_value(&left_rendered, left_is_string),
+                self.format_rendered_assert_value(&right_rendered, right_is_string)
             );
         }
 
-        self.format_rendered_diff(&left_rendered, &right_rendered, Some(left_ty))
+        self.format_rendered_diff(&left_rendered, &right_rendered, left_is_string)
+    }
+
+    fn rendered_values_equal(&self, left: &RenderedValue, right: &RenderedValue) -> bool {
+        self.format_rendered_assert_value(left, false)
+            == self.format_rendered_assert_value(right, false)
     }
 
     fn format_rendered_diff(
         &self,
         left: &RenderedValue,
         right: &RenderedValue,
-        top_level_ty: Option<&Ty>,
+        top_level_is_string: bool,
     ) -> String {
-        if rendered_values_equal(left, right) {
-            return self.format_rendered_assert_value(left, top_level_ty);
+        if self.rendered_values_equal(left, right) {
+            return self.format_rendered_assert_value(left, top_level_is_string);
         }
 
         match (left, right) {
@@ -2458,7 +2440,7 @@ impl FormatterContext<'_> {
             ) if left_variant == right_variant => {
                 self.format_union_case_diff(left, right, left_fields, right_fields)
             }
-            _ => self.format_leaf_diff(left, right, top_level_ty),
+            _ => self.format_leaf_diff(left, right, top_level_is_string),
         }
     }
 
@@ -2473,8 +2455,8 @@ impl FormatterContext<'_> {
         let right_value = union_case_payload(right_fields);
 
         match (left_value, right_value) {
-            (Some(left), Some(right)) => self.format_rendered_diff(left, right, None),
-            _ => self.format_leaf_diff(left, right, None),
+            (Some(left), Some(right)) => self.format_rendered_diff(left, right, false),
+            _ => self.format_leaf_diff(left, right, false),
         }
     }
 
@@ -2511,8 +2493,8 @@ impl FormatterContext<'_> {
                     self.write_equal_struct_field(&mut f, field_name, left, is_last);
                 }
                 (Some(left), Some(right)) if Self::can_diff_inline(left, right) => {
-                    let left_value = self.format_rendered_assert_value(left, None);
-                    let right_value = self.format_rendered_assert_value(right, None);
+                    let left_value = self.format_rendered_assert_value(left, false);
+                    let right_value = self.format_rendered_assert_value(right, false);
                     writeln!(f, "    {field_name}: {}", left_value.red()).ok();
                     write!(
                         f,
@@ -2528,7 +2510,7 @@ impl FormatterContext<'_> {
                     writeln!(f).ok();
                 }
                 (Some(left), Some(right)) => {
-                    let diff = self.format_rendered_diff(left, right, None);
+                    let diff = self.format_rendered_diff(left, right, false);
                     let diff = Self::add_indent_to_lines_except_first(&diff, 4);
                     write!(f, "    {field_name}: {diff}").ok();
                     if !is_last {
@@ -2537,7 +2519,7 @@ impl FormatterContext<'_> {
                     writeln!(f).ok();
                 }
                 (Some(left), None) => {
-                    let value = self.format_rendered_assert_value(left, None);
+                    let value = self.format_rendered_assert_value(left, false);
                     write!(f, "    {field_name}: {}", value.red()).ok();
                     if !is_last {
                         write!(f, "{}", ",".dimmed()).ok();
@@ -2545,7 +2527,7 @@ impl FormatterContext<'_> {
                     writeln!(f).ok();
                 }
                 (None, Some(right)) => {
-                    let value = self.format_rendered_assert_value(right, None);
+                    let value = self.format_rendered_assert_value(right, false);
                     writeln!(f, "    {}:", field_name.yellow()).ok();
                     write!(
                         f,
@@ -2575,7 +2557,7 @@ impl FormatterContext<'_> {
         value: &RenderedValue,
         is_last: bool,
     ) {
-        let value = self.format_rendered_assert_value(value, None);
+        let value = self.format_rendered_assert_value(value, false);
         let value = Self::add_indent_to_lines_except_first(&value, 4);
         write!(
             f,
@@ -2609,7 +2591,7 @@ impl FormatterContext<'_> {
                     self.write_collection_value(
                         &mut result,
                         &self
-                            .format_rendered_assert_value(left, None)
+                            .format_rendered_assert_value(left, false)
                             .dimmed()
                             .to_string(),
                         is_last,
@@ -2619,7 +2601,7 @@ impl FormatterContext<'_> {
                     self.write_collection_value(
                         &mut result,
                         &self
-                            .format_rendered_assert_value(left, None)
+                            .format_rendered_assert_value(left, false)
                             .red()
                             .to_string(),
                         false,
@@ -2627,21 +2609,21 @@ impl FormatterContext<'_> {
                     self.write_collection_value(
                         &mut result,
                         &self
-                            .format_rendered_assert_value(right, None)
+                            .format_rendered_assert_value(right, false)
                             .green()
                             .to_string(),
                         is_last,
                     );
                 }
                 (Some(left), Some(right)) => {
-                    let diff = self.format_rendered_diff(left, right, None);
+                    let diff = self.format_rendered_diff(left, right, false);
                     self.write_collection_value(&mut result, &diff, is_last);
                 }
                 (Some(left), None) => {
                     self.write_collection_value(
                         &mut result,
                         &self
-                            .format_rendered_assert_value(left, None)
+                            .format_rendered_assert_value(left, false)
                             .red()
                             .to_string(),
                         is_last,
@@ -2651,7 +2633,7 @@ impl FormatterContext<'_> {
                     self.write_collection_value(
                         &mut result,
                         &self
-                            .format_rendered_assert_value(right, None)
+                            .format_rendered_assert_value(right, false)
                             .green()
                             .to_string(),
                         is_last,
@@ -2677,20 +2659,20 @@ impl FormatterContext<'_> {
         &self,
         left: &RenderedValue,
         right: &RenderedValue,
-        top_level_ty: Option<&Ty>,
+        top_level_is_string: bool,
     ) -> String {
         let left = Self::add_indent_to_lines_except_first(
-            &self.format_leaf_diff_value(left, top_level_ty),
+            &self.format_leaf_diff_value(left, top_level_is_string),
             4,
         );
         let right = Self::add_indent_to_lines_except_first(
-            &self.format_leaf_diff_value(right, top_level_ty),
+            &self.format_leaf_diff_value(right, top_level_is_string),
             4,
         );
         format!("(\n    {},\n    {}\n)", left.red(), right.green())
     }
 
-    fn format_leaf_diff_value(&self, value: &RenderedValue, top_level_ty: Option<&Ty>) -> String {
+    fn format_leaf_diff_value(&self, value: &RenderedValue, top_level_is_string: bool) -> String {
         if let RenderedValue::UnionCase {
             variant_name,
             fields,
@@ -2704,10 +2686,10 @@ impl FormatterContext<'_> {
             ) = union_case_payload(fields)
             && payload_type == variant_name
         {
-            return self.format_rendered_assert_value(payload, None);
+            return self.format_rendered_assert_value(payload, false);
         }
 
-        self.format_rendered_assert_value(value, top_level_ty)
+        self.format_rendered_assert_value(value, top_level_is_string)
     }
 
     const fn can_diff_inline(left: &RenderedValue, right: &RenderedValue) -> bool {
@@ -3134,8 +3116,8 @@ impl FormatterContext<'_> {
                 let diff = self.format_tuple_diff(
                     &bin_failure.left,
                     &bin_failure.right,
-                    &bin_failure.left_ty,
-                    &bin_failure.right_ty,
+                    bin_failure.left_ty_idx,
+                    bin_failure.right_ty_idx,
                     &bin_failure.source_map,
                 );
                 writeln!(result, "{diff}").ok();
@@ -3143,7 +3125,7 @@ impl FormatterContext<'_> {
             AssertFailure::Bin(bin_failure) if bin_failure.operator == "!=" => {
                 let value = self.format_tuple_value(
                     &bin_failure.left,
-                    &bin_failure.left_ty,
+                    bin_failure.left_ty_idx,
                     &bin_failure.source_map,
                     0,
                 );
@@ -3153,13 +3135,13 @@ impl FormatterContext<'_> {
             AssertFailure::Bin(bin_failure) if bin_failure.is_ord() => {
                 let left = self.format_tuple_value(
                     &bin_failure.left,
-                    &bin_failure.left_ty,
+                    bin_failure.left_ty_idx,
                     &bin_failure.source_map,
                     0,
                 );
                 let right = self.format_tuple_value(
                     &bin_failure.right,
-                    &bin_failure.right_ty,
+                    bin_failure.right_ty_idx,
                     &bin_failure.source_map,
                     0,
                 );

--- a/tests/acton-stdlib/fmt.test.tolk
+++ b/tests/acton-stdlib/fmt.test.tolk
@@ -121,7 +121,6 @@ get fun `test format message`() {
         var loaded = inMsg.value.load();
         loaded.info.createdLt = 0;
         loaded.info.createdAt = 0;
-        // todo "union with unresolved layout" below, to be fixed later (need to reconsider instantated generics, now they do not carry stack layout)
         expect(
             format("{}", loaded),
         ).toEqual("""TlbMessageRelaxedGeneric {
@@ -140,8 +139,8 @@ get fun `test format message`() {
         createdLt: 0,
         createdAt: 0,
     },
-    init: union with unresolved layout,
-    body: null,
+    init: TlbNone,
+    body: slice{4_},
 }""");
     }
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -39,10 +39,10 @@ pub(crate) fn assert_ui() -> snapbox::Assert {
 }
 
 fn add_regex_redactions(subs: &mut snapbox::Redactions) {
-    subs.insert("[TIME]", regex!(r"(\d+\.)?\d+μs")).ok();
-    subs.insert("[TIME]", regex!(r"(\d+\.)?\d+µs")).ok();
-    subs.insert("[TIME]", regex!(r"(\d+\.)?\d+ms")).ok();
-    subs.insert("[TIME]", regex!(r"(\d+\.)?\d+s")).ok();
+    subs.insert("[TIME]", regex!(r"\b(\d+\.)?\d+μs\b")).ok();
+    subs.insert("[TIME]", regex!(r"\b(\d+\.)?\d+µs\b")).ok();
+    subs.insert("[TIME]", regex!(r"\b(\d+\.)?\d+ms\b")).ok();
+    subs.insert("[TIME]", regex!(r"\b(\d+\.)?\d+s\b")).ok();
     subs.insert("[LINE]", regex!(r"(\.tolk):\d+:\d+")).ok();
 }
 

--- a/tests/integration/snapshots/build/build_cmd_output_abi_tests/build_output_abi_cli_flag_overrides_configured_directory.abi.json
+++ b/tests/integration/snapshots/build/build_cmd_output_abi_tests/build_output_abi_cli_flag_overrides_configured_directory.abi.json
@@ -1,5 +1,6 @@
 {
   "abi_schema_version": "1.0",
+  "alias_instantiations": [],
   "compiler_name": "tolk",
   "compiler_version": "1.3.0",
   "contract_name": "Counter",
@@ -7,32 +8,28 @@
     {
       "fields": [
         {
+          "name": "counter",
+          "ty_idx": 8
+        }
+      ],
+      "kind": "struct",
+      "name": "Storage",
+      "ty_idx": 13
+    },
+    {
+      "fields": [
+        {
           "name": "value",
-          "ty": {
-            "kind": "intN",
-            "n": 32
-          }
+          "ty_idx": 8
         }
       ],
       "kind": "struct",
       "name": "Increment",
       "prefix": {
         "prefix_len": 32,
-        "prefix_str": "0x00000001"
-      }
-    },
-    {
-      "fields": [
-        {
-          "name": "counter",
-          "ty": {
-            "kind": "intN",
-            "n": 32
-          }
-        }
-      ],
-      "kind": "struct",
-      "name": "Storage"
+        "prefix_num": 1
+      },
+      "ty_idx": 12
     }
   ],
   "emitted_events": [],
@@ -40,20 +37,63 @@
   "incoming_external": [],
   "incoming_messages": [
     {
-      "body_ty": {
-        "kind": "StructRef",
-        "struct_name": "Increment",
-        "type_args": null
-      }
+      "body_ty_idx": 12
     }
   ],
   "outgoing_messages": [],
   "storage": {
-    "storage_ty": {
-      "kind": "StructRef",
-      "struct_name": "Storage",
-      "type_args": null
-    }
+    "storage_ty_idx": 13
   },
-  "thrown_errors": []
+  "struct_instantiations": [],
+  "thrown_errors": [],
+  "unique_types": [
+    {
+      "kind": "void"
+    },
+    {
+      "kind": "int"
+    },
+    {
+      "kind": "slice"
+    },
+    {
+      "kind": "cell"
+    },
+    {
+      "kind": "builder"
+    },
+    {
+      "kind": "bool"
+    },
+    {
+      "kind": "coins"
+    },
+    {
+      "kind": "address"
+    },
+    {
+      "kind": "intN",
+      "n": 32
+    },
+    {
+      "kind": "uintN",
+      "n": 32
+    },
+    {
+      "kind": "intN",
+      "n": 64
+    },
+    {
+      "kind": "uintN",
+      "n": 64
+    },
+    {
+      "kind": "StructRef",
+      "struct_name": "Increment"
+    },
+    {
+      "kind": "StructRef",
+      "struct_name": "Storage"
+    }
+  ]
 }

--- a/tests/integration/snapshots/build/build_cmd_output_abi_tests/build_writes_contract_abi_to_configured_directory.abi.json
+++ b/tests/integration/snapshots/build/build_cmd_output_abi_tests/build_writes_contract_abi_to_configured_directory.abi.json
@@ -1,5 +1,6 @@
 {
   "abi_schema_version": "1.0",
+  "alias_instantiations": [],
   "compiler_name": "tolk",
   "compiler_version": "1.3.0",
   "contract_name": "Counter",
@@ -7,32 +8,28 @@
     {
       "fields": [
         {
+          "name": "counter",
+          "ty_idx": 8
+        }
+      ],
+      "kind": "struct",
+      "name": "Storage",
+      "ty_idx": 13
+    },
+    {
+      "fields": [
+        {
           "name": "value",
-          "ty": {
-            "kind": "intN",
-            "n": 32
-          }
+          "ty_idx": 8
         }
       ],
       "kind": "struct",
       "name": "Increment",
       "prefix": {
         "prefix_len": 32,
-        "prefix_str": "0x00000001"
-      }
-    },
-    {
-      "fields": [
-        {
-          "name": "counter",
-          "ty": {
-            "kind": "intN",
-            "n": 32
-          }
-        }
-      ],
-      "kind": "struct",
-      "name": "Storage"
+        "prefix_num": 1
+      },
+      "ty_idx": 12
     }
   ],
   "emitted_events": [],
@@ -40,20 +37,63 @@
   "incoming_external": [],
   "incoming_messages": [
     {
-      "body_ty": {
-        "kind": "StructRef",
-        "struct_name": "Increment",
-        "type_args": null
-      }
+      "body_ty_idx": 12
     }
   ],
   "outgoing_messages": [],
   "storage": {
-    "storage_ty": {
-      "kind": "StructRef",
-      "struct_name": "Storage",
-      "type_args": null
-    }
+    "storage_ty_idx": 13
   },
-  "thrown_errors": []
+  "struct_instantiations": [],
+  "thrown_errors": [],
+  "unique_types": [
+    {
+      "kind": "void"
+    },
+    {
+      "kind": "int"
+    },
+    {
+      "kind": "slice"
+    },
+    {
+      "kind": "cell"
+    },
+    {
+      "kind": "builder"
+    },
+    {
+      "kind": "bool"
+    },
+    {
+      "kind": "coins"
+    },
+    {
+      "kind": "address"
+    },
+    {
+      "kind": "intN",
+      "n": 32
+    },
+    {
+      "kind": "uintN",
+      "n": 32
+    },
+    {
+      "kind": "intN",
+      "n": 64
+    },
+    {
+      "kind": "uintN",
+      "n": 64
+    },
+    {
+      "kind": "StructRef",
+      "struct_name": "Increment"
+    },
+    {
+      "kind": "StructRef",
+      "struct_name": "Storage"
+    }
+  ]
 }

--- a/tests/integration/snapshots/build/build_cmd_output_abi_tests/build_writes_contract_abi_to_default_directory.abi.json
+++ b/tests/integration/snapshots/build/build_cmd_output_abi_tests/build_writes_contract_abi_to_default_directory.abi.json
@@ -1,5 +1,6 @@
 {
   "abi_schema_version": "1.0",
+  "alias_instantiations": [],
   "compiler_name": "tolk",
   "compiler_version": "1.3.0",
   "contract_name": "Counter",
@@ -7,32 +8,28 @@
     {
       "fields": [
         {
+          "name": "counter",
+          "ty_idx": 8
+        }
+      ],
+      "kind": "struct",
+      "name": "Storage",
+      "ty_idx": 13
+    },
+    {
+      "fields": [
+        {
           "name": "value",
-          "ty": {
-            "kind": "intN",
-            "n": 32
-          }
+          "ty_idx": 8
         }
       ],
       "kind": "struct",
       "name": "Increment",
       "prefix": {
         "prefix_len": 32,
-        "prefix_str": "0x00000001"
-      }
-    },
-    {
-      "fields": [
-        {
-          "name": "counter",
-          "ty": {
-            "kind": "intN",
-            "n": 32
-          }
-        }
-      ],
-      "kind": "struct",
-      "name": "Storage"
+        "prefix_num": 1
+      },
+      "ty_idx": 12
     }
   ],
   "emitted_events": [],
@@ -40,20 +37,63 @@
   "incoming_external": [],
   "incoming_messages": [
     {
-      "body_ty": {
-        "kind": "StructRef",
-        "struct_name": "Increment",
-        "type_args": null
-      }
+      "body_ty_idx": 12
     }
   ],
   "outgoing_messages": [],
   "storage": {
-    "storage_ty": {
-      "kind": "StructRef",
-      "struct_name": "Storage",
-      "type_args": null
-    }
+    "storage_ty_idx": 13
   },
-  "thrown_errors": []
+  "struct_instantiations": [],
+  "thrown_errors": [],
+  "unique_types": [
+    {
+      "kind": "void"
+    },
+    {
+      "kind": "int"
+    },
+    {
+      "kind": "slice"
+    },
+    {
+      "kind": "cell"
+    },
+    {
+      "kind": "builder"
+    },
+    {
+      "kind": "bool"
+    },
+    {
+      "kind": "coins"
+    },
+    {
+      "kind": "address"
+    },
+    {
+      "kind": "intN",
+      "n": 32
+    },
+    {
+      "kind": "uintN",
+      "n": 32
+    },
+    {
+      "kind": "intN",
+      "n": 64
+    },
+    {
+      "kind": "uintN",
+      "n": 64
+    },
+    {
+      "kind": "StructRef",
+      "struct_name": "Increment"
+    },
+    {
+      "kind": "StructRef",
+      "struct_name": "Storage"
+    }
+  ]
 }

--- a/tests/integration/snapshots/test-runner/cmd_agent_h/save_test_trace_without_path_uses_default_directory.contract.txt
+++ b/tests/integration/snapshots/test-runner/cmd_agent_h/save_test_trace_without_path_uses_default_directory.contract.txt
@@ -1,6 +1,7 @@
 {
   "abi": {
     "abi_schema_version": "1.0",
+    "alias_instantiations": [],
     "compiler_name": "tolk",
     "compiler_version": "1.3.0",
     "contract_name": "",
@@ -11,11 +12,55 @@
     "incoming_messages": [],
     "outgoing_messages": [],
     "storage": {},
-    "thrown_errors": []
+    "struct_instantiations": [],
+    "thrown_errors": [],
+    "unique_types": [
+      {
+        "kind": "void"
+      },
+      {
+        "kind": "int"
+      },
+      {
+        "kind": "slice"
+      },
+      {
+        "kind": "cell"
+      },
+      {
+        "kind": "builder"
+      },
+      {
+        "kind": "bool"
+      },
+      {
+        "kind": "coins"
+      },
+      {
+        "kind": "address"
+      },
+      {
+        "kind": "intN",
+        "n": 32
+      },
+      {
+        "kind": "uintN",
+        "n": 32
+      },
+      {
+        "kind": "intN",
+        "n": 64
+      },
+      {
+        "kind": "uintN",
+        "n": 64
+      }
+    ]
   },
   "code_boc64": "te6ccgEBAgEAFAABFP8A9KQT9LzyyAsBAArTMPiR3A==",
   "name": "simple",
   "source_map": {
+    "alias_instantiations": [],
     "debug_marks": [],
     "declarations": [],
     "files": [
@@ -67,82 +112,47 @@
         "return_ty_idx": 0
       }
     ],
-    "unique_ty": [
+    "struct_instantiations": [],
+    "unique_types": [
       {
-        "ty": {
-          "kind": "void"
-        },
-        "ty_idx": 0
+        "kind": "void"
       },
       {
-        "ty": {
-          "kind": "int"
-        },
-        "ty_idx": 1
+        "kind": "int"
       },
       {
-        "ty": {
-          "kind": "slice"
-        },
-        "ty_idx": 2
+        "kind": "slice"
       },
       {
-        "ty": {
-          "kind": "cell"
-        },
-        "ty_idx": 3
+        "kind": "cell"
       },
       {
-        "ty": {
-          "kind": "builder"
-        },
-        "ty_idx": 4
+        "kind": "builder"
       },
       {
-        "ty": {
-          "kind": "bool"
-        },
-        "ty_idx": 5
+        "kind": "bool"
       },
       {
-        "ty": {
-          "kind": "coins"
-        },
-        "ty_idx": 6
+        "kind": "coins"
       },
       {
-        "ty": {
-          "kind": "address"
-        },
-        "ty_idx": 7
+        "kind": "address"
       },
       {
-        "ty": {
-          "kind": "intN",
-          "n": 32
-        },
-        "ty_idx": 8
+        "kind": "intN",
+        "n": 32
       },
       {
-        "ty": {
-          "kind": "uintN",
-          "n": 32
-        },
-        "ty_idx": 9
+        "kind": "uintN",
+        "n": 32
       },
       {
-        "ty": {
-          "kind": "intN",
-          "n": 64
-        },
-        "ty_idx": 10
+        "kind": "intN",
+        "n": 64
       },
       {
-        "ty": {
-          "kind": "uintN",
-          "n": 64
-        },
-        "ty_idx": 11
+        "kind": "uintN",
+        "n": 64
       }
     ]
   }

--- a/tests/integration/snapshots/test-runner/crypto_sign_is_hash_sensitive_for_different_cells_in_fixture_project/crypto_raw_sign_positive_and_negative_hash_values_do_not_collapse.stdout.txt
+++ b/tests/integration/snapshots/test-runner/crypto_sign_is_hash_sensitive_for_different_cells_in_fixture_project/crypto_raw_sign_positive_and_negative_hash_values_do_not_collapse.stdout.txt
@@ -17,7 +17,7 @@ See [ACTON_DOCS_URL]/building/reference/#contracts-section for more information
   ✗ ba-stdlib-raw-sign-positive-negative-hash-values [TIME]
     └─ Error: expect(actual).toNotEqual(expected)
        Values are equal but expected to be different:
-         [BOC_HEX]
+         slice{[HEX]}
       └─ at tests/crypto_signing_edges.test[LINE]
 
  ✗ 1 failed in 1 file

--- a/tests/integration/snapshots/test-runner/crypto_sign_is_hash_sensitive_for_different_cells_in_fixture_project/crypto_raw_sign_positive_and_negative_private_keys_do_not_collapse.stdout.txt
+++ b/tests/integration/snapshots/test-runner/crypto_sign_is_hash_sensitive_for_different_cells_in_fixture_project/crypto_raw_sign_positive_and_negative_private_keys_do_not_collapse.stdout.txt
@@ -17,7 +17,7 @@ See [ACTON_DOCS_URL]/building/reference/#contracts-section for more information
   ✗ ba-stdlib-raw-sign-positive-negative-private-keys [TIME]
     └─ Error: expect(actual).toNotEqual(expected)
        Values are equal but expected to be different:
-         [BOC_HEX]
+         slice{[HEX]}
       └─ at tests/crypto_signing_edges.test[LINE]
 
  ✗ 1 failed in 1 file

--- a/tests/integration/snapshots/test-runner/env_slice_returns_raw_and_empty_values_and_null_when_missing/env_slice_to_equal_string_reports_typed_mismatch.stdout.txt
+++ b/tests/integration/snapshots/test-runner/env_slice_returns_raw_and_empty_values_and_null_when_missing/env_slice_to_equal_string_reports_typed_mismatch.stdout.txt
@@ -16,7 +16,7 @@ See [ACTON_DOCS_URL]/building/reference/#contracts-section for more information
  > tests/env_slice_string_mismatch.test.tolk (1 test)
   ✗ bp stdlib env slice string typed mismatch [TIME]
     └─ Error: expect(actual).toEqual(expected)
-        [BOC_HEX] != slice-value
+        slice{736c6963652d76616c7565} != slice-value
       └─ at tests/env_slice_string_mismatch.test[LINE]
 
  ✗ 1 failed in 1 file

--- a/tests/integration/snapshots/test-runner/reporters/dot/test_dot_runtime_failure_details.stdout.txt
+++ b/tests/integration/snapshots/test-runner/reporters/dot/test_dot_runtime_failure_details.stdout.txt
@@ -6,7 +6,7 @@
      Running tests
 xx
 
-✗ test dot gas limit exceeded: Gas limit exceeded: used 122166, limit 100
+✗ test dot gas limit exceeded: Gas limit exceeded: used 122056, limit 100
 
 ✗ test dot wrong expected [EXIT_STATUS]: Expected exit_code=42, got=99
   exit_code=99

--- a/tests/integration/snapshots/test_basic_fixture_with_gas_limit.stdout.txt
+++ b/tests/integration/snapshots/test_basic_fixture_with_gas_limit.stdout.txt
@@ -9,7 +9,7 @@
 
  > tests/counter.test.tolk (2 tests)
   ✗ should increase counter [TIME]
-    └─ Gas limit exceeded: used 129265, limit 100
+    └─ Gas limit exceeded: used 129247, limit 100
   ✓ should reset counter [TIME]
 
  ✓ 1 passed, ✗ 1 failed in 1 file

--- a/tests/integration/snapshots/test_println_various_slices.stdout.svg
+++ b/tests/integration/snapshots/test_println_various_slices.stdout.svg
@@ -23,9 +23,9 @@
 </tspan>
     <tspan x="10px" y="46px"><tspan>hello world</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan>(</tspan><tspan class="dimmed">[BOC_HEX]</tspan><tspan>, </tspan><tspan class="dimmed">[BOC_HEX]</tspan><tspan>)</tspan>
+    <tspan x="10px" y="64px"><tspan>(</tspan><tspan class="dimmed">slice{abcdef}</tspan><tspan>, </tspan><tspan class="dimmed">slice{abcdef}</tspan><tspan>)</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan>(</tspan><tspan class="fg-green">"empty"</tspan><tspan>, </tspan><tspan class="dimmed">[BOC_HEX]</tspan><tspan>)</tspan>
+    <tspan x="10px" y="82px"><tspan>(</tspan><tspan class="fg-green">"empty"</tspan><tspan>, </tspan><tspan class="dimmed">slice{}</tspan><tspan>)</tspan>
 </tspan>
     <tspan x="10px" y="100px">
 </tspan>

--- a/tests/integration/snapshots/test_verify_backend_proof_already_deployed_returns_success.stdout.txt
+++ b/tests/integration/snapshots/test_verify_backend_proof_already_deployed_returns_success.stdout.txt
@@ -11,6 +11,6 @@
   → Sending sources to backend for verification
   → Using backend: [LOCALHOST_URL]/source
 
-  Warning: Contract with the hash 5n[TIME]O9SBx5EMh6Bh5gylCegu3Wh6DhyL8bQ35t4+aXM= has already been verified previously, no further action is required
+  Warning: Contract with the hash 5n7sO9SBx5EMh6Bh5gylCegu3Wh6DhyL8bQ35t4+aXM= has already been verified previously, no further action is required
 
 View at: https://verifier.ton.org/[WALLET_ADDRESS_BASE]

--- a/tests/integration/snapshots/test_verify_backend_proof_already_deployed_returns_success_on_testnet.stdout.txt
+++ b/tests/integration/snapshots/test_verify_backend_proof_already_deployed_returns_success_on_testnet.stdout.txt
@@ -11,6 +11,6 @@
   → Sending sources to backend for verification
   → Using backend: [LOCALHOST_URL]/source
 
-  Warning: Contract with the hash 5n[TIME]O9SBx5EMh6Bh5gylCegu3Wh6DhyL8bQ35t4+aXM= has already been verified previously, no further action is required
+  Warning: Contract with the hash 5n7sO9SBx5EMh6Bh5gylCegu3Wh6DhyL8bQ35t4+aXM= has already been verified previously, no further action is required
 
 View at: https://verifier.ton.org/[WALLET_ADDRESS_BASE]?testnet

--- a/tests/integration/snapshots/test_verify_backend_retries_then_proof_already_deployed_returns_success.stdout.txt
+++ b/tests/integration/snapshots/test_verify_backend_retries_then_proof_already_deployed_returns_success.stdout.txt
@@ -12,6 +12,6 @@
   → Using backend: [LOCALHOST_URL]/source
   ↻ Backend returned 500 Internal Server Error (HTTP/1.1, cf-ray=retry-please) on attempt 1/8, retrying...
 
-  Warning: Contract with the hash 5n[TIME]O9SBx5EMh6Bh5gylCegu3Wh6DhyL8bQ35t4+aXM= has already been verified previously, no further action is required
+  Warning: Contract with the hash 5n7sO9SBx5EMh6Bh5gylCegu3Wh6DhyL8bQ35t4+aXM= has already been verified previously, no further action is required
 
 View at: https://verifier.ton.org/[WALLET_ADDRESS_BASE]

--- a/tests/integration/wrapper_tests.rs
+++ b/tests/integration/wrapper_tests.rs
@@ -210,7 +210,7 @@ fn test_wrapper_generation_typescript_defaults_to_wrapper_ts_dir() {
     assert_eq!(abi_json["contract_name"], "MyContract");
     assert_eq!(abi_json["compiler_name"], "tolk");
     assert!(
-        abi_json["codeBoc64"]
+        abi_json["code_boc64"]
             .as_str()
             .is_some_and(|value| !value.is_empty())
     );

--- a/tests/support/snapshots.rs
+++ b/tests/support/snapshots.rs
@@ -58,7 +58,15 @@ fn normalize_output_internal(
 }
 
 fn normalize_dynamic_output(content: String) -> String {
-    normalize_dynamic_mutation_output(normalize_up_snapshot_text(content))
+    normalize_dynamic_slice_output(normalize_dynamic_mutation_output(
+        normalize_up_snapshot_text(content),
+    ))
+}
+
+fn normalize_dynamic_slice_output(content: String) -> String {
+    regex!(r"slice\{[0-9a-fA-F]{64,}_?\}")
+        .replace_all(&content, "slice{[HEX]}")
+        .into_owned()
 }
 
 fn normalize_dynamic_mutation_output(content: String) -> String {


### PR DESCRIPTION
Both ABI and symbol-types now contain:
- `unique_types` (array)
- `struct_instantiations`
- `alias_instantiations`
- `declarations`

All types reference unique_types table via ty_idx. Instead of `ty` / `param_ty` / `return_ty` / etc. we have `ty_idx` / `param_ty_idx` / `return_ty_idx` / etc. referencing a global table. Struct `Ty` became not a tree: it does not contain child `Ty` anymore, it only contains indices. Even `reflect.typeAbiJson` does not exist now in stdlib — instead, `reflect.typeUniqueIdx` added. So, all types became indexing-first. 

That's because we need to maintain monomorphic instantiations, that were completely absent in previous ABI versions. Earlier, client-side (TS and Rust) had no chance to instantiate complicated generics: stack layout info was not reconstructive. Now, the compiler provides all ever-instantiated generics with their stack layout, so even complicated structures with unions inside generics are rendered correctly. A TypeScript generator is also able to read/write them from a stack (in get methods).
