### PR TITLE
chore(docs): apply style guide edits to `testing/`

### DIFF
--- a/docs/content/docs/testing/built-in-matchers-and-helpers.mdx
+++ b/docs/content/docs/testing/built-in-matchers-and-helpers.mdx
@@ -1,13 +1,13 @@
 ---
-title: "Built-in Matchers and Helpers"
+title: "Built-in matchers and helpers"
 description: "Reference map for transaction predicates, map expectations, and out-action helpers in Acton tests"
 ---
 
 Before writing custom matchers, check the built-in ones first. Acton already ships a useful set of helpers for transaction search, map assertions, and out-action inspection.
 
-## Transaction Search Matchers
+## Transaction search matchers
 
-Use these when you want to find or assert on transactions produced by `net.send(...)`:
+Use these functions to find or assert on transactions from `net.send(...)`:
 
 - `findTransaction()`
 - `toHaveSuccessfulDeploy()`
@@ -33,7 +33,7 @@ expect(res).toHaveTx({
 Important matcher semantics:
 
 - `SearchParams` fields accept either exact values or predicate functions.
-- `toHaveSuccessfulTx()` forces `success = true` and defaults `exitCode = 0` unless you override it explicitly.
+- `toHaveSuccessfulTx()` forces `success = true` and defaults `exitCode = 0` unless overridden explicitly.
 - `toHaveFailedTx()` requires a non-zero `exitCode`.
 - Bounced-message opcode matching should be done with `toHaveBouncedTx()` or an explicit `bounced: true` filter.
 - Predicate functions can be useful for custom diagnostics, but runtime errors inside those predicates surface back to the test output.
@@ -44,7 +44,7 @@ Go deeper in:
 - [Transaction matchers](/docs/standard_library/emulation/network#expectationsendresultlisttohavesuccessfultx)
 - [Reading Transaction Chains](/docs/testing/reading-transaction-chains)
 
-## Map Expectations
+## Map expectations
 
 Map helpers are useful for get-method results and in-memory fixtures:
 
@@ -77,9 +77,9 @@ Go deeper in:
 
 - [Map expectations](/docs/standard_library/testing/expect#expectationmapk-vtocontainkey)
 
-## Out-action Helpers
+## Out-action helpers
 
-Use out-action helpers when you need to inspect C5 output, planned sends, or action kinds:
+Use action helpers to inspect C5 output, planned sends, or action kinds:
 
 ```tolk
 val outActions = testing.outActions();
@@ -113,8 +113,6 @@ Go deeper in:
 - [SendResult.allOutActions()](/docs/standard_library/emulation/network#sendresultalloutactions)
 - [out_actions helpers](/docs/standard_library/types/out_actions)
 
-## When To Write Custom Matchers
+## When to write custom matchers
 
-If the built-in helpers still do not match your domain language, extend `Expectation<T>` with a custom matcher.
-
-See [Custom Matchers](/docs/testing/writing-your-own-matchers).
+If the built-in helpers still do not match a domain-specific vocabulary, extend `Expectation<T>` with a [custom matcher](/docs/testing/writing-your-own-matchers).

--- a/docs/content/docs/testing/code-coverage.mdx
+++ b/docs/content/docs/testing/code-coverage.mdx
@@ -1,41 +1,33 @@
 ---
-title: "Code Coverage"
+title: "Code coverage"
 description: "Learn how to measure and analyze code coverage in your Tolk smart contract tests"
 ---
 
-Code coverage is a metric that measures how much of your code is executed during testing. It helps you identify untested parts of your codebase and ensure comprehensive test suites. Acton's test runner provides built-in code coverage support with detailed reporting, LCOV export, and a browser UI coverage view.
+Code coverage is a metric that reports how much contract source is executed during tests. It helps identify untested parts of the codebase.
 
-## What is Code Coverage?
-
-Code coverage measures the percentage of your code that is executed when running tests. It helps answer questions like:
-
-- Which parts of my code are tested?
-- Are there dead code paths?
-- How thorough are my tests?
-- Where should I add more tests?
-
-Acton's test runner reports:
+Acton's test runner reports line, branch, and blended score metrics:
 
 - **Line coverage**: executable source lines that were hit during test runs
 - **Branch coverage**: observed branch outcomes that were hit at runtime
 - **Score**: a blended metric that combines both numbers for quick comparison
 
-## Enabling Coverage
+Additionally, it can export coverage data in the [LCOV format](https://en.wikipedia.org/wiki/Gcov#Coverage_summaries) and present the Test UI coverage view in the browser.
 
-### Command Line Flag
+## Enable coverage
 
-To enable coverage collection, use the `--coverage` flag:
+### Command-line flag
+
+Run tests with `--coverage`:
 
 ```bash
 acton test --coverage
 ```
 
-This will run all tests and collect coverage data, then display a summary report.
+That collects coverage for the selected tests and prints a summary table afterward.
 
-### Coverage in Test UI
+### Coverage in the Test UI
 
-To inspect coverage in the browser UI, run tests with both `--coverage` and
-`--ui`:
+Run tests with `--coverage` and `--ui` together:
 
 ```bash
 acton test --coverage --ui
@@ -47,12 +39,11 @@ When both flags are enabled, Test UI shows a `Coverage` tab with:
 - sortable file list
 - per-file source view with annotated lines
 
-You do not need to pass `--coverage-format lcov` for the browser view. The UI
-receives coverage data automatically for the current run.
+The browser view does not require `--coverage-format lcov`; the UI receives coverage for the current run automatically.
 
-### Coverage for Specific Tests
+### Coverage with filters
 
-You can combine coverage with other flags:
+Combine `--coverage` with file paths or `--filter` as usual:
 
 ```bash
 # Run specific test file with coverage
@@ -67,16 +58,16 @@ By default, Acton excludes:
 - `.test.tolk` files
 - files under the `@wrappers` mapping
 
-Use these flags when you want them in the report:
+Pass these flags to include those sources in the report:
 
 ```bash
 acton test --coverage --coverage-include-tests
 acton test --coverage --coverage-include-wrappers
 ```
 
-## Understanding Coverage Reports
+## Read coverage reports
 
-When you enable coverage, you'll see a detailed report after test execution:
+With `--coverage`, Acton prints a table after the run:
 
 ```
 ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────
@@ -86,7 +77,7 @@ When you enable coverage, you'll see a detailed report after test execution:
  code/math.tolk               4             4    100.0%                  2                2       100.0%   100.0%
 ```
 
-### Coverage Metrics Explained
+### Coverage columns
 
 - **Covered Lines**: Number of lines that were executed during testing
 - **Total Lines**: Total number of executable lines in the file
@@ -96,7 +87,7 @@ When you enable coverage, you'll see a detailed report after test execution:
 - **% Branches**: Percentage of observed branch outcomes that were hit
 - **Score**: Blended metric used for sorting and quick comparison across files
 
-### Text Report Annotations
+### Text report annotations
 
 The text artifact is line-summary-first, but branch detail still appears inline on executable lines:
 
@@ -110,34 +101,33 @@ When multiple branch sites map to the same source line, Acton keeps them separat
 31 ✓ | return foo != null ? foo : 100; | hits:1 branches:site0 true=0 false=1; site1 true=1 false=0
 ```
 
-## Exporting Coverage Data
+## Export coverage data
 
-### LCOV Format
+### LCOV format
 
-Acton's test runner can export coverage data to LCOV format, which is compatible with many coverage visualization tools like:
+Acton can write LCOV for external tools such as:
 
 - VS Code Coverage Gutters
 - IntelliJ IDEA Coverage
-- lcov tools and report generators
+- LCOV tools and report generators
 
-To generate an LCOV file:
+To emit `lcov.info` in the project root:
 
 ```bash
 acton test --coverage --coverage-format lcov
 ```
 
-This creates a `lcov.info` file in your project root.
+That writes `lcov.info` in the project root.
 
-If you want both browser inspection and an exported LCOV artifact, combine all
-three flags:
+For both the browser view and an LCOV artifact on disk, pass all three flags:
 
 ```bash
 acton test --coverage --ui --coverage-format lcov
 ```
 
-### Using LCOV with External Tools
+### LCOV with other tools
 
-Once you have the `lcov.info` file, you can use various tools:
+After `lcov.info` exists, typical follow-ups include:
 
 ```bash
 # Generate HTML report
@@ -149,20 +139,20 @@ genhtml lcov.info -o coverage-report/
 # Use with other CI/CD tools that support LCOV
 ```
 
-## Best Practices
+## Guidelines
 
-### 1. Aim for High Coverage
+### 1. Set realistic coverage targets
 
-- Target ≥80% line coverage for critical business logic, but don't obsess over 100% coverage
-- Focus on thorough testing of complex functions
+- Aim for high, ≥80% line coverage on critical paths; 100% is rarely worth the cost.
+- Spend effort on complex branches and error paths.
 
-### 2. Understand Coverage Limitations
+### 2. Treat coverage as a signal, not proof
 
-- Coverage doesn't measure test quality
-- 100% coverage doesn't guarantee bug-free code
-- Focus on testing edge cases and error conditions (see [mutation testing](/docs/testing/mutation-testing/overview))
+- Coverage does not measure assertion quality.
+- Full line coverage does not imply absence of bugs.
+- Pair coverage with edge-case tests and, when needed, [mutation testing](/docs/testing/mutation-testing/overview).
 
-## Interpretation Caveats
+## Interpretation caveats
 
 - Executable lines come from source-map debug locations, not from every physical line in the file.
 - The text coverage artifact summarizes only line totals at the top. Branch detail appears inline on annotated executable lines.
@@ -170,19 +160,16 @@ genhtml lcov.info -o coverage-report/
 - Branch totals are runtime-observed, not a full static control-flow denominator for untouched code.
 - `--coverage-minimum-percent` is ignored with `--ui`.
 
-## Troubleshooting
+## Performance
 
-### Performance Considerations
-
-- Coverage collection adds overhead to test execution
-- For large test suites, consider running coverage less frequently
-- Use `--coverage-format lcov` to collect data once and analyze offline
+- Coverage adds execution overhead.
+- For large test suites, run coverage selectively or export LCOV once with `--coverage-format lcov` and inspect offline.
 
 ## Summary
 
-Code coverage helps you:
+Coverage helps with:
 
-1. Measure Test Effectiveness: See which parts of your code are tested
-2. Identify Gaps: Find untested code paths and edge cases
-3. Guide Development: Focus testing efforts where they're most needed
-4. Maintain Quality: Ensure new code doesn't reduce coverage
+1. Measuring reachability: see which code line are tested;
+2. Spotting gaps: find untouched paths or branches;
+3. Prioritizing tests: focus on low-coverage hot spots;
+4. Maintaining itself: ensure new code does not reduce the coverage.

--- a/docs/content/docs/testing/cookbook.mdx
+++ b/docs/content/docs/testing/cookbook.mdx
@@ -30,8 +30,7 @@ get fun `test mint`() {
 }
 ```
 
-See [Reading Transaction Chains](/docs/testing/reading-transaction-chains)
-for the exact text format and a guide to interpreting it.
+See the [reading transaction chains](/docs/testing/reading-transaction-chains) page for the exact text format and a guide to interpreting it.
 
 ## Calling get method
 
@@ -95,7 +94,7 @@ get fun `test mint`() {
 ```
 
 <Callout type="info">
-You can also specify the message type in some of the methods described below.
+  Some matchers accept an explicit message type parameter as well.
 </Callout>
 
 ## Asserting transaction in the result

--- a/docs/content/docs/testing/fork-testing.mdx
+++ b/docs/content/docs/testing/fork-testing.mdx
@@ -1,29 +1,32 @@
 ---
-title: "Fork Testing"
-description: "Learn how to test contracts against real blockchain state by forking testnet or mainnet"
+title: "Fork testing"
+description: "Learn how to test contracts against blockchain state by forking testnet or mainnet"
 ---
 
-Fork testing allows you to run tests against real blockchain state by loading accounts and libraries from TON's testnet or mainnet. This enables testing contract interactions with real deployed contracts without needing to set up a complex local environment.
+Fork testing runs tests against blockchain state by loading accounts and libraries from TON testnet or TON mainnet. Use it to test contract interactions with deployed contracts without a need in complex local environment setups.
 
-## What is Fork Testing?
+## What fork testing is
 
-Fork testing creates a local "fork" of the real blockchain state for your tests. When your test code accesses an account that exists on testnet or mainnet, the test runner automatically:
+Fork testing keeps a local view (fork) of remote chain state. When test code reads an account that exists on testnet or mainnet while fork mode is on, the runner:
 
 1. Fetches the account's state from the network
 2. Caches it locally for the test run
-3. Uses that real state in your test execution
+3. Uses that remote state inside local execution
 
-This is particularly useful for:
+Fork testing is useful for:
+
 - Testing integrations with existing contracts
 - Verifying behavior against real contract code
 - Debugging issues with deployed contracts
 - Testing edge cases with real on-chain data
 
-## Enabling Fork Testing
+It combines real on-chain data with local test execution speed.
 
-### Basic Usage
+## Enable fork testing
 
-To enable fork testing, use the `--fork-net` flag when running tests:
+### Basic usage
+
+Pass `--fork-net` when running tests:
 
 ```bash
 # Fork from testnet
@@ -33,69 +36,53 @@ acton test --fork-net testnet
 acton test --fork-net mainnet
 ```
 
-### Configuring API Access
+### Configure API access
 
-Access to TonCenter API requires an API key to avoid rate limiting. Set the env
-var that matches the forked network:
+Remote state is fetched through the TON Center APIs. Obtain the API key in the [Telegram bot](https://t.me/toncenter) to access higher RPS limits.
+
+Set `TONCENTER_MAINNET_API_KEY` or `TONCENTER_TESTNET_API_KEY` environment variables in the `.env` file or export them on the shell:
 
 ```bash
+# Key for and fork of the testnet
 TONCENTER_TESTNET_API_KEY=YOUR_API_KEY acton test --fork-net testnet
+
+# Key for and fork of the mainnet
 TONCENTER_MAINNET_API_KEY=YOUR_API_KEY acton test --fork-net mainnet
 ```
 
-<Callout type="info" title="Getting an API Key">
-You can obtain a free TonCenter API key from [toncenter.com](https://toncenter.com).
+## Execution model
+
+When fork testing is enabled and a test touches an account:
+
+1. The system first checks if the account was already loaded in the local cache.
+2. If not cached and `--fork-net` is specified, it queries TON Center API.
+3. Account state, i.e., balance, code, data, status, is downloaded and deserialized.
+4. The state is cached for subsequent accesses during the test run.
+5. Tests execute using this real state in the local emulator.
+
+<Callout type="warn" title="Network latency">
+    The first fetch of each distinct account hits the network and adds latency. Subsequent fetches reuse the cache. Plan accordingly when many distinct accounts appear in one run.
 </Callout>
 
-## How Fork Testing Works
+## Cache scope and refresh behavior
 
-When a test accesses an account while fork testing is enabled:
+Forked account snapshots are cached only in memory for the current `acton test` invocation:
 
-1. **Check Local Cache** — The system first checks if the account was already loaded
-2. **Fetch from Network** — If not cached and `--fork-net` is specified, it queries TonCenter API
-3. **Load State** — Account state (balance, code, data, status) is downloaded and deserialized
-4. **Cache for Reuse** — The state is cached for subsequent accesses during the test run
-5. **Execute Locally** — Tests execute using this real state in the local emulator
+- The cache key is the tuple of fork network, optional pinned block number, and account address.
+- The cache is shared across tests in the same run, so the second test that touches the same account does not re-fetch it.
+- The cache is not persisted to disk. A fresh `acton test --fork-net ...` run starts with an empty remote snapshot cache.
+- Failed lookups are not cached. If a request errors, the next access can try the network again.
 
-This hybrid approach gives you real data with local execution speed.
+To refetch remote snapshots, rerun `acton test --fork-net ...`. Local emulator mutations do not invalidate or re-download the cached remote snapshot.
 
-<Callout type="warn" title="Network Latency">
-The first access to each unique account will make a network request, which adds latency. Subsequent accesses use the cache. Consider this when writing tests that access many different accounts.
-</Callout>
+Accounts deployed or changed during the test are not replaced by remote snapshots. Fork testing only loads accounts that are not already present in the local emulated environment.
 
-## Cache Scope and Refresh Behavior
+That precedence also applies after an account is fetched once. Once the account exists in the emulated blockchain state, later reads and message execution use the local copy from that blockchain state rather than querying the network again.
 
-Forked account snapshots are cached only in memory for the current `acton test`
-invocation.
-
-- The cache key is the tuple of fork network, optional pinned block number, and
-  account address.
-- The cache is shared across tests in the same run, so the second test that
-  touches the same account does not re-fetch it.
-- The cache is not persisted to disk. A fresh `acton test --fork-net ...` run
-  starts with an empty remote snapshot cache.
-- Failed lookups are not cached. If a request errors, the next access can try
-  the network again.
-
-If you need to refetch network state, rerun the test command. Mutations made by
-the local emulator do not invalidate and re-download the remote snapshot.
-
-<Callout type="info" title="Local State Priority">
-Accounts that were deployed or modified within your test will **not** be overwritten by network state. Fork testing only loads accounts that don't exist in the local test environment.
-</Callout>
-
-That precedence also applies after an account is fetched once. Once the account
-exists in the emulated world state, later reads and message execution use the
-local copy from that world state rather than querying the network again.
-
-## Library Lookup Precedence
+## Library lookup precedence
 
 Library lookup follows the same "local first" rule.
 
-When code asks to resolve a library hash, Acton first checks libraries already
-registered in the current emulated world state, for example via
-`testing.registerLibrary(...)`. Only if the library is still missing does it
-fall back to the configured fork network.
+When code asks to resolve a library hash, Acton first checks libraries already registered in the current emulated blockchain state, for example via `testing.registerLibrary(...)`. Only if the library is still missing does it fall back to the configured fork network.
 
-This matters when you intentionally override a real network library during a
-forked test: the locally registered library wins for the rest of that run.
+That ordering matters when a forked test registers a different library cell than the remote network would supply: the locally registered library overrides its remote counterpart for the rest of the run.

--- a/docs/content/docs/testing/fuzz-testing.mdx
+++ b/docs/content/docs/testing/fuzz-testing.mdx
@@ -1,21 +1,15 @@
 ---
-title: "Fuzz Testing"
+title: "Fuzz testing"
 description: "Run parameterized tests with generated inputs, assumptions, and bounds"
 ---
 
-Fuzz testing means running the same parameterized test many times with
-automatically generated argument values.
+Fuzz testing means running the same parameterized test many times with automatically generated argument values.
 
-In Acton, a fuzz test is just a test function with parameters, for example
-`(value: int, flag: bool)`. The runner generates different values for those
-parameters and re-runs the test until all configured runs pass or one run
-fails.
+In Acton, a fuzz test is just a test function with parameters, for example `(value: int, flag: bool)`. The runner generates different values for those parameters and re-runs the test until all configured runs pass or one run fails.
 
-Acton does not fuzz parameterized tests unless you mark them with one of the
-supported dotted annotations: `@test.fuzz`, `@test.fuzz(<runs>)`, or
-`@test.fuzz({ ... })`.
+Acton does not fuzz parameterized tests unless they carry one of the supported dotted annotations: `@test.fuzz`, `@test.fuzz(<runs>)`, or `@test.fuzz({ ... })`.
 
-## What Happens During a Fuzz Test
+## What happens during a fuzz test
 
 For each fuzz test, Acton:
 
@@ -24,10 +18,9 @@ For each fuzz test, Acton:
 3. runs the test with those values
 4. repeats the process until it reaches the configured run count or finds a failure
 
-If one generated case fails, the fuzz test stops and Acton reports that failing
-input.
+If one generated case fails, the fuzz test stops and Acton reports that failing input.
 
-## Opt In Per Test
+## Opt in per test
 
 Use `@test.fuzz` to enable fuzzing with defaults,
 `@test.fuzz(<runs>)` to override the number of runs for a single test,
@@ -65,7 +58,7 @@ Rules:
 - Legacy `@test({ fuzz: ... })` is ignored by the runner.
 - `runs` means how many generated cases Acton should execute for that test.
 
-## Supported Parameter Types
+## Supported parameter types
 
 Acton currently fuzzes these parameter types:
 
@@ -77,15 +70,13 @@ Acton currently fuzzes these parameter types:
 
 Types such as `bits`, `bytes`, `cell`, structs, containers, and tuple-like values are not supported yet.
 
-## Assumptions and Bounds
+## Assumptions and bounds
 
 Import `@acton/testing/fuzz` to access fuzz-specific helpers.
 
-Use `fuzz.assume(...)` when the property you want to test only applies to part
-of the generated input space.
+Use `fuzz.assume(...)` when the property under test applies only to part of the generated input space.
 
-If the condition is false, the current generated case is discarded and Acton
-tries another one. That rejected case does not count toward `runs`.
+If the condition is false, the current generated case is discarded and Acton tries another one. That rejected case does not count toward `runs`.
 
 Outside fuzz tests, the same call fails the test.
 
@@ -100,9 +91,7 @@ get fun `test only positive values`(value: int) {
 }
 ```
 
-`fuzz.bound(...)` maps integer-like values into an inclusive range with wrap
-behavior. This is useful when your test accepts only a smaller range than the
-full range of the generated type.
+`fuzz.bound(...)` maps integer-like values into an inclusive range with wrap-around. Use it when the test accepts a smaller range than the generated type allows.
 
 ```tolk
 import "@acton/testing/expect"
@@ -118,7 +107,7 @@ get fun `test transfer amounts`(rawAmount: int, rawRecipient: address?) {
 }
 ```
 
-## Configure Defaults
+## Configure defaults
 
 Store project-wide defaults in `Acton.toml`:
 
@@ -139,7 +128,7 @@ seed = 42
 - When `seed` is omitted, Acton picks a new seed for each `acton test` run and shows it in console output.
 - When `max-test-rejects` is omitted, Acton uses `runs * 256`.
 
-## Failure Reporting
+## Failure reporting
 
 Acton stops at the first failing generated case and reports:
 
@@ -148,5 +137,4 @@ Acton stops at the first failing generated case and reports:
 - the first failing run number
 - the generated input values for that failing case
 
-When too many inputs are rejected by `fuzz.assume(...)`, Acton fails the test
-with an error saying that the rejection limit was reached.
+When too many inputs are rejected by `fuzz.assume(...)`, Acton fails the test with an error saying that the rejection limit was reached.

--- a/docs/content/docs/testing/gas-profiling-with-snapshots.mdx
+++ b/docs/content/docs/testing/gas-profiling-with-snapshots.mdx
@@ -1,35 +1,29 @@
 ---
-title: "Gas Profiling with Snapshots"
+title: "Gas profiling with snapshots"
 description: "Learn how to profile gas and fees of transaction chains with --snapshot and baseline comparison"
 ---
 
-Gas profiling helps you track performance regressions in tests by measuring gas and fee metrics for opcodes and full transaction chains.
+Gas profiling records gas and fee metrics for opcodes. Performance regressions show up in the `--snapshot` and `--baseline-snapshot` outputs.
 
 ## What gets profiled
 
 When profiling is enabled, Acton prints:
 
-- **Opcode gas table** (min/max/avg per opcode or message opcode name)
-- **Chain gas & fees summary** (per test)
-- **Chain gas & fees details** (per trace inside each test)
+- Opcode gas usage table: min, max, and avg gas per opcode or message opcode name.
+- Per test gas and fees summary.
+- Per trace gas and fees details inside each test.
 
-For chain-level metrics, Acton tracks:
+For chain-level metrics, Acton tracks: transaction count, gas used, gas fee, forward fee, and the total fee.
 
-- transaction count
-- gas used
-- gas fee
-- forward fee
-- total fee
+## Quick start
 
-## Quick Start
-
-### 1. Create a baseline snapshot
+### Create a baseline snapshot
 
 ```bash
 acton test --snapshot gas-baseline.json
 ```
 
-This runs tests and saves a JSON snapshot with opcode and trace-chain stats.
+This runs tests and writes a JSON snapshot of opcode and trace-chain statistics:
 
 ```text
  GAS USAGE
@@ -51,7 +45,7 @@ This runs tests and saves a JSON snapshot with opcode and trace-chain stats.
  test unknown message         5    5       2568   0.0010272 TON   0.002266953 TON   0.0010272 TON
 ```
 
-### 2. Compare current run with baseline
+### Compare current run with baseline
 
 ```bash
 acton test --baseline-snapshot gas-baseline.json
@@ -107,7 +101,7 @@ Baseline: gas-baseline.json (14 traces, captured 2026-02-28 14:49:39 UTC)
   In comparison tables, changed chains are shown as baseline row, current row, and diff row.
 </Callout>
 
-### 2.1 Fail CI on drift
+### Fail CI on drift
 
 Use strict mode to return non-zero exit code when baseline and current profile differ:
 
@@ -115,14 +109,14 @@ Use strict mode to return non-zero exit code when baseline and current profile d
 acton test --baseline-snapshot gas-baseline.json --fail-on-diff
 ```
 
-You can also enable it by default in `Acton.toml`:
+To enable it by default, set the `fail-on-diff` to `true` in the `Acton.toml`:
 
-```toml
+```toml title="Acton.toml"
 [test]
 fail-on-diff = true
 ```
 
-### 3. Update baseline intentionally
+### Update the baseline on purpose
 
 If changes are expected, recreate baseline:
 
@@ -131,10 +125,10 @@ acton test --snapshot gas-baseline.json
 ```
 
 <Callout type="info" title="Compare mode does not overwrite snapshot">
-If you pass both `--snapshot` and `--baseline-snapshot`, Acton runs in compare mode and does not rewrite the snapshot file.
+  With both `--snapshot` and `--baseline-snapshot`, Acton runs in compare mode and does not rewrite the snapshot file.
 </Callout>
 
-## Naming trace chains for readable reports
+## Name trace chains for readable reports
 
 Chain reports are much easier to read when traces have explicit names.
 
@@ -153,14 +147,11 @@ get fun `test transfer flow`() {
 
 Without custom names, traces are shown as `Trace 1`, `Trace 2`, and so on.
 
-## How snapshot matching works
+## How baseline matching works
 
-Baseline comparison is key-based rather than fuzzy.
+Baseline comparison is key-based rather than fuzzy. Opcode rows are keyed by the resolved opcode label.
 
-- Opcode rows are keyed by the resolved opcode label.
-- If ABI metadata resolves the opcode, the key is the message name such as
-  `IncreaseCounter`.
-- Otherwise the key falls back to the raw hex opcode such as `0x00000999`.
+If ABI metadata resolves the opcode, the key is the message name such as `IncreaseCounter`. Otherwise, the key falls back to the raw hex opcode such as `0x00000999`.
 
 Trace-chain rows are keyed by a stable internal snapshot key:
 
@@ -168,22 +159,19 @@ Trace-chain rows are keyed by a stable internal snapshot key:
 <test-name>::trace#<1-based trace index>
 ```
 
-That key comes from the test name plus the 1-based position of the trace in
-that test's execution order. `trace_name` is stored only for display. Renaming a
-trace with `giveName(...)` makes reports easier to read, but it does not change
-how baseline matching works.
+That key comes from the test name plus the 1-based position of the trace in that test's execution order. `trace_name` is stored only for display. Renaming a trace with `giveName(...)` makes reports easier to read, but it does not change how baseline matching works.
 
-## Reading comparison output
+## Read comparison output
 
 In baseline comparison mode:
 
-- New opcodes/traces are shown as `NEW`
+- New opcodes and traces are shown as `NEW`
 - Higher usage is highlighted as regression
 - Lower usage is highlighted as improvement
 - Unchanged rows are dimmed
 
 <Callout type="tip" title="Stabilize test data first">
-For meaningful diffs, keep tests deterministic: fixed inputs, stable send order, and no random/time-dependent behavior unless explicitly controlled.
+  For meaningful diffs, keep tests deterministic: use fixed inputs, stable send order, and no random or time-dependent behavior unless controlled explicitly.
 </Callout>
 
 ## Snapshot file format
@@ -217,7 +205,7 @@ Gas snapshot is stored as JSON with this high-level structure:
 
 ```
 
-## Useful flags to combine with profiling
+## Flags that pair well with profiling
 
 ```bash
 # Profile only selected tests
@@ -229,37 +217,34 @@ acton test tests/wallet.test.tolk --baseline-snapshot gas-baseline.json
 
 ## Troubleshooting
 
-### Baseline file is missing or invalid
+### Baseline file missing or invalid
 
 Default behavior: Acton prints a warning and continues without baseline comparison.
 
-With strict mode (`--fail-on-diff` or `[test].fail-on-diff = true`), Acton exits with error.
+With strict mode, i.e., `--fail-on-diff` or `[test].fail-on-diff = true`, Acton exits with error.
 
-### Snapshot is not created
+### Snapshot file was not created
 
 Snapshot is written only when:
 
-- `--snapshot` is set
-- `--baseline-snapshot` is **not** set
-- profiling collected at least one opcode or trace-chain metric
+- `--snapshot` is set;
+- `--baseline-snapshot` is **not** set;
+- profiling collected at least one opcode or trace-chain metric.
 
 ### Trace names changed but diff mapping is still stable
 
-Trace comparison is matched by stable snapshot key (`<test-name>::trace#<index>`), while `trace_name` is used for display.
+Trace comparison is matched by stable snapshot key, while `trace_name` is used for display: `<test-name>::trace#<index>`.
 
 ### `--fail-on-diff` is stricter than the tables
 
-The comparison tables mainly show aggregated numbers such as averages and fee
-totals. Strict drift detection compares the full snapshot content except for the
-top-level `timestamp`.
+The comparison tables mainly show aggregated numbers such as averages and fee totals. Strict drift detection compares the full snapshot content except for the top-level `timestamp`.
 
 That means `--fail-on-diff` treats these as real drift:
 
 - opcode sample-count changes
-- `min_gas` / `max_gas` / `avg_gas` changes
+- `min_gas`, `max_gas`, or `avg_gas` changes
 - differences in per-opcode `all_values`
 - per-trace `tx_count` or fee changes
 - changed `trace_name` for the same snapshot key
 
-For stable CI baselines, keep both the execution order and the profiled test
-data deterministic.
+For stable CI baselines, keep both the execution order and the profiled test data deterministic.

--- a/docs/content/docs/testing/generating-wrappers.mdx
+++ b/docs/content/docs/testing/generating-wrappers.mdx
@@ -1,25 +1,23 @@
 ---
-title: "Generating Wrappers"
+title: "Generating wrappers"
 description: "Learn how to automatically generate wrappers for Tolk contracts"
 ---
 
-When working on integration tests, you'll often need wrappers to send messages and call get-methods. To spare you from writing these manually, Acton offers the `wrapper` command, which automatically generates wrappers for your contracts.
+Integration tests often need utility wrapper files to interact with smart contracts: send messages and call get-methods. The [`acton wrapper`](/docs/commands/wrapper) command generates those wrappers from Tolk contracts.
 
-## Generating a Wrapper
+## Generate a wrapper
 
-To generate a wrapper for a contract defined in your `Acton.toml`, use the `wrapper` command:
+Run `acton wrapper` with the contract name from `Acton.toml`:
 
 ```bash
 acton wrapper Counter
 ```
 
-This will:
-1.  Generate a wrapper file (e.g., `wrappers/Counter.gen.tolk`).
-2.  Optionally generate a test stub if you pass the `--test` flag.
+This will generate a Tolk wrapper file, e.g., `wrappers/Counter.gen.tolk`.
 
-## Bootstrapping Tests with `--test`
+## Bootstrap tests with `--test`
 
-Often when you start testing a contract, you need the same setup boilerplate: imports, deploying the contract, and basic checks. The `--test` flag can generate a ready-to-run test file for you.
+New contract tests repeat the same boilerplate: imports, deploy, and basic checks. Pass `--test` to emit a runnable test stub file in addition to the wrapper:
 
 ```bash
 acton wrapper Counter --test
@@ -62,15 +60,14 @@ get fun `test basic flow`() {
 }
 ```
 
-This gets you from zero to a running test in one command!
+## Requirements and caveats
 
-## Requirements and "Gotchas"
-
-### Contract Header Is Required
+### Contract header is required
 
 Wrapper generation uses the ABI emitted by the Tolk compiler. The contract header is the source of truth for:
-- storage, via `storage: ...`
-- incoming message wrappers, via `incomingMessages: ...`
+
+- storage, via `storage: ...`;
+- incoming message wrappers, via `incomingMessages: ...`.
 
 If `incomingMessages` is not declared in the `contract` header, `send{MessageName}` methods will not be generated. If `storage` is missing, the wrapper falls back to an empty `fromStorage()` initializer instead of a typed storage-based one.
 
@@ -98,7 +95,7 @@ fun onInternalMessage(in: InMessage) {
 }
 ```
 
-### Types Can Be Local Or Imported
+### Types in the contract file or imports
 
 Storage and message types may live either in the contract file itself or in imported files. Both layouts are supported.
 
@@ -130,9 +127,9 @@ fun onInternalMessage(in: InMessage) {
 }
 ```
 
-### Contract must be in Acton.toml
+### Register the contract in Acton.toml
 
-The command takes a **contract name**, not a file path. Ensure your contract is defined in the configuration:
+The command takes a contract name, not a file path. The contract must appear under `[contracts.<Name>]` in `Acton.toml`:
 
 ```toml title="Acton.toml"
 [contracts.Counter]
@@ -140,17 +137,17 @@ display-name = "Counter"
 src = "contracts/Counter.tolk"
 ```
 
-## Using the Generated Wrapper
+## Use the generated wrapper
 
-The generated wrapper provides a struct representing your contract and methods to interact with it.
+The generated wrapper provides a struct representing the contract and helper methods to deploy and interact with it.
 
-### Initializing and Deploying
+### Initialize and deploy
 
-The wrapper provides a static `fromStorage` method to create the initial state and a `deploy` method to put it on the chain.
+The wrapper provides static `fromStorage()` method to create the initial state and a `deploy` method to put it on the chain.
 
 ```tolk title="tests/Counter.test.tolk"
 import "@wrappers/Counter"
-// Don't forget to import types for the storage struct!
+// NOTE: Always import types used by the storage struct!
 import "@contracts/types"
 import "@acton/emulation/testing"
 
@@ -166,18 +163,18 @@ get fun `test example`() {
 }
 ```
 
-### Sending Messages
+### Send messages
 
 For every message type listed in `contract { incomingMessages: ... }`, the wrapper generates a corresponding `send{MessageName}` method.
 
-If your contract handles `Increase`:
+For instance, if the counter contract handles the `Increase` message, the method signature would look like this:
 
 ```tolk
 // Generated method signature:
 fun Counter.sendIncrease(self, from: address, amount: int, config: ...): SendResultList
 ```
 
-You can use it like this:
+Usage examples:
 
 ```tolk
 // Send the "Increase" message
@@ -190,18 +187,18 @@ contract.sendIncrease(deployer.address, 10, {
 });
 ```
 
-### Calling Get Methods
+### Call get methods
 
-Get-methods are also wrapped. They return typed values directly.
+Get-method helpers are also generated. They return typed values directly:
 
 ```tolk
 val current = contract.currentCounter();
 expect(current).toEqual(10);
 ```
 
-## Command Options
+## Command-line options
 
-You can customize the output paths:
+Customize output paths:
 
 ```bash
 # Generate wrapper in a specific file
@@ -217,7 +214,7 @@ acton wrapper Counter --test --test-output tests/my.test.tolk
 acton wrapper Counter --test --test-output-dir tests/generated
 ```
 
-You can also configure project-wide defaults in `Acton.toml`:
+Customize project defaults in `Acton.toml`:
 
 ```toml
 [wrappers.tolk]
@@ -229,8 +226,9 @@ test-output-dir = "tests/generated-tests"
 output-dir = "./wrappers-ts"
 ```
 
-Then:
-- `acton wrapper Counter` writes `tests/generated-wrappers/Counter.gen.tolk` and `tests/generated-tests/Counter.test.tolk`
-- `acton wrapper Counter --ts` writes `wrappers-ts/Counter.gen.ts` by default
+With this configuration:
 
-See the [wrapper command reference](/docs/commands/wrapper) for more details about CLI options.
+- `acton wrapper Counter` would write `tests/generated-wrappers/Counter.gen.tolk` and `tests/generated-tests/Counter.test.tolk`
+- `acton wrapper Counter --ts` would write to `wrappers-ts/Counter.gen.ts` (by default)
+
+See the [`acton wrapper` command reference](/docs/commands/wrapper) for more details on CLI options.

--- a/docs/content/docs/testing/mutation-testing/overview.mdx
+++ b/docs/content/docs/testing/mutation-testing/overview.mdx
@@ -3,13 +3,13 @@ title: "Overview"
 description: "Learn how to use mutation testing to assess the quality of your test suite"
 ---
 
-Mutation testing is a powerful technique to evaluate the quality of your test suite. Unlike code coverage, which only tells you *which* lines of code were executed, mutation testing tells you *how well* those lines are tested.
+Mutation testing runs small edits (mutations) on the contract source, recompiles, and re-runs the suite. For instance, it might change `+` to `-`, flip the `<` to `>=`, or remove an assertion. If tests still pass, the mutant code survived, and the suite likely missed an assertion on that behavior.
 
-It works by automatically making small changes (mutations) to your code — like changing `+` to `-` or removing an `assert` — and checking if your tests fail. If the tests still pass (the mutant "survives"), it means your tests didn't catch that change, revealing a potential gap in your test suite.
+## Why mutation testing
 
-## Why Mutation Testing?
+Code coverage only shows execution and lines of code executed, whereas mutation testing tells how well those lines are tested and whether existing assertions contradict mutations.
 
-Code coverage can be misleading. Consider this example:
+Additionally, coverage can be misleading and overlook weak tests. For example, a test that only calls `add(1, 2)` can reach every line yet never exercise the `a > 0` guard in the following code:
 
 ```tolk
 fun add(a: int, b: int): int {
@@ -18,27 +18,23 @@ fun add(a: int, b: int): int {
 }
 ```
 
-If you write a test `add(1, 2)`, you might achieve 100% line coverage. However, what if you forgot to test the validation logic?
+Mutation testing can delete `assert (a > 0) throw 5`. Without a failing test case such as `add(-1, 2)`, that mutant survives: the line ran, but the guard was not actually enforced by the test suite. This is critical for smart contracts where assertions guard invariants: if an `assert` can be removed without tests failing, that assertion is effectively untested.
 
-Mutation testing will try to **remove** the `assert (a > 0) throw 5` statement. If your test suite doesn't have a test case like `add(-1, 2)` that expects a failure, the mutant will survive. This tells you that even though the line is "covered", the logic within it is not actually verified.
+Further, mutation testing can reveal implementation issues. For example, two `storage.save()` calls where removing the second does not fail any test suggests that the second call might be redundant and can be removed to optimize gas usage.
 
-This is especially critical for smart contracts where assertions guard security invariants. If an assertion can be removed without any test failing, that security check might be effectively untested.
+## How it works
 
-Beyond testing gaps, mutation testing can also reveal implementation issues. For example, if you have two `storage.save()` calls and removing the second one doesn't cause tests to fail, it might indicate that the second call is redundant and could be removed to optimize gas usage.
+1. **Mutant generation**: Acton scans the contract code and picks mutation sites.
+2. **Compilation**: Each mutant compiles; invalid syntax is discarded.
+3. **Testing**: Acton runs the test suite against each valid mutant.
+4. **Reporting**:
+   - **Killed**: tests failed on the mutant as **expected**.
+   - **Survived**: tests **unexpectedly** passed, indicating a coverage gap.
+   - **Compile errors**: mutants that failed to compile are reported separately and excluded from the mutation score.
 
-## How It Works
+## Run mutation tests
 
-1.  **Mutant Generation**: Acton scans your contract code and identifies places where it can introduce bugs (mutants).
-2.  **Compilation**: Each mutant is compiled. If a mutant doesn't compile (e.g., syntax error), it's discarded.
-3.  **Testing**: Acton runs your test suite against each valid mutant.
-4.  **Reporting**:
-- **Killed**: The tests failed (good!).
-- **Survived**: The tests passed (bad!). This indicates a gap in testing.
-- **Compile errors**: Mutants that fail to compile are reported separately and excluded from the mutation score.
-
-## Running Mutation Tests
-
-To run mutation tests, you need to specify the contract you want to mutate using the `--mutate-contract` flag. This corresponds to the contract name defined in your `Acton.toml`.
+Pass `--mutate` and name the contract from `Acton.toml` with `--mutate-contract`:
 
 ```bash
 acton test --mutate --mutate-contract Wallet
@@ -60,40 +56,29 @@ acton test --mutate --mutate-contract Wallet
 | `--mutation-minimum-percent <P>`  | Fails the run when the mutation score drops below the required percentage.         |
 | `--mutation-disable-rules <RULE>` | Disables specific mutation rules (can be used multiple times).                     |
 
-### Parallel Workers
+### Parallel workers
 
-Mutation testing can spawn a lot of compile and test workers. By default, Acton
-uses the host's available parallelism and keeps one isolated mutation
-workspace per worker.
+Mutation testing can spawn a lot of compile and test workers. By default, Acton uses the host's available parallelism and keeps one isolated mutation workspace per worker.
 
-Use `--mutation-workers <N>` when you want to cap or raise concurrency for a
-specific run:
+Use `--mutation-workers <N>` to cap or raise concurrency for a specific run:
 
 ```bash
 acton test --mutate --mutate-contract Wallet --mutation-workers 4
 ```
 
-This is useful when you want to reduce CPU, disk, or process pressure on a
-laptop or CI machine. Results are still reported incrementally as workers
-finish, while output stays ordered by mutation ID.
+This is useful when limiting CPU, disk, or process count on a laptop or CI host. Progress still streams by mutation ID while output stays ordered.
 
-### Scoping Mutation Runs
+### Scope mutation runs
 
-Mutation testing can be expensive because each valid mutant is compiled and
-tested separately. In practice, most local runs should use one or more filters
-to keep the scope small and the feedback fast.
+Mutation testing can be expensive because each valid mutant is compiled and tested separately. In practice, most local runs should use one or more filters to keep the scope small and the feedback fast.
 
 #### Changed-line modes
 
 Use `--mutation-diff` to mutate only code that intersects changed lines.
 
-- `worktree`: compares the current worktree with `HEAD`. This is the best mode
-  for uncommitted local changes. Untracked files are treated as fully changed.
-- `ref`: compares the current checkout against an explicit ref, tag, or commit.
-  This mode requires `--mutation-diff-ref <REF>`.
-- `branch`: compares the current branch against the merge-base with its upstream
-  branch. If the branch has no upstream, pass `--mutation-diff-ref <REF>` to
-  choose the base explicitly, for example `origin/main`.
+- `worktree`: compares the current worktree with `HEAD`. This is the best mode for uncommitted local changes. Untracked files are treated as fully changed.
+- `ref`: compares the current checkout against an explicit ref, tag, or commit. This mode requires `--mutation-diff-ref <REF>`.
+- `branch`: compares the current branch against the merge-base with its upstream branch. If the branch has no upstream, pass `--mutation-diff-ref <REF>` to choose the base explicitly, for example `origin/main`.
 
 Examples:
 
@@ -113,7 +98,7 @@ acton test --mutate --mutate-contract Wallet --mutation-diff branch --mutation-d
 
 #### Level and rule filters
 
-Use `--mutation-levels` to restrict the run to selected rule levels:
+Use `--mutation-levels` to restrict the run to select rule levels:
 
 ```bash
 acton test --mutate --mutate-contract Wallet --mutation-levels critical,major
@@ -125,27 +110,21 @@ Use `--mutation-disable-rules` to exclude noisy or intentionally ignored rules:
 acton test --mutate --mutate-contract Wallet --mutation-disable-rules replace_plus_with_minus --mutation-disable-rules replace_minus_with_plus
 ```
 
-All mutation filters compose. For example, this command runs only `critical`
-mutations on lines changed in the current worktree and skips one specific rule:
+All mutation filters compose. For example, this command runs only `critical` mutations on lines changed in the current worktree and skips one specific rule:
 
 ```bash
 acton test --mutate --mutate-contract Wallet --mutation-diff worktree --mutation-levels critical --mutation-disable-rules remove_logical_not
 ```
 
-The reported mutation score always reflects only the mutants that remain after
-all filters are applied.
+The reported mutation score always reflects only the mutants that remain after all filters are applied.
 
 #### Custom JSON rules
 
-Use `--mutation-rules-file` when you want to add project-specific query-based
-mutations without recompiling Acton.
-
-Custom rules are merged with the built-in set. If a custom rule uses the same
-rule ID as a built-in rule, the custom rule overrides it.
+Custom rules are merged with the built-in set. If a custom rule uses the same rule ID as a built-in rule, the custom rule overrides it.
 
 Example:
 
-```json
+```json title="mutation-rules.json"
 [
   {
     "name": "replace_plus_with_multiply_custom",
@@ -166,7 +145,7 @@ Example:
 ]
 ```
 
-Then run:
+Use `--mutation-rules-file` to run project-specific query-based mutations without rebuilding Acton:
 
 ```bash
 acton test --mutate --mutate-contract Wallet --mutation-rules-file mutation-rules.json
@@ -178,34 +157,26 @@ Print the JSON schema for editor integration or validation with:
 acton meta get-schema mutation-rules
 ```
 
-Currently, JSON rules support only the serializable `query` matcher and `remove`
-or `replace` edits.
+Currently, JSON rules support only the serializable `query` matcher and `remove` or `replace` edits.
 
 #### Session logs and resume
 
-Each mutation run gets a session ID. If you do not pass one explicitly, Acton
-generates a hash-like ID and starts writing append-only JSON Lines progress to
-`.acton/mutation-sessions/<SESSION_ID>.jsonl`.
+Each mutation run gets a session ID. Without explicit `--mutation-session-id`, Acton generates a hash-like ID and appends progress to `.acton/mutation-sessions/<SESSION_ID>.jsonl`.
 
-Use `--mutation-session-id` when you want to keep that ID stable and continue
-the same run later:
+Use `--mutation-session-id` to keep that ID stable and append to the same log on later runs:
 
 ```bash
 # Start or resume a session for the current worktree changes
 acton test --mutate --mutate-contract Wallet --mutation-diff worktree --mutation-session-id wallet-worktree
 ```
 
-To resume successfully, keep the same contract and the same mutation filters.
-Acton validates the stored session metadata before reusing the file.
+To resume successfully, keep the same contract and the same mutation filters. Acton validates the stored session metadata before reusing the file.
 
-If you interrupt the run with `Ctrl+C`, Acton stops without marking the session
-as finished and prints the exact resume command for that session.
+Interrupting with `Ctrl+C` stops Acton without marking the session finished and prints the exact resume command for that session.
 
-#### Re-running specific mutants
+#### Re-run specific mutants
 
-Use `--mutation-id` when you want to focus on one or more mutants from a previous run.
-Pass the mutation numbers shown in the report and keep the same mutation
-filters you used when those IDs were produced.
+Use `--mutation-id` to focus on one or more mutants from a previous report. Pass the mutation numbers from that report and keep the same mutation filters used when those IDs were produced.
 
 Examples:
 
@@ -217,12 +188,9 @@ acton test --mutate --mutate-contract Wallet --mutation-id 2
 acton test --mutate --mutate-contract Wallet --mutation-id 1,3
 ```
 
-If you also use filters such as `--mutation-diff`, `--mutation-levels`, or
-`--mutation-disable-rules`, the IDs must still exist after those filters are applied.
-When you combine this with `--mutation-session-id`, the session must be created
-with the same filtered mutation set.
+With extra filters such as `--mutation-diff`, `--mutation-levels`, or `--mutation-disable-rules`, the IDs must still exist after those filters apply. With `--mutation-session-id`, the session metadata must match the same filtered mutation set.
 
-#### Minimum mutation score
+#### Minimum mutation score gate
 
 Use `--mutation-minimum-percent` to turn mutation testing into a CI quality
 gate:
@@ -234,7 +202,7 @@ acton test --mutate --mutate-contract Wallet --mutation-minimum-percent 85
 The threshold is applied to the final mutation score after filters are applied.
 Compile errors are reported separately and excluded from that score.
 
-#### Config defaults
+#### Config defaults in `Acton.toml`
 
 You can store the same filters in `Acton.toml`:
 
@@ -251,7 +219,7 @@ CLI flags override `[test.mutation]` for the current run.
 
 ### Requirements
 
-For mutation testing to work correctly, your tests must build contracts using their name from `Acton.toml`, not direct file paths:
+Tests must build the mutated contract by contract name from `Acton.toml`, not by raw file path:
 
 ```tolk
 // ✅ Correct — uses contract name
@@ -261,19 +229,15 @@ val wallet = build("JettonWallet");
 val wallet = build("JettonWallet", "./contracts/JettonWallet.tolk");
 ```
 
-Mutation testing analyzes the contract specified by `--mutate-contract` and its dependencies. When tests use direct file paths, the mutated code won't be used, making mutation testing inefficient.
+Mutation rewrites apply to the tree selected by `--mutate-contract`. File-path `build(...)` calls bypass that wiring and skip mutations, which weakens overall results.
 
-## Mutation Rules
+## Mutation rules
 
-Acton currently includes 49 built-in mutation rules for assertions, storage and
-upgrade calls, external-message handling, control flow, arithmetic,
-comparisons, booleans, logical operators, and bitwise or shift operators.
+Acton includes many built-in [mutation rules](/docs/testing/mutation-testing/rules) for assertions, storage and upgrade calls, external-message handling, control flow, arithmetic, comparisons, booleans, logical operators, and bitwise or shift operators.
 
-See [Mutation Rules](/docs/testing/mutation-testing/rules) for complete list.
+## Read the report
 
-## Interpreting Results
-
-After running mutation tests, you will see a summary of the results:
+After a mutation run, the console shows a summary of the results:
 
 ```text
 Mutation Testing
@@ -296,14 +260,12 @@ Mutants:  51
   ...
 ```
 
-- **KILLED**: Your tests successfully detected the bug.
-- **SURVIVED**: Your tests failed to detect the bug. You should add a test case to cover this scenario.
-- **Session log**: Progress is written incrementally to
-  `.acton/mutation-sessions/<SESSION_ID>.jsonl`, which makes interrupted runs resumable.
-- **Mutation IDs**: The number in `Mutation 2/51` or `Mutation #2` can be used
-  later with `--mutation-id 2` to re-run that specific mutant.
+- **KILLED**: tests failed on the mutant as expected.
+- **SURVIVED**: tests still passed, failing to detect the bug; add a test case and tighten coverage for this scenario.
+- **Session log**: Progress is written incrementally to `.acton/mutation-sessions/<SESSION_ID>.jsonl`, which makes interrupted runs resumable.
+- **Mutation IDs**: The number in `Mutation 2/51` or `Mutation #2` can be used later with `--mutation-id 2` to re-run that specific mutant.
 
-For survived mutants, Acton provides a diff showing exactly what was changed and explains why it's an issue:
+For survived mutants, Acton prints a diff of the edit plus a short rationale tied to the rule:
 
 ```text
   ✗ Mutation #2

--- a/docs/content/docs/testing/mutation-testing/rules.mdx
+++ b/docs/content/docs/testing/mutation-testing/rules.mdx
@@ -1,27 +1,13 @@
 ---
-title: "Mutation Rules"
+title: "Mutation rules"
 description: "Reference of all available mutation rules in Acton"
 ---
 
-This page lists all 49 mutation rules available in Acton, categorized by their type.
+Acton ships 49 built-in [mutation](/docs/testing/mutation-testing/overview) rules, categorized by their type. Use rule IDs with `acton test --mutation-disable-rules <RULE>` or `[test.mutation].disable-rules` inside `Acton.toml`.
 
-Use rule IDs with `acton test --mutation-disable-rules <RULE>` or
-`[test.mutation].disable-rules` inside `Acton.toml`.
+## Critical rules
 
-Use mutation levels with `acton test --mutation-levels critical,major` or
-`[test.mutation].mutation-levels = ["critical", "major"]`.
-
-Use changed-line filtering with `acton test --mutation-diff worktree` or
-`[test.mutation].diff = "branch"`.
-
-For when to use `worktree`, `ref`, or `branch`, see
-[Mutation Testing](/docs/testing/mutation-testing/overview).
-
-## Critical Rules
-
-These rules affect control flow, assertions, storage persistence, and contract
-upgrade or external-message semantics. Mutations in this category that survive
-are often indicators of missing tests for security-critical behavior.
+These rules affect control flow, assertions, storage persistence, and contract upgrade or external-message semantics. Mutations in this category that survive are often indicators of missing tests for security-critical behavior.
 
 | Rule                                      | Description                                   | Explanation                                                                                                               |
 |-------------------------------------------|-----------------------------------------------|---------------------------------------------------------------------------------------------------------------------------|
@@ -37,7 +23,7 @@ are often indicators of missing tests for security-critical behavior.
 | `replace_while_condition_with_false`      | Replace while condition with `false`          | The loop execution path is not fully covered.                                                                             |
 | `remove_logical_not`                      | Remove logical NOT (`!`)                      | The logical negation is not fully covered.                                                                                |
 
-## Arithmetic Rules
+## Arithmetic rules
 
 These rules mutate arithmetic operations to ensure calculations are verified by tests.
 
@@ -55,7 +41,7 @@ These rules mutate arithmetic operations to ensure calculations are verified by 
 | `replace_minus_assign_with_plus_assign`      | Replace `-=` with `+=`   |
 | `remove_unary_minus`                         | Remove unary minus (`-`) |
 
-## Comparison Rules
+## Comparison rules
 
 These rules mutate comparison operators to check if boundary conditions are tested.
 
@@ -68,7 +54,7 @@ These rules mutate comparison operators to check if boundary conditions are test
 | `replace_less_or_equal_with_less_than`       | Replace `<=` with `<`  |
 | `replace_greater_or_equal_with_greater_than` | Replace `>=` with `>`  |
 
-## Boolean & Logical Rules
+## Boolean and logical rules
 
 These rules invert boolean values and logical operators.
 
@@ -79,7 +65,7 @@ These rules invert boolean values and logical operators.
 | `replace_logical_and_with_logical_or` | Replace `&&` with `\|\|`    |
 | `replace_logical_or_with_logical_and` | Replace `\|\|` with `&&`    |
 
-## Bitwise Rules
+## Bitwise rules
 
 These rules mutate bitwise operators, compound bitwise assignments, and shifts.
 

--- a/docs/content/docs/testing/overview.mdx
+++ b/docs/content/docs/testing/overview.mdx
@@ -3,55 +3,55 @@ title: "Overview"
 description: "Learn how to write and run tests for Tolk smart contracts"
 ---
 
-This section contains guides and reference documentation for Acton's test runner.
+This section contains guides and reference documentation for the Acton test runner.
 
 <Cards>
-  <Card href="/docs/testing/generating-wrappers" title="Generating Wrappers">
-    Learn how to automatically generate wrappers for Tolk contracts
+  <Card href="/docs/testing/generating-wrappers" title="Generating wrappers">
+    Generate wrappers for Tolk smart contracts
   </Card>
-  <Card href="/docs/testing/test-attributes" title="Test Attributes">
-    Learn how to use test attributes to control test behavior, skip tests, and set expectations
+  <Card href="/docs/testing/test-attributes" title="Test attributes">
+    Control test behavior, skip tests, and set expectations with `@test.*` attributes
   </Card>
-  <Card href="/docs/testing/fuzz-testing" title="Fuzz Testing">
-    Learn how to run parameterized tests with generated inputs, assumptions, and bounds
+  <Card href="/docs/testing/fuzz-testing" title="Fuzz testing">
+    Run parameterized tests with generated inputs, assumptions, and bounds
   </Card>
-  <Card href="/docs/testing/test-configuration" title="Test Configuration">
-    Learn how to configure test runner behavior through project settings and command line options
+  <Card href="/docs/testing/test-configuration" title="Test configuration">
+    Configure the test runner in `Acton.toml` and with CLI flags
   </Card>
-  <Card href="/docs/testing/world-state-snapshots" title="World State Snapshots">
-    Learn how to save and restore local emulation state as JSON fixtures inside tests
+  <Card href="/docs/testing/world-state-snapshots" title="World state snapshots">
+    Save and restore local emulation state as JSON fixtures inside tests
   </Card>
-  <Card href="/docs/testing/step-by-step-execution" title="Step-by-step Execution">
-    Learn how to use `testing.createTraceIterationCursor()` and `TxCursor` to execute transaction chains in parts
+  <Card href="/docs/testing/step-by-step-execution" title="Step-by-step execution">
+    Use `testing.createTraceIterationCursor()` and `TxCursor` to run transaction chains in parts
   </Card>
   <Card href="/docs/testing/test-ui/overview" title="Test UI">
-    Learn how to inspect traces, transaction trees, logs, and failures in the browser UI
+    Inspect traces, transaction trees, logs, and failures in the browser UI
   </Card>
-  <Card href="/docs/testing/saved-trace-bundles" title="Saved Trace Bundles">
-    Reference for the JSON artifacts written by `acton test --save-test-trace` and reused by the Test UI
+  <Card href="/docs/testing/saved-trace-bundles" title="Saved trace bundles">
+    Reference for JSON artifacts from `acton test --save-test-trace`, reused by the Test UI
   </Card>
-  <Card href="/docs/testing/built-in-matchers-and-helpers" title="Built-in Matchers and Helpers">
-    Find transaction predicates, map expectations, and out-action helpers before writing your own matchers
+  <Card href="/docs/testing/built-in-matchers-and-helpers" title="Built-in matchers and helpers">
+    Reference for transaction predicates, map expectations, and out-action helpers
   </Card>
-  <Card href="/docs/testing/reading-transaction-chains" title="Reading Transaction Chains">
-    Learn how to read the text trace format printed by `println(txs)` and matcher failures
+  <Card href="/docs/testing/reading-transaction-chains" title="Reading transaction chains">
+    Read the text trace format from `println(txs)` and matcher failures
   </Card>
-  <Card href="/docs/testing/gas-profiling-with-snapshots" title="Gas Profiling with Snapshots">
-    Learn how to profile opcode and transaction-chain gas/fee metrics, save snapshots, and compare with baselines
+  <Card href="/docs/testing/gas-profiling-with-snapshots" title="Gas profiling with snapshots">
+    Profile opcode and chain gas and fees, save snapshots, and compare baselines
   </Card>
-  <Card href="/docs/testing/fork-testing" title="Fork Testing">
-    Learn how to test contracts against real blockchain state by forking testnet or mainnet
+  <Card href="/docs/testing/fork-testing" title="Fork testing">
+    Test contracts against real chain state by forking testnet or mainnet
   </Card>
-  <Card href="/docs/testing/code-coverage" title="Code Coverage">
-    Learn how to measure and analyze code coverage in your Tolk smart contract tests
+  <Card href="/docs/testing/code-coverage" title="Code coverage">
+    Measure and inspect code coverage in Tolk smart contract tests
   </Card>
-  <Card href="/docs/testing/mutation-testing/overview" title="Mutation Testing">
-    Learn how to use mutation testing to assess the quality of your test suite
+  <Card href="/docs/testing/mutation-testing/overview" title="Mutation testing">
+    Run mutation testing to assess the test suite quality and find hidden gaps in the coverage
   </Card>
   <Card href="/docs/testing/cookbook" title="Cookbook">
-    Practical examples and code snippets for common testing scenarios in Tolk smart contracts
+    Short examples for common assertions, helpers, and scenarios in tests
   </Card>
-  <Card href="/docs/testing/writing-your-own-matchers" title="Custom Matchers">
-    Learn how to add custom matchers for expect() calls
+  <Card href="/docs/testing/writing-your-own-matchers" title="Custom matchers">
+    Extend `expect()` with domain-specific matchers
   </Card>
 </Cards>

--- a/docs/content/docs/testing/reading-transaction-chains.mdx
+++ b/docs/content/docs/testing/reading-transaction-chains.mdx
@@ -1,38 +1,32 @@
 ---
-title: "Reading Transaction Chains"
+title: "Reading transaction chains"
 description: "Understand the text trace format printed for transaction results and matcher failures"
 ---
 
-Acton can render a result of `net.send()` as a text tree. You will usually see this
-format in two places:
+The result of `net.send()` and `net.deploy()` calls can be rendered as a text tree trace of transactions. The tree can be printed:
 
-- after `println(txs)` or `println(result)` in a test
-- inside failure diagnostics from transaction matchers such as
-  [`toHaveTx()`](/docs/standard_library/emulation/network#expectationsendresultlisttohavetx),
-  [`toHaveSuccessfulTx()`](/docs/standard_library/emulation/network#expectationsendresultlisttohavesuccessfultx),
-  and
-  [`toHaveFailedTx()`](/docs/standard_library/emulation/network#expectationsendresultlisttohavefailedtx)
+- By passing the result as an argument to the `println()` function call;
+- Within failure diagnostics from transaction matchers such as [`toHaveTx()`](/docs/standard_library/emulation/network#expectationsendresultlisttohavetx), [`toHaveSuccessfulTx()`](/docs/standard_library/emulation/network#expectationsendresultlisttohavesuccessfultx), and
+  [`toHaveFailedTx()`](/docs/standard_library/emulation/network#expectationsendresultlisttohavefailedtx).
 
-Use this output when you want a quick terminal-native view of what happened in a
-trace without opening the browser UI.
+This trace tree is a terminal counterpart of the traces formed in the [Test UI](/docs/testing/test-ui/overview).
 
-If you are using this trace together with matcher failures, see
-[Built-in Matchers and Helpers](/docs/testing/built-in-matchers-and-helpers)
-for predicate-based transaction search, map helpers, and out-action helpers.
+<Callout type="tip">
+    To use matcher failures together with this trace, see [built-in matchers and helpers](/docs/testing/built-in-matchers-and-helpers) for predicate-based transaction search, map helpers, and out-action helpers.
+</Callout>
 
-Decoded message bodies are hidden by default. To show parsed fields under
-transactions, run `acton test --show-bodies` or `acton script ... --show-bodies`.
-Acton prints them only when it knows the contract compiler ABI and can decode
-the payload completely.
+Decoded message bodies are hidden by default. To show parsed fields under transactions, run `acton test --show-bodies` or `acton script ... --show-bodies`. Acton prints them only when it knows the contract compiler ABI and can decode the payload completely.
 
-## Print a Trace
+## Print a trace
+
+Use `println()` with the result of the `net.send()` or `net.deploy()` call to render it as a text tree:
 
 ```tolk
 val txs = net.send(deployer.address, msg);
 println(txs);
 ```
 
-Example:
+Example output:
 
 ```acton-trace
 N/A -> sender A
@@ -41,7 +35,7 @@ N/A -> sender A
         └── Compute phase failed: Unable to load data from cell because prefix does not match
 ```
 
-## Show Decoded Message Bodies
+## Show decoded message bodies
 
 With `--show-bodies`, Acton adds decoded fields under the transaction line.
 
@@ -53,8 +47,7 @@ N/A -> sender A
     queryId: 0, newAdminAddress: 0QDx... (not_deployer)
 ```
 
-Multi-line bodies use the continuation gutter `│` so they stay visually attached
-to the transaction header even when child transactions follow:
+Multi-line bodies use the continuation gutter `│` so they stay visually attached to the transaction header even when child transactions follow:
 
 ```acton-trace
 N/A -> sender A
@@ -67,58 +60,43 @@ N/A -> sender A
     └── empty 0.0096 TON -> sender A                                    gas=309
 ```
 
-## How to Read the Main Line
+## How to read the main line
 
-- `N/A -> sender A` is the entry into this printed trace. It is not a blockchain
-  transaction by itself. It shows where the root transaction came from inside
-  the current result list.
-- `└──` and `├──` show the parent/child transaction structure. A child line was
-  produced by the parent transaction above it.
-- `FmRoute` and `FmDelivered` are message names resolved from ABI opcodes.
-  `empty` means an empty body. Unknown opcodes are printed as hex, for example
-  `0x1`.
+- `N/A -> sender A` is the entry into this printed trace. It is not a blockchain transaction by itself. It shows where the root transaction came from inside the current result list.
+- The `└──` and `├──` lines show the parent-child transaction structure. A child line is produced by the parent transaction above it.
+- `FmRoute` and `FmDelivered` are message names resolved from ABI opcodes. `empty` means an empty body. Unknown opcodes are printed as hex, for example `0x1`.
 - `0.6 TON` is the incoming message value for that transaction.
-- `sender`, `fm_linear_root`, and `fm_linear_mid` are display names for
-  participants. When Acton knows a symbolic name, it prints that name.
-  Otherwise it falls back to a shortened address.
-- `A`, `B`, `C` are local aliases for addresses inside the current printed
-  result. They make repeated participants easier to follow.
+- `sender`, `fm_linear_root`, and `fm_linear_mid` are display names for participants. When Acton knows a symbolic name, it prints that name. Otherwise, it falls back to a shortened address.
+- `A`, `B`, `C` are local aliases for addresses inside the current printed result. They make repeated participants easier to follow.
 - `gas=1782` is compute gas usage for the transaction.
-- `exit_code=63` means compute phase failed with that exit code.
+- `exit_code=63` means that compute phase failed with this exit code.
 - `aborted` means the transaction finished in aborted state.
 
 <Callout type="info">
-The `A`, `B`, `C` aliases are local to one printed result. They are a reading
-aid, not stable identifiers across different runs.
+    The `A`, `B`, `C` aliases are local to one printed result. They are a reading aid, not stable identifiers across different runs.
 </Callout>
 
-## Special Markers
+## Special markers
 
-### Bounced Messages
+### Bounced messages
 
 ```acton-trace
 N/A -> sender A
 └── (!) empty 0.2 TON -> fm_bounce_echo B                                       gas=271
 ```
 
-- `(!)` marks a bounced internal message.
-- For bounced messages, Acton still tries to resolve the original opcode from
-  the bounced body, so you can often see the original message name instead of a
-  generic bounce wrapper.
+`(!)` marks a bounced internal message. For bounced messages, Acton still tries to resolve the original opcode from Acton often resolves the original opcode from the bounced body, so the original message name appears instead of a generic bounce wrapper.
 
-### Compute Skipped
+### Compute skipped
 
 ```acton-trace
 N/A -> sender A
 └── FmBouncePing 0.2 TON -> EQAAAA..ALrXfh B                          compute phase skipped aborted
 ```
 
-- `compute phase skipped` means TVM compute did not run for this transaction.
-- In practice this usually means the message reached an account/state where only
-  envelope-level processing happened, so the next step is to inspect the
-  destination and message kind.
+`compute phase skipped` means TVM compute did not run for this transaction. In practice, this usually means the message reached an account where only envelope-level processing happened, so the next step is to inspect the destination and message kind.
 
-### External Input and Output
+### External input and output
 
 ```acton-trace
 N/A -> external
@@ -129,10 +107,9 @@ N/A -> external
 
 - `ext-in` is an external inbound message.
 - `ext-out` lines are external messages emitted by the transaction.
-- External destinations are shown either as `none` or as raw external address
-  bytes.
+- External destinations are shown either as `none` or as raw external address bytes.
 
-## Extra Diagnostic Lines
+## Extra diagnostic lines
 
 Transactions can print extra lines under the main row:
 
@@ -150,31 +127,19 @@ N/A -> sender A
 
 Common extra lines:
 
-- `account created` and `account destroyed` show storage lifecycle changes
-- `Compute phase failed: ...` explains a non-zero `exit_code`
-- `Action phase failed` and `action_result_code=...` describe action-phase
-  errors
-- decoded body fields may appear before child transactions when `--show-bodies`
-  is enabled and ABI is known
-- `Executed actions:` shows parsed out actions such as `sendMsg` and `reserve`
-- `Re-run with --backtrace full ...` means Acton can show source locations for
-  failed actions or compute errors if you enable full backtraces
+- `account created` and `account destroyed` show storage lifecycle changes.
+- `Compute phase failed: ...` explains a non-zero `exit_code`.
+- `Action phase failed` and `action_result_code=...` describe action-phase errors.
+- Decoded body fields may appear before child transactions when `--show-bodies` is enabled and ABI is known.
+- `Executed actions:` shows parsed out actions such as `sendMsg` and `reserve`.
+- `Re-run with --backtrace full ...` means Acton can show source locations for failed actions or compute errors after enabling full backtraces.
 
-## Making Traces More Readable
+## Make traces easier to read
 
 - Give treasuries explicit names with `testing.treasury("deployer")`.
-- Name arbitrary addresses with
-  [`randomAddress("name")`](/docs/standard_library/emulation/network#randomaddress)
-  or
-  [`net.registerAddress(...)`](/docs/standard_library/emulation/network#netregisteraddress).
-- Label undeployed or dynamically-created contracts with
-  [`net.registerCodeCell(...)`](/docs/standard_library/emulation/network#netregistercodecell).
-- Use matcher failures as a focused debugger: when
-  `expect(txs).toHaveSuccessfulTx({...})` fails, Acton prints the same trace tree
-  plus the exact search parameters that were not matched.
-- Re-run with `acton test --show-bodies` when you want decoded message fields in
-  the terminal tree.
-- Re-run with `acton test --backtrace full` when you need source locations for
-  compute/action failures.
-- Switch to [`acton test --ui`](/docs/testing/test-ui/overview) when the tree is too
-  large and you need clickable transactions, fee tables, or grouped logs.
+- Name arbitrary addresses with [`randomAddress("name")`](/docs/standard_library/emulation/network#randomaddress) or [`net.registerAddress(...)`](/docs/standard_library/emulation/network#netregisteraddress).
+- Label not deployed or dynamically-created contracts with [`net.registerCodeCell(...)`](/docs/standard_library/emulation/network#netregistercodecell).
+- Use matcher failures as a focused debugger: when `expect(txs).toHaveSuccessfulTx({...})` fails, Acton prints the same trace tree plus the exact search parameters that were not matched.
+- Rerun with `acton test --show-bodies` to print decoded message fields in the terminal tree.
+- Rerun with `acton test --backtrace full` for source locations on compute or action failures.
+- Switch to [`acton test --ui`](/docs/testing/test-ui/overview) when the tree is too large for clickable transactions, fee tables, or grouped logs.

--- a/docs/content/docs/testing/saved-trace-bundles.mdx
+++ b/docs/content/docs/testing/saved-trace-bundles.mdx
@@ -1,10 +1,13 @@
 ---
-title: "Saved Trace Bundles"
+title: "Saved trace bundles"
 description: "Reference for the files produced by `acton test --save-test-trace` and reused by the Test UI"
 ---
 
-`acton test --save-test-trace` writes reusable JSON artifacts for offline inspection.
-The browser Test UI reads the same trace and contract files.
+Pass `--save-test-trace` to [`acton test`](/docs/commands/test) to write reusable JSON artifacts for offline inspection. The browser [Test UI](/docs/testing/test-ui/overview) can read the same trace and contract files.
+
+```bash
+acton test --save-test-trace
+```
 
 ## When bundles are written
 
@@ -30,7 +33,7 @@ build/traces/
 - Contract metadata is stored once per output directory under `contracts/<contract-name>.json`, even when multiple tests reuse the same contract.
 - Filenames are derived only from the test name and contract name. If those names collide across files, later exports overwrite earlier artifacts in the same output directory.
 
-## Root Trace File
+## Root trace file
 
 Each `<test-name>_trace.json` file has this top-level structure:
 
@@ -66,7 +69,7 @@ Each `<test-name>_trace.json` file has this top-level structure:
 - `wallets`: known-address map used to preserve local wallet names such as `deployer` or `sender`.
 - `traces`: logical transaction chains captured during the test.
 
-## Trace Chains
+## Trace chains
 
 Each item in `traces` represents one logical message chain:
 
@@ -97,7 +100,7 @@ Each transaction entry carries both raw and decoded debugging context:
 - `actions`: optional base64-encoded actions cell copied from the trace export. Runtime helpers may decode it later when needed.
 - `dest_contract_info`: contract name hint for lookup in `contracts/<name>.json`.
 
-## Contract Files
+## Contract files
 
 Each `contracts/<contract-name>.json` file stores the metadata needed to decode and inspect transactions:
 
@@ -109,8 +112,8 @@ Each `contracts/<contract-name>.json` file stores the metadata needed to decode 
 
 This lets offline tooling and the Test UI map traces back to source locations and known message layouts.
 
-## Step-by-step Execution
+## Step-by-step execution
 
 Trace export keeps logical chains intact even when execution is split into batches with [`testing.createTraceIterationCursor()`](/docs/standard_library/emulation/testing#testingcreatetraceiterationcursor).
 
-If you run part of a chain with `executeN()` and then continue with `executeAllRemaining()`, Acton merges those batches back into one exported trace when they belong to the same root transaction. Naming any batch with `giveName(...)` keeps that logical trace readable in the final JSON.
+Running part of a chain with `executeN()` and then `executeAllRemaining()` merges those batches back into one exported trace when they share the same root transaction. Naming any batch with `giveName(...)` keeps that logical trace readable in the final JSON.

--- a/docs/content/docs/testing/step-by-step-execution.mdx
+++ b/docs/content/docs/testing/step-by-step-execution.mdx
@@ -1,40 +1,40 @@
 ---
-title: "Step-by-step Execution"
+title: "Step-by-step execution"
 description: "Use testing.createTraceIterationCursor() and TxCursor to execute transaction chains in parts, stop at a matching hop, and interleave multiple cursors"
 ---
 
-[`net.send()`](/docs/standard_library/emulation/network#netsend) eagerly executes the whole transaction chain produced by a message.
-That is the right default for most tests.
+The [`net.send()`](/docs/standard_library/emulation/network#netsend) function eagerly executes the whole transaction chain produced by a message. That is the right default for most tests.
 
-Use [`testing.createTraceIterationCursor()`](/docs/standard_library/emulation/testing#testingcreatetraceiterationcursor) when you need control over *when* later hops execute:
+Alternatively, use [`testing.createTraceIterationCursor()`](/docs/standard_library/emulation/testing#testingcreatetraceiterationcursor) when later hops must run under explicit control:
 
-- inspect the first few transactions of a long cascade
-- assert intermediate state before downstream messages run
-- interleave two independent message chains against the same emulated world
-- discard the remaining tail intentionally
+- Inspect the first few transactions of a long cascade.
+- Assert intermediate state before downstream messages run.
+- Interleave two independent message chains against the same emulated world.
+- Discard the remaining tail intentionally.
 
 <Callout type="tip">
-Prefer [`net.send()`](/docs/standard_library/emulation/network#netsend) unless you specifically need partial execution. It keeps
-tests shorter and easier to read.
+    Prefer [`net.send()`](/docs/standard_library/emulation/network#netsend) unless partial execution is required. It keeps tests shorter and more readable.
 </Callout>
 
 Import `@acton/emulation/testing` in test files that use the cursor APIs from the `testing` namespace.
 
-## Mental Model
+```tolk
+import "@acton/emulation/testing"
+```
 
-[`testing.createTraceIterationCursor(from, message)`](/docs/standard_library/emulation/testing#testingcreatetraceiterationcursor) starts a cursor for one root message and returns a
-[`TxCursor`](/docs/standard_library/emulation/testing#txcursor).
+## Mental model
+
+[`testing.createTraceIterationCursor(from, message)`](/docs/standard_library/emulation/testing#testingcreatetraceiterationcursor) starts a cursor for one root message and returns a [`TxCursor`](/docs/standard_library/emulation/testing#txcursor).
 
 ```tolk
 val iter = testing.createTraceIterationCursor(sender.address, msg);
 ```
 
-The cursor owns the pending tail of that message chain. Every `execute...()`
-call:
+The cursor owns the pending tail of that message chain. Every `execute...()` call:
 
-- runs the next part of the chain
-- mutates the same emulated blockchain state
-- returns only the newly executed segment as `SendResultList`
+- runs the next part of the chain;
+- mutates the same emulated blockchain state;
+- returns only the newly executed segment as `SendResultList`.
 
 The main cursor methods are:
 
@@ -44,10 +44,9 @@ The main cursor methods are:
 - [`isDone()`](/docs/standard_library/emulation/testing#txcursorisdone) — check whether the cursor has no more pending transactions
 - [`close()`](/docs/standard_library/emulation/testing#txcursorclose) — discard the remaining tail
 
-## Execute the First Hop, Then Drain the Rest
+## Execute the first hop, then drain the rest
 
-Suppose a contract forwards a message to another contract and you want to check
-state between the first and second hop.
+Suppose a contract forwards a message and the state should be checked between the first and second hop:
 
 ```tolk
 val forwardMessage = createMessage({
@@ -83,14 +82,11 @@ expect(net.runGetMethod<int>(receiverAddress, "received")).toEqual(1);
 expect(iter.isDone()).toBeTrue();
 ```
 
-This is the main difference from [`net.send()`](/docs/standard_library/emulation/network#netsend): after [`executeN(1)`](/docs/standard_library/emulation/testing#txcursorexecuten), the
-emulator state already reflects the first transaction, while the child message
-is still queued inside the cursor.
+This is the main difference from [`net.send()`](/docs/standard_library/emulation/network#netsend): after [`executeN(1)`](/docs/standard_library/emulation/testing#txcursorexecuten), the emulator state already reflects the first transaction, while the child message is still queued inside the cursor.
 
-## Stop When a Specific Hop Appears
+## Stop when a specific hop appears
 
-Use [`executeTill<Msg>(...)`](/docs/standard_library/emulation/testing#txcursorexecutetill) when you want to run a chain until a particular
-transaction is reached.
+Use [`executeTill<Msg>(...)`](/docs/standard_library/emulation/testing#txcursorexecutetill) to run a chain until a matching transaction appears:
 
 ```tolk
 val routeMessage = createMessage({
@@ -126,17 +122,13 @@ expect(iter.isDone()).toBeFalse();
 
 The matching transaction is included in the returned segment.
 
-When you pass the generic message type, Acton automatically fills the opcode
-part of the search from that message type. You can still narrow the match with
-regular [`SearchParams`](/docs/standard_library/emulation/network#searchparams) filters.
+When the generic message type is supplied, Acton fills the opcode slice of the search from that type. Narrow the match further with regular [`SearchParams`](/docs/standard_library/emulation/network#searchparams) filters.
 
-If no matching transaction is found before the queue is exhausted,
-[`executeTill()`](/docs/standard_library/emulation/testing#txcursorexecutetill) fails the test.
+If no matching transaction is found before the queue is exhausted, [`executeTill()`](/docs/standard_library/emulation/testing#txcursorexecutetill) fails the test.
 
-## Interleave Two Message Chains
+## Interleave two message chains
 
-Each [`testing.createTraceIterationCursor()`](/docs/standard_library/emulation/testing#testingcreatetraceiterationcursor) call creates its own cursor, so you can interleave two
-chains against shared world state.
+Each [`testing.createTraceIterationCursor()`](/docs/standard_library/emulation/testing#testingcreatetraceiterationcursor) call returns its own cursor, so two independent chains can interleave on shared world state.
 
 ```tolk
 val beginMessage = createMessage({
@@ -178,13 +170,11 @@ expect(beginTail).toHaveSuccessfulTx<Finish>({
 expect(beginTail.at(0).parentLt).toEqual(beginFirst.at(0).tx.load().lt);
 ```
 
-This pattern is useful for race conditions, ordering-sensitive flows, and
-"message in the middle" scenarios.
+This pattern is useful for race conditions, ordering-sensitive flows, and "message in the middle" scenarios.
 
-## Discard the Remaining Tail
+## Discard the remaining tail
 
-Use [`close()`](/docs/standard_library/emulation/testing#txcursorclose) when the rest of the chain is irrelevant for the test and you want
-to drop it explicitly.
+Use [`close()`](/docs/standard_library/emulation/testing#txcursorclose) when the rest of the chain is irrelevant to the test and the pending tail should be dropped:
 
 ```tolk
 val forwardMessage = createMessage({
@@ -207,38 +197,31 @@ expect(iter.isDone()).toBeTrue();
 expect(iter.executeAllRemaining()).toBeEmpty();
 ```
 
-Closing the cursor discards any pending internal tail that has not been executed
-yet.
+Closing the cursor discards any pending internal tail that has not been executed yet.
 
-## What You Get Back
+## Shape of the return
 
-Every `execute...()` call returns the same result shape you already know from
-[`net.send()`](/docs/standard_library/emulation/network#netsend): a [`SendResultList`](/docs/standard_library/emulation/network#sendresultlist).
+Every `execute...()` call returns the same result shape as [`net.send()`](/docs/standard_library/emulation/network#netsend): a [`SendResultList`](/docs/standard_library/emulation/network#sendresultlist).
 
-That means you can keep using the usual tools:
+That means the usual tools still apply:
 
 - transaction matchers such as [`toHaveTx()`](/docs/standard_library/emulation/network#expectationsendresultlisttohavetx) and [`toHaveSuccessfulTx()`](/docs/standard_library/emulation/network#expectationsendresultlisttohavesuccessfultx)
 - direct access to `tx`, `parentLt`, `childTxs`, `outMessages`, and `externals`
 - `println(segment)` to inspect the executed batch in the terminal
 
-This also makes it easy to split one logical scenario into several assertions
-without inventing a second assertion API just for step-by-step execution.
+The same layout also supports splitting one scenario into several assertions without a separate assertion API for partial runs.
 
-## Limits and Caveats
+## Limits and caveats
 
-- [`testing.createTraceIterationCursor()`](/docs/standard_library/emulation/testing#testingcreatetraceiterationcursor) is available only in emulation mode. It is not a broadcast
-  workflow.
+- [`testing.createTraceIterationCursor()`](/docs/standard_library/emulation/testing#testingcreatetraceiterationcursor) is available only in emulation mode. It is not a broadcast workflow.
 - Step-by-step execution is not supported in debug mode yet.
 - [`executeN(0)`](/docs/standard_library/emulation/testing#txcursorexecuten) is a no-op and leaves the cursor untouched.
 - [`executeTill()`](/docs/standard_library/emulation/testing#txcursorexecutetill) fails if the queue is exhausted before a match is found.
 - [`close()`](/docs/standard_library/emulation/testing#txcursorclose) discards pending work; it does not roll the state back.
 
-If you need rollback or checkpoints together with partial execution, combine
-[`testing.createTraceIterationCursor()`](/docs/standard_library/emulation/testing#testingcreatetraceiterationcursor) with
-[`testing.saveSnapshot()`](/docs/standard_library/emulation/testing#testingsavesnapshot) and [`testing.loadSnapshot()`](/docs/standard_library/emulation/testing#testingloadsnapshot), or see [World State Snapshots](/docs/testing/world-state-snapshots).
+For rollback or checkpoints together with partial execution, combine [`testing.createTraceIterationCursor()`](/docs/standard_library/emulation/testing#testingcreatetraceiterationcursor) with [`testing.saveSnapshot()`](/docs/standard_library/emulation/testing#testingsavesnapshot) and [`testing.loadSnapshot()`](/docs/standard_library/emulation/testing#testingloadsnapshot), or see [world state snapshots](/docs/testing/world-state-snapshots).
 
-## See Also
+## See also
 
-- [Reading Transaction Chains](/docs/testing/reading-transaction-chains)
-- [Test UI](/docs/testing/test-ui/overview)
-- [network reference](/docs/standard_library/emulation/network)
+- [Reading transaction chains](/docs/testing/reading-transaction-chains)
+- [`@acton/emulation/network` reference](/docs/standard_library/emulation/network)

--- a/docs/content/docs/testing/test-attributes.mdx
+++ b/docs/content/docs/testing/test-attributes.mdx
@@ -1,13 +1,13 @@
 ---
-title: "Test Attributes"
+title: "Test attributes"
 description: "Learn how to use test attributes to control test behavior, skip tests, and set expectations"
 ---
 
-Test runner supports various attributes that allow you to control test behavior, set expectations, and organize your test suite. Attributes are specified using dotted `@test.*` annotations and can be applied to any test function.
+The test runner reads dotted `@test.*` annotations on test functions to control execution, expectations, and status reporting.
 
 Only dotted `@test.*` syntax is supported by the test runner. Legacy `@test(...)` forms are ignored.
 
-## The @test Annotation
+## The `@test` Annotation
 
 Test attributes are specified using the `@test` annotation namespace:
 
@@ -33,7 +33,7 @@ get fun `test with gas limit`() {
 }
 ```
 
-You can combine multiple attributes by stacking annotations:
+Stack multiple attributes on the same function:
 
 ```tolk
 @test.fail_with(13)
@@ -45,19 +45,21 @@ get fun `test complex validation`() {
 }
 ```
 
-## Available Attributes
+## Available attributes
 
-### skip
+### `skip`
 
-Skips the test execution. The test won't run but will be counted in the test summary.
+Skips the test. The test does not run but still appears in the summary.
 
-**Syntax:**
+Syntax:
+
 ```tolk
 @test.skip
 @test.skip("Custom description")
 ```
 
-**Examples:**
+Examples:
+
 ```tolk
 @test.skip
 get fun `test broken for now`() {
@@ -70,23 +72,25 @@ get fun `test blocked on parser refactor`() {
 }
 ```
 
-**Output:**
+Output:
+
 ```
 ○ test broken for now skipped
 ○ test blocked on parser refactor [waiting for parser cleanup]
 ```
 
-### todo
+### `todo`
 
-Marks the test as a work-in-progress item. The test won't run and will be counted as TODO in the summary.
+Marks the test as TODO. The test does not run and is counted in the TODO summary line.
 
-**Syntax:**
+Syntax:
+
 ```tolk
 @test.todo
 @test.todo("Custom description")
 ```
 
-**Examples:**
+Examples:
 
 ```tolk
 @test.todo
@@ -100,22 +104,25 @@ get fun `test depends on external api`() {
 }
 ```
 
-**Output:**
+Output:
+
 ```
 □ test new feature [TODO]
 □ test depends on external api [Waiting for API changes]
 ```
 
-### fail_with
+### `fail_with`
 
-Sets the expected exit code for the test. By default, tests expect exit code 0 (success). Use this attribute when your test is supposed to fail with a specific exit code.
+Sets the expected exit code. The default expected exit code is `0` (success). Use `fail_with` when the test should end with a different exit code.
 
-**Syntax:**
+Syntax:
+
 ```tolk
 @test.fail_with(<number>)
 ```
 
-**Example:**
+Example:
+
 ```tolk
 @test.fail_with(42)
 get fun `test expects failure`() {
@@ -123,21 +130,24 @@ get fun `test expects failure`() {
 }
 ```
 
-**Use cases:**
-- Testing error conditions
-- Validating that certain operations fail as expected
-- Testing custom error codes in your contract logic
+Typical uses:
 
-### gas_limit
+- Testing error conditions.
+- Validating that certain operations fail as expected.
+- Testing custom error codes in contract logic.
 
-Sets a maximum gas limit for the test. If the test consumes more gas than specified, it will fail.
+### `gas_limit`
 
-**Syntax:**
+Sets a maximum gas limit. If the test uses more gas than the limit, it fails.
+
+Syntax:
+
 ```tolk
 @test.gas_limit(<number>)
 ```
 
-**Example:**
+Example:
+
 ```tolk
 @test.gas_limit(1000)
 get fun `test efficient algorithm`() {
@@ -147,17 +157,18 @@ get fun `test efficient algorithm`() {
 }
 ```
 
-**Use cases:**
-- Performance testing and optimization
-- Ensuring algorithms stay within gas bounds
-- Preventing gas-related regressions
+Typical uses:
 
-### fuzz
+- Performance testing and optimization.
+- Ensuring algorithms stay within gas bounds.
+- Preventing gas-related regressions.
 
-Enables fuzzing for a parameterized test. The runner generates input values from
-the test ABI and executes the same test multiple times.
+### `fuzz`
 
-**Syntax:**
+Enables fuzzing for a parameterized test. The runner generates input values from the test ABI and executes the same test multiple times.
+
+Syntax:
+
 ```tolk
 @test.fuzz
 // or
@@ -166,7 +177,8 @@ the test ABI and executes the same test multiple times.
 @test.fuzz({ runs: <runs>, max_test_rejects: <number>, seed: <number> })
 ```
 
-**Examples:**
+Examples:
+
 ```tolk
 @test.fuzz
 get fun `test default fuzz runs`(value: int) {
@@ -185,23 +197,22 @@ get fun `test custom fuzz budget`(value: int) {
 }
 ```
 
-**Notes:**
+Notes:
+
 - `fuzz` is valid only for tests with parameters
 - parameterized tests require explicit fuzz opt-in
 - `@test.fuzz` uses defaults from `[test.fuzz]` in `Acton.toml`
 - `@test.fuzz({ ... })` overrides individual fuzz settings for that test
 - `seed` can be set in `[test.fuzz]` or in `@test.fuzz({ seed: ... })`
 - legacy `@test({ fuzz: ... })` is ignored by the runner
-- for assumptions and bounds, import `@acton/testing/fuzz` and use
-  `fuzz.assume(...)` / `fuzz.bound(...)`
+- for assumptions and bounds, import `@acton/testing/fuzz` and use `fuzz.assume(...)` / `fuzz.bound(...)`
 
-See [Fuzz Testing](/docs/testing/fuzz-testing) for the execution model,
-supported types, helper APIs, and configuration details.
+See the [fuzz testing](/docs/testing/fuzz-testing) guide for the execution model, supported types, helper APIs, and configuration details.
 
-## Best Practices
+## Guidelines
 
-1. Use `skip` for temporarily disabled tests — Better than commenting out the entire test function
-2. Use `todo` with descriptions — Makes it clear what needs to be implemented
-3. Set `fail_with` for error testing — Ensures your error handling works correctly
-4. Use `gas_limit` for performance-critical code — Prevents performance regressions
-5. Use `fuzz` only with explicit intent — Keep the annotation on tests that are meant to explore input space
+1. Prefer `skip` over commenting out a whole test when disabling it temporarily.
+2. Prefer `todo` with a short description so the summary states what is missing.
+3. Use `fail_with` when asserting on expected non-zero exit codes.
+4. Use `gas_limit` when a test should guard against gas regressions.
+5. Apply `fuzz` only on parameterized tests that intentionally explore the input space.

--- a/docs/content/docs/testing/test-configuration.mdx
+++ b/docs/content/docs/testing/test-configuration.mdx
@@ -1,30 +1,30 @@
 ---
-title: "Test Configuration"
+title: "Test configuration"
 description: "Learn how to configure test runner behavior through project settings and command line options"
 ---
 
-Test runner provides flexible configuration options that allow you to set default test behavior in your project configuration file and override it as needed via command line flags. This approach helps maintain consistent testing practices across your project while still allowing per-run customization.
+Default test behavior is set in `Acton.toml`. Command-line flags override those defaults for a single run.
 
-## Configuration Methods
+## Configuration methods
 
 Acton supports two methods for configuring test behavior:
 
-1. **Project Configuration** — Set defaults in `Acton.toml` for consistent behavior
-2. **Command Line Flags** — Override configuration for specific test runs
+- Project configuration: set defaults in `Acton.toml`.
+- Command-line flags: override defaults for a specific run.
 
-### Configuration Precedence
+### Configuration precedence
 
 When both methods are used, the precedence order is:
 
-1. **Command line flags** (highest priority) — override everything
-2. **Acton.toml settings** (medium priority) — project defaults
-3. **Built-in defaults** (lowest priority) — fallback values
+1. Command line flags (highest priority) — override everything.
+2. `Acton.toml` settings (medium priority) — project defaults.
+3. Built-in defaults (lowest priority) — fallback values.
 
-## Project Configuration in Acton.toml
+## Project configuration in `Acton.toml`
 
-### Basic Configuration
+### Basic configuration
 
-Add a `[test]` section to your `Acton.toml` file to configure default test behavior:
+Add a `[test]` section to `Acton.toml` to set default test behavior:
 
 ```toml title="Acton.toml"
 [package]
@@ -47,9 +47,9 @@ enabled = true
 format = "lcov"
 ```
 
-## Command Line Override
+## Command-line overrides
 
-Any configuration option can be overridden via command line flags:
+Any configuration option can be overridden with command-line flags:
 
 ```bash
 # Use specific reporter
@@ -77,9 +77,9 @@ acton test --reporter teamcity
 acton test --coverage --filter "test deploy" --debug --reporter junit
 ```
 
-## Configuration Options Reference
+## Configuration options reference
 
-### Filter Options
+### Filter options
 
 | Configuration | CLI Flag    | Type   | Description                              |
 |---------------|-------------|--------|------------------------------------------|
@@ -87,46 +87,51 @@ acton test --coverage --filter "test deploy" --debug --reporter junit
 | `exclude`     | `--exclude` | Array  | Glob patterns to exclude test files      |
 | `include`     | `--include` | Array  | Glob patterns to include only test files |
 
-**Examples:**
+Examples:
+
 ```toml
 [test]
-filter = ".*wallet.*"              # Only get fun `...wallet...`
+filter = ".*wallet.*"              # Only tests whose names have "wallet" within
 exclude = ["**/integration/**"]    # Skip integration directory
 include = ["**/unit/**"]           # Only include unit test files
 ```
 
-### Execution Options
+### Execution options
 
 | Configuration | CLI Flag      | Type    | Description                                  |
 |---------------|---------------|---------|----------------------------------------------|
 | `fail-fast`   | `--fail-fast` | Boolean | Stop executing tests after the first failure |
 
-**Examples:**
+Examples:
+
 ```toml
 [test]
 fail-fast = true
 ```
 
-### Reporter Options
+### Reporter options
 
 | Configuration | CLI Flag      | Type  | Description                          |
 |---------------|---------------|-------|--------------------------------------|
 | `reporter`    | `--reporter`  | Array | Test output format(s)                |
 
-**Supported reporters:**
+Supported reporters:
+
 - `console` — Detailed console output with code context (default)
 - `teamcity` — TeamCity CI integration (minimal output, best combined with console)
 - `junit` — JUnit XML reports for external tools
 - `dot` — Compact dot-style progress with detailed failure diagnostics at the end
 
-<Callout type="info" title="TeamCity Integration">
-When using TeamCity CI, combine `teamcity` with `console` reporter to see detailed test output alongside CI integration data.
-```bash
-acton test --reporter console,teamcity
-```
+<Callout type="info" title="TeamCity integration">
+    For TeamCity CI, combine the `teamcity` and `console` reporters so detailed test output appears alongside CI integration data.
+
+    ```bash
+    acton test --reporter console,teamcity
+    ```
 </Callout>
 
-**Examples:**
+Examples:
+
 ```toml
 [test]
 # Use multiple reporters
@@ -142,7 +147,7 @@ reporter = ["dot"]
 reporter = ["console", "teamcity"]
 ```
 
-### Debug Options
+### Debug options
 
 | Configuration | CLI Flag          | Type    | Description                                   |
 |---------------|-------------------|---------|-----------------------------------------------|
@@ -151,11 +156,10 @@ reporter = ["console", "teamcity"]
 | `backtrace`   | `--backtrace`     | String  | Enable stack traces ("full")                  |
 | `-`           | `--verbose`       | Count   | Enable level-1 executor debug logs (CLI only) |
 
-`--verbose` is currently binary in practice: default level `0`, and level `1`
-when `--verbose` is passed once. Higher user-selected levels are not
-supported yet.
+`--verbose` is currently binary in practice: default level `0`, and level `1` when `--verbose` is passed once. Higher user-selected levels are not supported yet.
 
-**Examples:**
+Examples:
+
 ```toml
 [test]
 debug = false
@@ -167,7 +171,7 @@ backtrace = "full"
 acton test --verbose --filter "debug.*"
 ```
 
-### Coverage Options
+### Coverage options
 
 | Configuration                      | CLI Flag                      | Type    | Description                                                    |
 |------------------------------------|-------------------------------|---------|----------------------------------------------------------------|
@@ -177,7 +181,8 @@ acton test --verbose --filter "debug.*"
 | `[test.coverage].include-wrappers` | `--coverage-include-wrappers` | Boolean | Include files from the `@wrappers` mapping in coverage reports |
 | `[test.coverage].include-tests`    | `--coverage-include-tests`    | Boolean | Include `.test.tolk` files in coverage reports                 |
 
-**Examples:**
+Examples:
+
 ```toml
 [test.coverage]
 enabled = true
@@ -186,16 +191,12 @@ include-wrappers = true
 include-tests = true
 ```
 
-### Fuzz Options
+### Fuzz options
 
-These defaults apply only to parameterized tests that explicitly opt in with
-`@test.fuzz`, `@test.fuzz(<runs>)`, or `@test.fuzz({ ... })`.
-Per-test annotations can override them with
-`@test.fuzz({ runs: ..., max_test_rejects: ..., seed: ... })`.
-When `max-test-rejects` is omitted, Acton uses `runs * 256`.
+These defaults apply only to parameterized tests that explicitly opt in with `@test.fuzz`, `@test.fuzz(<runs>)`, or `@test.fuzz({ ... })`. Per-test annotations can override them with
+`@test.fuzz({ runs: ..., max_test_rejects: ..., seed: ... })`. When `max-test-rejects` is omitted, Acton uses `runs * 256`.
 
-See [Fuzz Testing](/docs/testing/fuzz-testing) for annotation syntax,
-helper APIs, supported parameter types, and failure reporting.
+See the [fuzz testing](/docs/testing/fuzz-testing) guide for annotation syntax, helper APIs, supported parameter types, and failure reporting.
 
 | Configuration                    | CLI Flag | Type    | Description                                                        |
 |----------------------------------|----------|---------|--------------------------------------------------------------------|
@@ -203,7 +204,8 @@ helper APIs, supported parameter types, and failure reporting.
 | `[test.fuzz].max-test-rejects`   | -        | Integer | Maximum `assume(...)` rejections before the fuzz test fails        |
 | `[test.fuzz].seed`               | `--fuzz-seed` | Integer | Seed for reproducible fuzz input generation                    |
 
-**Examples:**
+Examples:
+
 ```toml
 [test.fuzz]
 runs = 512
@@ -211,7 +213,7 @@ max-test-rejects = 4096
 seed = 42
 ```
 
-### Profiling Options
+### Profiling options
 
 | Configuration  | CLI Flag         | Type    | Description                                                           |
 |----------------|------------------|---------|-----------------------------------------------------------------------|
@@ -220,7 +222,8 @@ seed = 42
 `fail-on-diff` is applied when running baseline comparison mode with
 `--baseline-snapshot <FILE>`.
 
-**Examples:**
+Examples:
+
 ```toml
 [test]
 fail-on-diff = true
@@ -230,43 +233,44 @@ fail-on-diff = true
 acton test --baseline-snapshot gas-baseline.json --fail-on-diff
 ```
 
-### JUnit Options
+### JUnit options
 
 | Configuration     | CLI Flag        | Type    | Description                      |
 |-------------------|-----------------|---------|----------------------------------|
 | `junit-path`      | `--junit-path`  | String  | JUnit XML output directory       |
 | `junit-merge`     | `--junit-merge` | Boolean | Merge all suites into one file   |
-| `fork-net`        | `--fork-net`    | String  | Network to fork from             |
 
-### Fork Testing Options
+Examples:
+
+```toml
+[test]
+# Custom JUnit output directory
+junit-path = "custom-reports"
+junit-merge = true
+```
+
+### Fork testing options
 
 | Configuration       | CLI Flag              | Type      | Description                                                                                          |
 |:--------------------|:----------------------|:----------|:-----------------------------------------------------------------------------------------------------|
 | `fork-net`          | `--fork-net`          | `string`  | Network name to fork state from (`mainnet`, `testnet`, or a custom network defined in `[networks]`). |
 | `fork-block-number` | `--fork-block-number` | `integer` | Specific block number to fork from.                                                                  |
 
-**Examples:**
+Examples:
+
 ```toml
 [test]
 fork-net = "mainnet"
 ```
 
-Use `TONCENTER_TESTNET_API_KEY` or `TONCENTER_MAINNET_API_KEY` in the
-environment when the built-in fork target needs TonCenter authentication.
+Use `TONCENTER_TESTNET_API_KEY` or `TONCENTER_MAINNET_API_KEY` to supply fork targets with higher RPS limits.
 
 Using a custom network:
+
 ```toml
 [networks.my-local-node]
 api = { v2 = "http://localhost:8081/api/v2/jsonRPC" }
 
 [test]
 fork-net = "my-local-node"
-```
-
-**Examples:**
-```toml
-[test]
-# Custom JUnit output directory
-junit-path = "custom-reports"
-junit-merge = true
 ```

--- a/docs/content/docs/testing/test-ui/overview.mdx
+++ b/docs/content/docs/testing/test-ui/overview.mdx
@@ -3,14 +3,11 @@ title: "Overview"
 description: "Navigate Test UI docs by choosing quickstart or full reference"
 ---
 
-Test UI is a browser interface for reviewing completed `acton test` runs with
-traces, transaction trees, logs, source links, and coverage data when tests are
-run with `--coverage`.
+Test UI is a browser interface for reviewing completed `acton test` runs with traces, transaction trees, logs, source links, and coverage data when tests are run with `--coverage`.
 
 <Cards>
   <Card href="/docs/testing/test-ui/quickstart" title="Quickstart">
-    Run `acton test --ui`, inspect failed tests, and navigate Info,
-    Transactions, Logs, and Coverage tabs.
+    Run `acton test --ui`, inspect failed tests, and navigate Info, Transactions, Logs, and Coverage tabs.
   </Card>
   <Card href="/docs/testing/test-ui/reference" title="Reference">
     Full feature reference for all Test UI sections, controls, and panels.

--- a/docs/content/docs/testing/test-ui/quickstart.mdx
+++ b/docs/content/docs/testing/test-ui/quickstart.mdx
@@ -3,7 +3,7 @@ title: "Quickstart"
 description: "Step-by-step guide to run Test UI and inspect failed tests, traces, transactions, and logs"
 ---
 
-This quickstart shows how to go from `acton test --ui` to diagnosing a failed test.
+The `acton test --ui` runs the suite, opens the browser UI, and surfaces failed tests, traces, and logs.
 
 ## 1. Run tests with UI
 
@@ -24,8 +24,7 @@ acton test tests/counter.test.tolk --ui --filter "test deploy"
 acton test --coverage --ui
 ```
 
-If you start Test UI with both `--coverage` and `--ui`, an additional
-`Coverage` tab appears next to the regular test results view.
+With both `--coverage` and `--ui`, an extra `Coverage` tab appears next to the regular test results view.
 
 ## 2. Open failed test first
 

--- a/docs/content/docs/testing/test-ui/reference.mdx
+++ b/docs/content/docs/testing/test-ui/reference.mdx
@@ -3,9 +3,7 @@ title: "Reference"
 description: "Complete reference for all Test UI features and interface sections"
 ---
 
-Test UI is a browser interface for reviewing completed `acton test` runs with
-traces, transaction trees, logs, source links, and coverage data when the run
-includes `--coverage`.
+Test UI is a browser interface for reviewing completed `acton test` runs with traces, transaction trees, logs, source links, and coverage data when the run includes `--coverage`.
 
 ## 1. Start Test UI
 
@@ -39,15 +37,16 @@ acton test --coverage --ui
   `--coverage` and `--ui`.
 </Callout>
 
-## 2. Sidebar Features
+## 2. Sidebar features
 
-### Test Search and Status Filters
+### Test search and status filters
 
 - Text filter (`Filter tests...`) matches test names
 - Status toggles for all statuses: `Passed`, `Failed`, `Skipped`, `Todo`
-- You can combine text + status filters
 
-### Suite/Test Navigation
+Both can be used simultaneously.
+
+### Suite and test navigation
 
 - Tests are grouped by files
 - Each suite can be collapsed/expanded
@@ -57,14 +56,14 @@ acton test --coverage --ui
 
 ![Sidebar filters with text search and status toggles](../imgs/test-ui-filters.png)
 
-### Sidebar Controls
+### Sidebar controls
 
 - Theme toggle (`light`/`dark`)
 - Collapse sidebar button
 
 ![Sidebar controls with theme toggle and collapse button](../imgs/test-ui-sidebar-controls.png)
 
-## 3. Test Header and IDE Integration
+## 3. Test header and IDE integration
 
 The selected test header contains:
 
@@ -82,7 +81,7 @@ Supported IDE deep links include Cursor, VS Code-family, and JetBrains IDEs.
 
 ![IDE selector dropdown in test header with quick-open action](../imgs/test-ui-ide-selector.png)
 
-## 4. Info Tab
+## 4. Info tab
 
 The `Info` tab includes:
 
@@ -91,20 +90,19 @@ The `Info` tab includes:
 - file location (`file:line:column`)
 - duration and total transaction count
 
-### Failure Diagnostics
+### Failure diagnostics
 
 For failed tests, Info tab also shows:
 
 - error message block
 - detailed matcher/exit-code message
-- structured mismatch context for transaction assertions
-  (`from`, `to`, and matcher params)
+- structured mismatch context for transaction assertions (`from`, `to`, and matcher params)
 - failed transaction tree (if available)
 - highlighted source snippet around failure location
 
 ![Failed test details with error block, mismatch context, and highlighted source snippet](../imgs/test-ui-failed-test.png)
 
-### Fee Summary
+### Fee summary
 
 If traces are available, Info tab also shows `Fee Summary` table per trace:
 
@@ -115,34 +113,31 @@ If traces are available, Info tab also shows `Fee Summary` table per trace:
 
 Clicking a trace row opens that trace in `Transactions` tab.
 
-For baseline and regression-oriented fee analysis, see
-[Gas Profiling with Snapshots](/docs/testing/gas-profiling-with-snapshots).
+For baseline and regression-oriented fee analysis, see the [gas profiling with snapshots](/docs/testing/gas-profiling-with-snapshots) page.
 
 <Callout type="tip">
-Name trace chains in tests with
-[`txs.giveName(...)`](/docs/standard_library/emulation/network#sendresultlistgivename) to make trace
-tabs and fee summaries easier to read.
+  Name trace chains in tests with [`txs.giveName(...)`](/docs/standard_library/emulation/network#sendresultlistgivename) to make trace tabs and fee summaries easier to read.
 </Callout>
 
 ![Fee Summary table with per-trace gas, forward fee, and total fee columns](../imgs/test-ui-fees.png)
 
-## 5. Transactions Tab
+## 5. Transactions tab
 
 If a test has trace data, Transactions tab provides full tree visualization.
 
-### Trace Switcher
+### Trace switcher
 
 - When a test has multiple traces, tabs appear above content
 - Selecting a trace updates tree and details
 
-### Transaction Tree
+### Transaction tree
 
 - Horizontal transaction tree with root blockchain node
 - Node color indicates success/failure
 - Dashed edges indicate bounced messages
 - Hover tooltip shows route, state transition, and gas/exit-code details
 
-### Transaction Details Panel
+### Transaction details panel
 
 Clicking a node opens detailed transaction view below tree:
 
@@ -153,7 +148,7 @@ Clicking a node opens detailed transaction view below tree:
 
 ![Transactions tab with trace tree and selected transaction details](../imgs/test-ui-transactions-tree.png)
 
-### Actions Details
+### Actions details
 
 When action phase has out actions:
 
@@ -163,23 +158,20 @@ When action phase has out actions:
 
 ![Actions panel showing out actions and expanded action details](../imgs/test-ui-actions.png)
 
-## 6. Logs Tab
+## 6. Logs tab
 
 Logs tab shows `Executor Log` and `VM Log` grouped by transaction for the selected trace. If a transaction has no logs, it is skipped; if all VM logs are missing for the selected trace, UI shows a hint to rerun with `acton test --ui --verbose`.
 
 ![Logs tab with Executor Log and VM Log grouped by transaction](../imgs/test-ui-logs.png)
 
-## 7. Coverage Tab
+## 7. Coverage tab
 
 When the run includes `acton test --coverage --ui`, Test UI adds a dedicated
-`Coverage` tab.
-
-The Coverage view includes:
+`Coverage` tab with:
 
 - summary cards for overall coverage
 - file list sorted by coverage score
 - source viewer with annotated covered and uncovered lines
 - search field for filtering files
 
-Use this tab when you want a fast visual pass over untested areas without
-leaving the browser UI.
+The `Coverage` tab supports a quick visual scan of uncovered lines without leaving the browser UI.

--- a/docs/content/docs/testing/world-state-snapshots.mdx
+++ b/docs/content/docs/testing/world-state-snapshots.mdx
@@ -1,18 +1,18 @@
 ---
-title: "World State Snapshots"
+title: "World state snapshots"
 description: "Save and restore test runner world state as JSON fixtures with testing.saveSnapshot() and testing.loadSnapshot()"
 ---
 
-World state snapshots let you capture the current emulation state during a test and restore it later from a JSON file.
+World state snapshots capture the current emulation state during a test and restore it later from a JSON file.
 
-This is useful when you want to:
+This is useful to:
 
-- reuse a complex setup across multiple test runs
-- freeze a real regression scenario as a fixture
-- checkpoint state mid-test and return to it later
-- debug stateful flows without repeating the full bootstrap sequence every time
+- reuse a complex setup across multiple test runs;
+- freeze a real regression scenario as a fixture;
+- checkpoint state mid-test and return to it later;
+- debug stateful flows without repeating the full bootstrap sequence every time.
 
-## Quick Start
+## Quick start
 
 Save the current emulation state:
 
@@ -47,7 +47,7 @@ get fun `test load snapshot`() {
 }
 ```
 
-## What snapshot stores
+## Snapshot contents
 
 The snapshot file stores the local emulation state needed for deterministic replay:
 
@@ -58,7 +58,7 @@ The snapshot file stores the local emulation state needed for deterministic repl
 - materialized account state
 
 <Callout type="info" title="Snapshots store state, not cache noise">
-Read-only cache misses such as checking balance on an unknown address are not persisted into the snapshot file.
+    Read-only cache misses such as checking balance on an unknown address are not persisted into the snapshot file.
 </Callout>
 
 ## Cross-run workflow
@@ -81,7 +81,7 @@ This works well for expensive setup flows, multi-contract fixtures, and regressi
 
 ## Same-run restore
 
-You can also use snapshots as checkpoints inside a single test:
+Snapshots can also checkpoint state inside one test:
 
 ```tolk
 import "@acton/emulation/network"
@@ -102,7 +102,7 @@ get fun `test checkpoint and restore`() {
 }
 ```
 
-`testing.loadSnapshot(...)` replaces the current local emulation state instead of merging into it.
+There, `testing.loadSnapshot(...)` replaces the current local emulation state instead of merging into it.
 
 ## Failure handling
 
@@ -122,13 +122,12 @@ If loading fails, the current world state is left unchanged.
 
 ## Limitations
 
-- snapshots restore the local emulation state only
-- loading a snapshot switches execution to local state, not fork mode
-- snapshot file paths are regular host file paths relative to the project working directory
-- if you intentionally change storage layout or config assumptions, an old snapshot may stop being compatible
+- Snapshots restore the local emulation state only.
+- Loading a snapshot switches execution to local state, not fork mode.
+- Snapshot file paths are regular host file paths relative to the project working directory.
+- If storage layout or config assumptions change on purpose, an older snapshot may stop loading.
 
-## Learn more
+## Related topics
 
-- [Fork Testing](/docs/testing/fork-testing)
-- [Gas Profiling with Snapshots](/docs/testing/gas-profiling-with-snapshots)
-- [Persistence and Snapshots for localnet](/docs/localnet/persistence-and-snapshots)
+- [Fork testing](/docs/testing/fork-testing)
+- [Gas profiling with snapshots](/docs/testing/gas-profiling-with-snapshots)

--- a/docs/content/docs/testing/writing-your-own-matchers.mdx
+++ b/docs/content/docs/testing/writing-your-own-matchers.mdx
@@ -1,20 +1,17 @@
 ---
-title: "Custom Matchers"
+title: "Custom matchers"
 description: "Learn how to add custom matchers for expect() calls"
 ---
 
-This guide will walk you through creating your own custom matchers for `expect()` assertions. Custom matchers allow you to extend the standard set of assertions with your own domain-specific logic, making your tests more readable and expressive.
+Custom matchers extend `expect()` with project-specific checks while keeping the fluent `expect(...).matcher(...)` style.
 
-<Callout type="info">
-Before writing a custom matcher, check
-[Built-in Matchers and Helpers](/docs/testing/built-in-matchers-and-helpers).
-Acton already provides built-in transaction matchers, map expectations, and
-out-action helpers that often cover the common cases.
+<Callout>
+    Before writing a custom matcher, review [built-in matchers and helpers](/docs/testing/built-in-matchers-and-helpers). Acton already ships transaction matchers, map expectations, and out-action helpers for many workflows.
 </Callout>
 
-## The Problem with Standalone Check Functions
+## Standalone check helpers are vague and poorly readable
 
-Imagine you have some validation logic that you want to extract into a function. By extracting it into a function, you'll get code like this:
+Validation logic extracted into a plain helper often reads like this:
 
 ```tolk
 import "@acton/testing/expect"
@@ -31,11 +28,11 @@ get fun `test unit`() {
 }
 ```
 
-This approach works, but it breaks the fluent API pattern of `expect()` and makes tests harder to read. It's not immediately clear what is being asserted.
+That pattern works, but it drops out of the `expect()` fluent chain and hides what is being asserted. This makes tests harder to read.
 
-### The Solution: Custom Matchers
+### Use custom matchers on `Expectation<T>`
 
-This code can be written much more readably and consistently by creating a custom matcher:
+The same check can fit the matcher style as an extension on `Expectation<T>`:
 
 ```tolk
 import "@acton/testing/expect"
@@ -52,19 +49,13 @@ get fun `test unit`() {
 }
 ```
 
-As you can see, instead of a standalone function, we added a new method directly to the `Expectation<int>` type. The `expect()` function returns an instance of `Expectation<T>`, where `T` is the type of the value passed to `expect()`. By extending this type, you can add your own matchers.
+The `expect()` call returns `Expectation<T>` for the wrapped value `T`. Write extension methods on `Expectation<T>` to add custom matchers.
 
-Now using your matcher is no different from standard ones.
+Custom matchers centralize validation logic on `Expectation<T>` so failures stay consistent with the built-in matchers, carefully hiding the implementation details and providing abstractions that are easy to reason about.
 
-<Callout type="info">
-Custom matchers are a powerful way to create reusable validation logic. They keep your tests clean and focused on the business logic rather than implementation details.
-</Callout>
+## Define a matcher
 
-## Creating Custom Matchers
-
-To create a custom matcher, you need to define a function that extends the `Expectation<T>` struct. The `T` is a generic parameter that will be replaced with the actual type of the value you're testing.
-
-Here's a basic structure of a custom matcher:
+A matcher is an extension function on `Expectation<T>`:
 
 ```tolk
 fun Expectation<T>.myCustomMatcher(self, arg1: Type1, arg2: Type2) {
@@ -73,13 +64,13 @@ fun Expectation<T>.myCustomMatcher(self, arg1: Type1, arg2: Type2) {
 }
 ```
 
-### Matchers for Specific Types
+### Matchers for specific types
 
-While you can define generic matchers for `Expectation<T>`, it's often more useful to create matchers for specific data types. This allows you to build powerful, domain-specific assertions.
+Generic matchers on `Expectation<T>` are allowed, whereas matchers on a concrete `T` are often clearer for domain-specific data types.
 
-#### Example: `int` Matcher
+#### Example: even `int` matcher
 
-Let's create a matcher that checks if an integer is even.
+The `toBeEven()` matcher checks if an integer is even:
 
 ```tolk
 import "@acton/testing/expect"
@@ -100,11 +91,12 @@ get fun `test even number`() {
     // expect(9).toBeEven(); // This would fail
 }
 ```
-In this example, `toBeEven` is defined on `Expectation<int>`, so it will only be available when `expect()` is called with an `int`. Inside the matcher, `self.value` holds the integer `10`.
 
-#### Example: `address` Matcher
+Here, `toBeEven` is defined on `Expectation<int>`, so it is available only after `expect()` receives an `int`. Inside the matcher, `self.value` holds that integer, e.g., `10`.
 
-You can create matchers for any type, including complex ones like `address`. Let's create a matcher to check if an address has a specific workchain.
+#### Example: `address` workchain matcher
+
+The `toHaveWorkchain()` matcher checks if an `address` has a specific workchain:
 
 ```tolk
 import "@acton/testing/expect"
@@ -131,9 +123,9 @@ get fun `test address workchain`() {
 }
 ```
 
-#### Example: `string` Matcher
+#### Example: `string` length matcher
 
-Here is how you can write a matcher for a `string` to check if it has desired length.
+The `toHaveLength()` matcher checks if a `string` is of desired length:
 
 ```tolk
 import "@acton/testing/expect"
@@ -159,11 +151,11 @@ get fun `test string len`() {
 }
 ```
 
-## Matchers for Custom Structs
+## Matchers for structs
 
-You can create matchers for any custom type in your project including structs. This is a great way to build a domain-specific testing language that makes your tests more readable.
+Matches can be created for any custom type, including structures.
 
-Let's say you have a `User` struct:
+Start from a sample struct:
 
 ```tolk
 struct User {
@@ -173,14 +165,14 @@ struct User {
 }
 ```
 
-Now, let's create a matcher to verify that a user is active.
+Add a matcher `toBeActive()` that asserts `isActive` is true:
 
 ```tolk
 import "@acton/testing/expect"
 import "@acton/testing/assert"
 import "@acton/fmt"
 
-// Assume User struct is defined here or imported
+// NOTE: Assume User struct is defined here or imported
 
 fun Expectation<User>.toBeActive(self) {
     if (!self.value.isActive) {
@@ -200,53 +192,56 @@ get fun `test user status`() {
 }
 ```
 
-## Leveraging `Assert`
+## Use `Assert` inside matchers
 
-Inside your custom matchers, you can use the `Assert` library to perform checks and produce descriptive error messages. This is the preferred way to report assertion failures.
+Inside custom matchers, use the `Assert` type from the `@acton/testing/assert` library to perform checks and produce descriptive error messages. This is the preferred way to report assertion failures.
 
-The `Assert.fail()` function is particularly useful for providing custom error messages. It takes the error message and an optional `location` parameter, which is available as `self.location` in your matcher. The testing framework uses this location to point to the exact line in your test where the assertion failed.
+```tolk
+import "@acton/testing/assert"
+```
+
+The `Assert.fail(message, location)` is the usual choice for custom error messages. Pass the error message as the first argument, and `self.location` as the second, so the runner could point to the exact line where the assertion is made when that assertion fails.
 
 ```tolk
 fun Expectation<int>.toBePositive(self) {
     if (self.value <= 0) {
         Assert.fail(
             format("Expected {} to be a positive number", self.value),
-            self.location // Pass the location for better error reporting
+            // Pass the location to attribute the failure to the code of this assertion
+            self.location,
         );
     }
 }
 ```
 
-By using `Assert` functions, your custom matchers will integrate seamlessly with the test runner, providing consistent and helpful output on failures.
+With `Assert` functions, custom matchers provide consistent and helpful runner output.
 
-## Best Practices
+## Guidelines
 
-Here are some tips to help you write effective and maintainable custom matchers.
+### Clear error messages
 
-### Providing Clear Error Messages
+On failure, state both the expectation and the observed value. Including actual values and error locations in assertions helps with debugging.
 
-A good matcher is only as good as its error message. When an assertion fails, the message should clearly explain what was expected and what was actually received.
+Bad:
 
-**Bad:**
 ```tolk
 Assert.fail("Value is not even");
 ```
 
-**Good:**
+Good:
+
 ```tolk
 Assert.fail(
     format("Expected {} to be even, but it was odd.", self.value),
-    self.location
+    self.location,
 );
 ```
 
-Including the actual value in the error message helps developers debug failures much faster.
+### Group matchers in one module
 
-### Organizing Your Matchers
+As matchers accumulate, keep them in a dedicated module instead of scattering copies across test files. This keeps testing utilities organized and reusable across the project.
 
-As your test suite grows, you'll likely accumulate many custom matchers. Instead of scattering them across your test files, it's a good practice to group them in dedicated files.
-
-For example, you could create a `matchers.tolk` file in your `tests` directory:
+Example layout:
 
 ```
 my-project/
@@ -254,11 +249,11 @@ my-project/
 │   └── ...
 ├── tests/
 │   ├── my_contract.test.tolk
-│   └── matchers.tolk  <-- Your custom matchers
+│   └── matchers.tolk
 └── Acton.toml
 ```
 
-Then, you can import them in your test files where needed:
+Import the shared module from tests:
 
 ```tolk
 import "./matchers"
@@ -267,4 +262,3 @@ get fun `test my`() {
     expect(42).toBeEven();
 }
 ```
-This keeps your testing utilities organized and reusable across your entire project.


### PR DESCRIPTION
Edited all 19 files there, tidying the text and straightening the presentation. Tried my best not to alter the meaning and practically did not introduce anything extra to the existing content. Spotted couple errors and inconsistencies and fixed them.