### PR TITLE
feat(docs): list libraries on overview pages of stdlib references

### DIFF
--- a/docs/content/docs/installation.mdx
+++ b/docs/content/docs/installation.mdx
@@ -7,7 +7,6 @@ icon: Download
 import {Tabs, Tab} from "fumadocs-ui/components/tabs";
 import {Accordion, Accordions} from "fumadocs-ui/components/accordion";
 import {Step, Steps} from "fumadocs-ui/components/steps";
-import {Card, Cards} from "fumadocs-ui/components/card";
 import {SiApple, SiLinux} from "react-icons/si";
 
 ## Overview

--- a/docs/content/docs/standard_library/overview.mdx
+++ b/docs/content/docs/standard_library/overview.mdx
@@ -9,3 +9,73 @@ description: "All available functions, structs, constants, and other entities av
 Acton provides a collection of functions for writing scripts and tests in Tolk.
 
 The Tolk stdlib is documented in [Tolk standard library](/docs/tolk_standard_library/overview).
+
+<Cards>
+    <Card href="/docs/standard_library/build" title="build">
+        Module for building contract code cells.
+    </Card>
+    <Card href="/docs/standard_library/crypto" title="crypto">
+        Module for cryptographic operations.
+    </Card>
+    <Card href="/docs/standard_library/emulation/config" title="config">
+        Module for configuring the emulated blockchain environment.
+    </Card>
+    <Card href="/docs/standard_library/emulation/network" title="network">
+        Module for sending messages to a real or emulated blockchain.
+    </Card>
+    <Card href="/docs/standard_library/emulation/scripts" title="scripts">
+        Module for public API to be used in scripts (interacting with real blockchain).
+    </Card>
+    <Card href="/docs/standard_library/emulation/testing" title="testing">
+        Module for public API to be used in tests (which do NOT interact with real blockchain).
+    </Card>
+    <Card href="/docs/standard_library/env" title="env">
+        Module for accessing environment variables.
+    </Card>
+    <Card href="/docs/standard_library/ffi" title="ffi">
+        Namespace for host-provided functions implemented via `EXTCALL`.
+    </Card>
+    <Card href="/docs/standard_library/fmt" title="fmt">
+        Module for string parsing and formatting.
+    </Card>
+    <Card href="/docs/standard_library/fs" title="fs">
+        Module for file system operations.
+    </Card>
+    <Card href="/docs/standard_library/io" title="io">
+        Module for input/output operations.
+    </Card>
+    <Card href="/docs/standard_library/prompts" title="prompts">
+        Module for user prompts.
+    </Card>
+    <Card href="/docs/standard_library/testing/assert" title="assert">
+        Module for assertion functions.
+    </Card>
+    <Card href="/docs/standard_library/testing/expect" title="expect">
+        Module for high-level assertion API.
+    </Card>
+    <Card href="/docs/standard_library/testing/fuzz" title="fuzz">
+        Module for fuzz-testing helpers.
+    </Card>
+    <Card href="/docs/standard_library/tlb/either" title="either">
+        Represents a TL-B `Either X Y`: either `X` (left) or `Y` (right).
+    </Card>
+    <Card href="/docs/standard_library/tlb/maybe" title="maybe">
+        Represents an optional value (TL-B Maybe) that may or may not be present.
+        This is similar to the Option type in other programming languages.
+    </Card>
+    <Card href="/docs/standard_library/types/array" title="array">
+        This module provides additional methods for builtin `array` type.
+    </Card>
+    <Card href="/docs/standard_library/types/big_array" title="big_array">
+        Module defining `BigArray<T>`
+    </Card>
+    <Card href="/docs/standard_library/types/message" title="message">
+        Module defining message types.
+    </Card>
+    <Card href="/docs/standard_library/types/out_actions" title="out_actions">
+        Module defining out actions.
+    </Card>
+    <Card href="/docs/standard_library/types/transaction" title="transaction">
+        Module defining transaction types.
+    </Card>
+</Cards>

--- a/docs/content/docs/tolk_standard_library/overview.mdx
+++ b/docs/content/docs/tolk_standard_library/overview.mdx
@@ -7,3 +7,14 @@ description: "Bundled Tolk stdlib modules used by Acton standard library"
 {/* Source: `crates/tolk-compiler/assets/tolk-stdlib` */}
 
 This section contains documentation of Tolk standard library.
+
+<Cards>
+    <Card href="/docs/tolk_standard_library/common" title="common" />
+    <Card href="/docs/tolk_standard_library/exotic-cells" title="exotic-cells" />
+    <Card href="/docs/tolk_standard_library/gas-payments" title="gas-payments" />
+    <Card href="/docs/tolk_standard_library/lisp-lists" title="lisp-lists" />
+    <Card href="/docs/tolk_standard_library/reflection" title="reflection" />
+    <Card href="/docs/tolk_standard_library/strings" title="strings" />
+    <Card href="/docs/tolk_standard_library/tvm-dicts" title="tvm-dicts" />
+    <Card href="/docs/tolk_standard_library/tvm-lowlevel" title="tvm-lowlevel" />
+</Cards>

--- a/docs/content/docs/tutorial/overview.mdx
+++ b/docs/content/docs/tutorial/overview.mdx
@@ -3,8 +3,6 @@ title: "Build a poll dApp on TON"
 description: "A hands-on tutorial: from zero to a live, on-chain poll with a React frontend."
 ---
 
-import { Cards, Card } from "fumadocs-ui/components/card";
-
 The "hello world" of smart contracts on most blockchains is a counter contract. Yet, this contract is not sufficient for overcoming two main struggles of contracts on TON: asynchronicity and account limits, especially data and computation limits. The former prevents contracts from directly impacting the state of each over during computation, only allowing asynchronous message exchange.
 
 As for the latter, one cannot place a large hashmap for individual user data in a single contract and expect it to scale. A single contract cannot hold too much data, and cannot perform too much computations in a single transaction initiated by an incoming message. Instead of trying to use a large hashmap, the common approach is to shard the contract by making the parent contract an entry point and a manager of its subsidiary child contracts, where each child contract holds and modifies individual user data.

--- a/docs/content/docs/welcome.mdx
+++ b/docs/content/docs/welcome.mdx
@@ -3,7 +3,6 @@ title: "Welcome to Acton"
 description: "Acton is an all-in-one TON smart contract development toolkit"
 ---
 
-import {Cards, Card} from "fumadocs-ui/components/card";
 import {Step, Steps} from "fumadocs-ui/components/steps";
 
 Acton is an all-in-one TON smart contract development toolkit written in Rust. It combines project scaffolding, build, testing, scripting, wallet and network operations, verification, linting, formatting, and low-level VM tooling in one CLI.

--- a/docs/src/lib/mdx-components.tsx
+++ b/docs/src/lib/mdx-components.tsx
@@ -1,5 +1,6 @@
 import defaultMdxComponents from "fumadocs-ui/mdx"
 import {File, Folder, Files} from "fumadocs-ui/components/files"
+import {Cards, Card} from "fumadocs-ui/components/card"
 import * as Twoslash from "fumadocs-twoslash/ui"
 import type {MDXComponents} from "mdx/types"
 import {
@@ -19,6 +20,8 @@ export function getMDXComponents(components?: MDXComponents): MDXComponents {
     CommandOptionMeta,
     CommandOptions,
     CommandOptionTitle,
+    Cards,
+    Card,
     File,
     Folder,
     Files,

--- a/src/commands/docgen/stdlib.rs
+++ b/src/commands/docgen/stdlib.rs
@@ -284,15 +284,15 @@ fn render_cards(docs: &[FileDoc]) -> String {
                 .map(|l| format!("        {l}"))
                 .collect::<Vec<_>>()
                 .join("\n");
-            let _ = write!(
+            let _ = writeln!(
                 out,
-                "    <Card href=\"{}\" title=\"{}\">\n{}\n    </Card>\n",
+                "    <Card href=\"{}\" title=\"{}\">\n{}\n    </Card>",
                 doc.docs_url, doc.title, indented
             );
         } else {
-            let _ = write!(
+            let _ = writeln!(
                 out,
-                "    <Card href=\"{}\" title=\"{}\" />\n",
+                "    <Card href=\"{}\" title=\"{}\" />",
                 doc.docs_url, doc.title
             );
         }

--- a/src/commands/docgen/stdlib.rs
+++ b/src/commands/docgen/stdlib.rs
@@ -22,15 +22,14 @@ pub(super) fn generate_stdlib_docs(
         fs::remove_dir_all(&legacy_nested_tolk_dir)?;
     }
 
-    let mut docs = collect_docs(lib_dir, stdlib_out_dir, SourceKind::Acton)?;
-    docs.extend(collect_docs(
-        tolk_stdlib_dir,
-        tolk_stdlib_out_dir,
-        SourceKind::Tolk,
-    )?);
+    let stdlib_docs = collect_docs(lib_dir, stdlib_out_dir, SourceKind::Acton)?;
+    let tolk_stdlib_docs = collect_docs(tolk_stdlib_dir, tolk_stdlib_out_dir, SourceKind::Tolk)?;
 
-    write_stdlib_index(stdlib_out_dir)?;
-    write_tolk_stdlib_index(tolk_stdlib_out_dir)?;
+    write_stdlib_index(stdlib_out_dir, &stdlib_docs)?;
+    write_tolk_stdlib_index(tolk_stdlib_out_dir, &tolk_stdlib_docs)?;
+
+    let mut docs = stdlib_docs;
+    docs.extend(tolk_stdlib_docs);
 
     let symbol_map = build_symbol_map(&docs);
     let link_regex = Regex::new(r"\[([a-zA-Z0-9_.]+)]")?;
@@ -42,15 +41,19 @@ pub(super) fn generate_stdlib_docs(
     Ok(())
 }
 
-fn write_stdlib_index(stdlib_out_dir: &Path) -> Result<()> {
+fn write_stdlib_index(stdlib_out_dir: &Path, docs: &[FileDoc]) -> Result<()> {
     fs::create_dir_all(stdlib_out_dir)?;
     let index_article = stdlib_out_dir.join("overview.mdx");
+    let cards = render_cards(docs);
+    let body = format!(
+        "Acton provides a collection of functions for writing scripts and tests in Tolk.\n\nThe Tolk stdlib is documented in [Tolk standard library](/docs/tolk_standard_library/overview).\n\n{cards}"
+    );
     fs::write(
         &index_article,
         render_generated_index_page(
             "Overview",
             "All available functions, structs, constants, and other entities available in Acton standard library",
-            "Acton provides a collection of functions for writing scripts and tests in Tolk.\n\nThe Tolk stdlib is documented in [Tolk standard library](/docs/tolk_standard_library/overview).\n",
+            &body,
             Path::new(super::ACTON_STDLIB_SRC),
         ),
     )?;
@@ -62,15 +65,17 @@ fn write_stdlib_index(stdlib_out_dir: &Path) -> Result<()> {
     Ok(())
 }
 
-fn write_tolk_stdlib_index(tolk_stdlib_out_dir: &Path) -> Result<()> {
+fn write_tolk_stdlib_index(tolk_stdlib_out_dir: &Path, docs: &[FileDoc]) -> Result<()> {
     fs::create_dir_all(tolk_stdlib_out_dir)?;
     let index_article = tolk_stdlib_out_dir.join("overview.mdx");
+    let cards = render_cards(docs);
+    let body = format!("This section contains documentation of Tolk standard library.\n\n{cards}");
     fs::write(
         &index_article,
         render_generated_index_page(
             "Overview",
             "Bundled Tolk stdlib modules used by Acton standard library",
-            "This section contains documentation of Tolk standard library.\n",
+            &body,
             Path::new(super::TOLK_STDLIB_SRC),
         ),
     )?;
@@ -258,6 +263,42 @@ fn write_doc_page(
 
     fs::write(output_path, mdx_content)?;
     Ok(())
+}
+
+fn render_cards(docs: &[FileDoc]) -> String {
+    if docs.is_empty() {
+        return String::new();
+    }
+    let mut out = String::from("<Cards>\n");
+    for doc in docs {
+        let first_para = doc
+            .file_header
+            .as_deref()
+            .and_then(|h| h.split("\n\n").next())
+            .map(str::trim)
+            .filter(|s| !s.is_empty());
+        if let Some(desc) = first_para {
+            let sanitized = sanitize_mdx_text(desc);
+            let indented = sanitized
+                .lines()
+                .map(|l| format!("        {l}"))
+                .collect::<Vec<_>>()
+                .join("\n");
+            let _ = write!(
+                out,
+                "    <Card href=\"{}\" title=\"{}\">\n{}\n    </Card>\n",
+                doc.docs_url, doc.title, indented
+            );
+        } else {
+            let _ = write!(
+                out,
+                "    <Card href=\"{}\" title=\"{}\" />\n",
+                doc.docs_url, doc.title
+            );
+        }
+    }
+    out.push_str("</Cards>\n");
+    out
 }
 
 fn render_generated_index_page(


### PR DESCRIPTION
Before (quite deserted):

<img width="1416" height="629" alt="image" src="https://github.com/user-attachments/assets/a9d67ec4-a053-4639-a991-cf597401fb90" /><br/>

After:

<img width="1364" height="1126" alt="image" src="https://github.com/user-attachments/assets/89c6d5a9-67c4-4314-a61b-371eeab4c314" /><br/>

Hopefully, I did not butcher anything in the sources.