### PR TITLE
feat(docs): complete `building/` and apply miscellaneous edits elsewhere

### DIFF
--- a/docs/content/docs/building/contracts.mdx
+++ b/docs/content/docs/building/contracts.mdx
@@ -1,6 +1,0 @@
----
-title: "Build contracts"
-description: "How to build contracts"
----
-
-Stub.

--- a/docs/content/docs/building/meta.json
+++ b/docs/content/docs/building/meta.json
@@ -3,7 +3,6 @@
   "icon": "Wrench",
   "pages": [
     "overview",
-    "contracts",
     "wrappers",
     "reference"
   ]

--- a/docs/content/docs/building/overview.mdx
+++ b/docs/content/docs/building/overview.mdx
@@ -1,214 +1,82 @@
 ---
-title: "Overview"
-description: "Learn how Acton's build system manages smart contract compilation, dependencies, and code generation"
+title: "Build system overview"
+description: "How Acton's build system manages smart contract compilation, dependencies, and code generation"
 ---
 
-Acton provides a flexible smart contract build system with support for code generation and dependency management between contracts. The build system automatically handles contract compilation, dependency resolution, and generates helper functions for embedding child contracts.
+Two commands drive compilation:
 
-For a complete reference of all configuration options and CLI flags, see:
+- [`acton build`](/docs/commands/build) runs the full project pipeline: it compiles Tolk contracts registered in `Acton.toml`, resolves the [dependency graph](#contract-dependencies), and [writes artifacts](#best-effort-builds) to be consumed by [tests](/docs/testing/overview), [wrappers](/docs/building/wrappers), and [scripts](/docs/scripting/overview).
+- [`acton compile`](/docs/commands/compile) targets a single `.tolk` file — useful for quick inspection of compiler output or producing standalone `.boc` and `.fif` files outside a project build.
 
 <Cards>
-  <Card href="/docs/building/reference" title="Build Reference">
-    Complete reference for all build system configuration options, CLI flags, and contract settings
+  <Card href="/docs/building/wrappers" title="Tolk wrappers">
+    Generate typed Tolk wrappers and use them to deploy and interact with contracts
+  </Card>
+  <Card href="/docs/building/reference" title="Build reference">
+    Complete reference for all build system configuration options and CLI flags
   </Card>
 </Cards>
 
-## Basic Configuration
+## Contract dependencies
 
-Contracts are described in the Acton.toml project configuration file. A simple contract might look like this:
-
-```toml title=Acton.toml
-[package]
-name = "my-counter"
-description = "The Best Counter Ever"
-version = "0.1.0"
-license = "MIT"
-
-[contracts.Counter]
-display-name = "Counter"
-src = "contracts/Counter.tolk"
-depends = []
-```
-
-Now when calling `acton build`, the contract will be compiled and added to the cache.
-
-## Contract Dependencies
-
-Very often, one contract's code needs to be included in another contract. There are three main ways to implement this:
-
-1. **Storage approach**: Store the code in `Storage` during deployment
-2. **Code embedding**: Compile the child contract code and embed it through an assembly function directly into the parent contract's code
-3. **Library reference**: Deploy a library with the child contract code and reference this library through an assembly function
-
-Acton supports all three approaches and provides convenient file generation for the second and third methods.
-
-### Code Embedding
-
-Let's imagine we have a Jetton Minter and Jetton Wallet, and we need the Wallet code inside the Minter. All you need to do to embed the Wallet code into the Minter is to specify the dependency in Acton.toml:
+Parent contracts often need child contract code at runtime — to deploy children or verify their code hash. The dependencies are declared in `Acton.toml`:
 
 ```toml
 [contracts.JettonMinter]
-display-name = "Minter"
 src = "contracts/JettonMinter.tolk"
 depends = ["JettonWallet"]
 
 [contracts.JettonWallet]
-display-name = "Wallet"
 src = "contracts/JettonWallet.tolk"
 depends = []
 ```
 
-Now after calling `acton build`, a file `gen/JettonWallet.code.tolk` will appear in the `gen/` folder with the function `jettonWalletCompiledCode` which returns a Cell with the Wallet code.
+See how to [declare contract dependencies](/docs/projects#declare-contract-dependencies) in the project management guide.
 
+### No circular dependencies
 
-### Library References
+Acton resolves the full dependency graph and compiles contracts in topological order. A circular dependency aborts the build before any contract is compiled:
 
-If you want to reference code through a library reference, specify the dependency kind in the `depends` array:
-
-```toml
-[contracts.JettonMinter]
-display-name = "Minter"
-src = "contracts/JettonMinter.tolk"
-depends = [
-  { name = "JettonWallet", kind = "library_ref" }
-]
-
-[contracts.JettonWallet]
-display-name = "Wallet"
-src = "contracts/JettonWallet.tolk"
-depends = []
 ```
-
-The generated file `gen/JettonWallet.code.tolk` will contain the function `jettonWalletCompiledCode` which references the library by its hash instead of embedding the full code.
-
-<Callout type="info">
-Check out the [Libraries](/docs/libraries) guide for more information on how to deploy and use libraries.
-</Callout>
-
-### Dependency Resolution
-
-Acton automatically resolves contract dependencies and ensures they are compiled in the correct order. If a circular dependency is detected between contracts, the build will fail with a detailed error message showing the cycle path:
-
-```bash
 Error: Circular dependency detected in contracts: A → B → A → C
 ```
 
-Dependency-graph failures such as missing contracts or cycles happen before the
-main compile loop starts, so those failures do not leave behind partial build
-artifacts.
+Dependency-graph failures such as missing contracts or cycles happen before the main compile loop starts, so those failures do not leave behind partial build artifacts.
 
-## Best-Effort Builds
+## Best-effort builds
 
-Once dependency resolution succeeds, `acton build` switches to best-effort
-execution:
+When compiled with `acton build`, each successful contract build produces: a JSON file with Base64- and hex-encoded contract code in `build/`, a JSON file with compiler ABI in `build/abi/`, and dependency helper files in `gen/` for contracts with declared dependencies.
 
-- a compile failure for one contract is recorded, but Acton continues building
-  other eligible contracts
-- artifact-writing failures are also collected instead of aborting the whole run
-- contracts that compiled successfully before a later failure keep their JSON,
-  BoC, helper, or Fift artifacts on disk
+Once dependency resolution succeeds, Acton builds eligible contracts, discarding those failed to compile and not aborting the build immediately. Same goes for artifact-writing failures. Further, artifacts produced from successful builds in the current run remain on disk.
 
-This means a failing build can still leave useful partial outputs behind for the
-contracts that already succeeded.
+Compilation of a parent contract may still fail if its dependency failed to build or its helper file in `gen/` was never produced.
 
-There is one dependency-related caveat: if a dependency failed earlier, its
-generated helper file is not produced. A parent contract may then fail later
-because the expected generated import is missing.
+To limit the build set to a single contract and its transitive dependencies, provide its ID explicitly, e.g., by running `acton build Counter`.
 
-When you run `acton build <NAME>`, Acton does not build every configured
-contract. It limits work to the requested contract and its transitive
-dependencies.
+## Build caching
 
-## Build vs Compile
+Acton uses a shared file-based cache under `build/cache/`. Each cache entry is keyed on the source file path, Tolk compiler version, optimization level, debug mode, Fift generation flag, and import mappings from `Acton.toml`.
 
-`acton build` and `acton compile` share the same compiler and cache, but they
-solve different problems:
+A cache entry is valid only if the content hash of every imported source file matches the stored hash. This includes helper files generated in `gen/`, so changing a child contract's source also invalidates the cache for any parent that imports the generated helper.
 
-| Aspect   | `acton build`                                                       | `acton compile`                                                 |
-|----------|---------------------------------------------------------------------|-----------------------------------------------------------------|
-| Scope    | Contract graph from `Acton.toml`                                    | One explicit `.tolk` file                                       |
-| Manifest | Required for normal operation                                       | Optional; used for mappings/project context when available      |
-| Outputs  | Project build JSON, optional BoC, dependency helpers, optional Fift | Only the files explicitly requested via CLI flags               |
-| Defaults | Uses `[build]` config and contract metadata                         | Does not use `[build]` output defaults or generate helper files |
+The same cache directory is shared by `acton build`, `acton compile`, and [`acton test`](/docs/commands/test). Recent builds often speed up subsequent test runs.
 
-Use `build` when you want project-aware artifact generation. Use `compile` when
-you want to inspect or export one file in isolation.
+Clear the cache to force a full rebuild:
 
-## Build Caching
+```bash
+acton build --clear-cache
+```
 
-Acton uses a shared file-based compilation cache to speed up repeated `build`,
-`compile`, and test runs. By default it lives under `build/cache` relative to
-the project root.
-
-### Cache Layout
-
-| Path                       | Purpose                                                                  |
-|----------------------------|--------------------------------------------------------------------------|
-| `build/cache/*.json`       | Normal compilation cache entries                                         |
-| `build/cache/debug/*.json` | Debug-oriented entries compiled with source-map/debug metadata           |
-| `build/cache/.lock`        | A write lock that coordinates concurrent cache updates between processes |
-
-Debug and non-debug compilation results are stored separately, so a
-source-map-enabled compile does not overwrite the normal cached artifact for
-the same file.
-
-### Cache Management
-
-| Command                     | Description                        |
-|-----------------------------|------------------------------------|
-| `acton build`               | Build with incremental caching     |
-| `acton build --clear-cache` | Clear cache and rebuild everything |
-
-### How Caching Works
-
-The build system tracks:
-- Source file content and imported file content
-- Declared contract dependencies from `Acton.toml`
-- Compiler mode differences such as debug/source-map output and Fift output
-- Compiler/cache schema version changes
-
-Each cache entry stores the compiled code, code hash, and any optional metadata
-requested for that compilation mode, such as ABI, source-map data, debug marks,
-or Fift output.
-
-When Acton checks whether a cache entry is still valid, it recomputes a hash
-across the normalized dependency set for that source file. This includes both
-regular file imports and source files pulled in through contract dependencies.
-If any of those inputs change, the cached entry is treated as stale and the file
-is recompiled.
-
-Because dependency hashes are part of cache validation, changing a child
-contract or imported file invalidates parent cache entries that depend on it.
-That is what lets incremental builds recompile only the affected part of the
-graph instead of rebuilding everything.
-
-### What `--clear-cache` Actually Clears
-
-Commands that expose `--clear-cache` wipe the shared file cache before
-continuing. In practice this means:
-
-- all cached JSON entries under `build/cache/` are removed
-- the debug cache subdirectory `build/cache/debug/` is removed and recreated on demand
-- the lock file `build/cache/.lock` is preserved
-- other generated artifacts are not deleted automatically
-
-So `--clear-cache` does **not** clean the rest of `build/`, your generated
-helpers under `gen/`, saved traces under `build/traces/`, logs under
-`build/logs/`, or mutation-session artifacts. It only forces recompilation by
-resetting the file compilation cache.
-
-### Shared Cache Across Commands
-
-The same cache directory is reused by several workflows:
-
-- `acton build` reads and writes cache entries while building project contracts
-- `acton compile` uses the same cache for standalone file compilation
-- `acton test` reuses the same cache during the contract build/preparation phase
-
-This shared design means a recent `acton build` often speeds up a later
-`acton test`, and vice versa.
-
-<Callout type="info">
-Cache writes are guarded by `build/cache/.lock`. If another process is already
-updating the cache, Acton waits for that lock instead of writing concurrently.
+<Callout>
+    `--clear-cache` removes all entries under `build/cache/` but does not delete other artifacts in `build/`, generated helpers in `gen/`, or saved traces.
 </Callout>
+
+## See also
+
+- [Tolk wrappers](/docs/building/wrappers)
+- [Build system reference](/docs/building/reference)
+- [`acton build` command reference](/docs/commands/build)
+- [`acton compile` command reference](/docs/commands/compile)
+
+- [TypeScript wrappers](/docs/dapps)
+- [`acton wrapper` command reference](/docs/commands/compile)

--- a/docs/content/docs/building/reference.mdx
+++ b/docs/content/docs/building/reference.mdx
@@ -5,7 +5,7 @@ description: "Complete reference for all build system configuration options, CLI
 
 This page provides a complete reference for all configuration options available in Acton's build system.
 
-## Path Resolution Rules
+## Path resolution rules
 
 Acton uses two different path-resolution models:
 
@@ -74,9 +74,9 @@ acton build --output-abi build/abi
 acton build --output-fift build/fift
 ```
 
-## Acton.toml Configuration
+## `Acton.toml` configuration
 
-### Build Section
+### Build section
 
 Use `[build]` to configure default outputs for `acton build`:
 
@@ -105,7 +105,7 @@ acton build --output-fift artifacts/fift
 
 Config values in `[build]` are project-root-relative. CLI paths such as `--out-dir`, `--gen-dir`, `--output-abi`, `--output-fift`, and `--graph` remain cwd-relative unless absolute.
 
-### Wrappers Section
+### Wrappers section
 
 Use `[wrappers]` to configure default output locations for `acton wrapper`:
 
@@ -137,7 +137,7 @@ Override rules:
 
 Configured wrapper paths are project-root-relative. CLI paths such as `--output`, `--output-dir`, `--test-output`, and `--test-output-dir` remain cwd-relative unless absolute.
 
-### Contracts Section
+### Contracts section
 
 Contracts are defined using `[contracts.*]` sections where `*` is the contract name.
 
@@ -149,7 +149,7 @@ output = "build/MyContract.boc"
 depends = []
 ```
 
-#### Contract Fields
+#### Contract fields
 
 | Field          | Type   | Required | Description                                                                                                        |
 |----------------|--------|----------|--------------------------------------------------------------------------------------------------------------------|
@@ -158,34 +158,36 @@ depends = []
 | `output`       | string | No       | Path where the compiled `.boc` file should be saved. If omitted, the compiled contract is only cached              |
 | `depends`      | array  | No       | Array of contract dependencies. Can be simple strings or detailed dependency objects                               |
 
-#### Contract Names
+#### Contract names
 
-The contract name (`[contracts.NAME]` in `Acton.toml`, e.g., `Counter`) is used:
-- As a contract entrypoint `contracts/Counter.tolk` (with `onInternalMessage`, get methods, etc.)
+The `[contracts.ID]` in `Acton.toml` is used:
+
+- As a contract entrypoint, referencing a Tolk file with `onInternalMessage()`
 - As a filename for generated wrappers (e.g., `wrappers/Counter.gen.tolk`, `wrappers-ts/Counter.gen.ts`)
 - As the dependency name when referencing this contract
 - To generate the output file name in the dependency output directory (default: `gen/`, e.g., `Counter` → `gen/Counter.code.tolk`)
 - To generate the function name (e.g., `Counter` → `counterCompiledCode()`)
 - In console messages and web UI, unless overridden by optional `display-name` in `Acton.toml`
 
-Names should use PascalCase (e.g., `JettonWallet`, `NftCollection`).
+Contract IDs should use PascalCase, e.g., `JettonWallet`, `NftCollection`.
 
-### Dependencies Configuration
+### Dependencies configuration
 
 Dependencies can be specified in two formats:
 
-#### Simple Format
+#### Simple format
 
 ```toml
 depends = ["ChildContract", "AnotherContract"]
 ```
 
 Uses default settings:
+
 - `kind = "embed_code"`
 - Generated file: `{gen-dir}/{contract-name}.code.tolk` (`gen-dir` defaults to `gen`)
 - Generated function: auto-derived from the dependency key using the normalization rules below
 
-#### Detailed Format
+#### Detailed format
 
 ```toml
 depends = [
@@ -200,7 +202,7 @@ depends = [
 | `function` | string | No       | Auto-generated               | Custom name for the generated function. If omitted, Acton derives it from the dependency key using the rules below |
 | `path`     | string | No       | `{gen-dir}/{name}.code.tolk` | Custom output path for the generated file. Relative manifest paths are resolved from the project root              |
 
-#### Dependency Helper Generation Rules
+#### Dependency helper generation rules
 
 Acton generates one helper file per direct dependency of the parent contract.
 Those helper paths and function names are derived from the dependency `name`
@@ -227,10 +229,10 @@ Default helper filenames use the raw dependency key:
 
 Default helper function names are normalized separately:
 
-1. Replace `-`, `.`, and spaces with `_`
-2. If the first character is not alphabetic, prefix `contract_`
-3. Convert the result to lowerCamelCase
-4. Append `CompiledCode`
+1. The `-`, `.`, and spaces are replaced with `_`
+2. If the first character is not alphabetic, they are prefixed with `contract_`
+3. The result is converted to `camelCase`
+4. `CompiledCode` suffix is appended.
 
 Examples:
 
@@ -238,10 +240,9 @@ Examples:
 - `child.lib` -> `childLibCompiledCode()`
 - `123contract` -> `contract123contractCompiledCode()`
 
-Custom `function` overrides only the function name. Custom `path` overrides only
-the output file location.
+Custom `function` overrides only the function name. Custom `path` overrides only the output file location.
 
-#### Dependency Kinds
+#### Dependency kinds
 
 **`embed_code`** (default)
 
@@ -254,6 +255,7 @@ depends = [{ name = "Wallet", kind = "embed_code" }]
 ```
 
 Generated assembly:
+
 ```tolk
 @pure
 fun walletCompiledCode(): cell asm """
@@ -270,6 +272,7 @@ depends = [{ name = "Wallet", kind = "library_ref" }]
 ```
 
 Generated assembly:
+
 ```tolk
 @pure
 fun walletCompiledCode(): cell asm """
@@ -277,9 +280,9 @@ fun walletCompiledCode(): cell asm """
 """
 ```
 
-### Using Precompiled Contracts
+### Using precompiled contracts
 
-You can use precompiled `.boc` files instead of `.tolk` sources:
+It is possible to use precompiled `.boc` files instead of `.tolk` sources:
 
 ```toml
 [contracts.Precompiled]
@@ -289,14 +292,16 @@ depends = []
 ```
 
 When using `.boc` files:
+
 - No compilation is performed
 - The BoC is loaded and cached directly
 - Dependencies can still reference this contract
-- Useful for third-party contracts or cross-platform builds
 
-### Path Mappings
+This is useful for referencing third-party contracts.
 
-You can define path aliases for the Tolk compiler in the `[import-mappings]` section. These are useful for importing library code without using complex relative paths.
+### Path mappings
+
+Define additional path aliases for the Tolk compiler in the `[import-mappings]` section. These are useful for importing library code without using complex relative paths.
 
 ```toml
 [import-mappings]
@@ -305,6 +310,7 @@ utils = "./libs/utils"
 ```
 
 In Tolk code:
+
 ```tolk
 import "@core/math.tolk"
 ```
@@ -319,18 +325,15 @@ Built-in project mappings commonly used in Acton projects:
 | `@wrappers`  | `wrappers` or `contracts/wrappers` | Generated wrappers such as `@wrappers/Counter`           |
 | `@gen`       | `gen`                              | Generated dependency helper files                        |
 
-These defaults are usually written into `Acton.toml` by `acton new` and
-`acton init`. Standard scaffolds use `contracts` / `tests` / `wrappers`, while
-`--app` scaffolds use `contracts/src` / `contracts/tests` /
-`contracts/wrappers`. If you remove them manually, Acton does not recreate them
-during normal compilation.
+These defaults are usually written into `Acton.toml` by `acton new` and `acton init`. Standard scaffolds use `contracts`, `tests`, and `wrappers`, while `--app` scaffolds use `contracts/src`, `contracts/tests`, and `contracts/wrappers`. Acton does not recreate these folders during normal compilation.
 
 Mappings follow these rules:
+
 1. **Normalization**: Any mapping key missing the `@` prefix will have it added automatically.
 2. **Resolution**: Mappings are resolved relative to project root for the current invocation.
 3. **Exact Match**: When importing, the first part of the path (before the first slash) is used to look up the mapping. For example, `import "@core/math.tolk"` will look for a mapping named `@core`.
 
-## Dependency Graph Visualization
+## Dependency graph visualization
 
 Generate a DOT representation of contract dependencies:
 

--- a/docs/content/docs/building/wrappers.mdx
+++ b/docs/content/docs/building/wrappers.mdx
@@ -1,6 +1,147 @@
 ---
-title: "Create and use wrappers"
-description: "How to create and use contract wrappers"
+title: "Tolk wrappers"
+description: "Learn how to generate Tolk wrappers and use them in tests and scripts"
 ---
 
-Stub.
+[`acton wrapper`](/docs/commands/wrapper) generates a typed Tolk wrapper from a contract's compiler ABI. The wrapper exposes methods to create, deploy, send messages to, and call get methods on the contract — the same API works in both tests and scripts.
+
+## Generate a Tolk wrapper
+
+Run `acton wrapper` with the contract name from `Acton.toml`:
+
+```bash
+acton wrapper Counter
+```
+
+This writes a `Counter.gen.tolk` wrapper to `wrappers/` by default. The `acton wrapper` does not require a prior `acton build` run.
+
+Generate wrappers for every contract in `Acton.toml` at once:
+
+```bash
+acton wrapper --all
+```
+
+Pass `--test` to also emit a runnable test stub alongside the wrapper:
+
+```bash
+acton wrapper Counter --test
+```
+
+The stub is written to `tests/Counter.test.tolk` and contains a `setupTest()` helper with an example test case ready to extend.
+
+### Wrapper file structure
+
+The generated file provides:
+
+- `Counter.fromStorage(storage)` — initializes contract state from a storage struct instance and calculates the deployment address.
+- `counter.deploy(from, config)` — deploys the contract.
+- `counter.send{MessageName}(from, ...)` — one method per incoming message type declared in `contract { incomingMessages: ... }`.
+- `counter.{getMethodName}()` — one method per declared get method.
+
+Fine tune wrapper generation with the `contract { ... }` header in the contract entrypoint file:
+
+- `storage: ...` enables the typed `fromStorage()` initializer; without it, the initializer falls back to an untyped form.
+- `incomingMessages: ...` enables `send{MessageName}` helpers; without it, no message-sending methods are generated.
+
+### Use a wrapper in a Tolk test
+
+Import the wrapper and any types it references, then create and deploy the contract:
+
+```tolk title="tests/Counter.test.tolk"
+import "@wrappers/Counter"
+import "@contracts/types"
+import "@acton/emulation/testing"
+
+get fun `test increase`() {
+    val deployer = testing.treasury("deployer");
+
+    val contract = Counter.fromStorage({ id: 0, counter: 0 });
+    val deployResult = contract.deploy(deployer.address, ton("0.05"));
+    expect(deployResult).toHaveSuccessfulDeploy({ to: contract.address });
+
+    val sendResult = contract.sendIncrease(deployer.address, 5);
+    expect(sendResult).toHaveTransaction({ success: true });
+
+    expect(contract.currentCounter()).toEqual(5);
+}
+```
+
+See the [testing guides](/docs/testing/overview) for more.
+
+### Use a wrapper in a Tolk script
+
+Replace `testing.treasury()` with `scripts.wallet()`:
+
+```tolk title="scripts/deploy.tolk"
+import "@wrappers/Counter"
+import "@contracts/types"
+// Replaces @acton/emulation/testing:
+import "@acton/emulation/scripts"
+
+fun main() {
+    val deployer = scripts.wallet("deployer");
+
+    val contract = Counter.fromStorage({ id: 0, counter: 0 });
+    val result = contract.deploy(deployer.address, ton("0.05"));
+    result.waitForFirstTransaction();
+
+    println("Deployed to {}", contract.address);
+}
+```
+
+Run and test locally first, then broadcast to testnet with `--net`:
+
+```bash
+acton script scripts/deploy.tolk
+acton script scripts/deploy.tolk --net testnet
+```
+
+See the [scripting guides](/docs/testing/overview) for more.
+
+### Regenerate after contract changes
+
+Regenerate the wrapper whenever the contract's storage struct, accepted messages, or get-methods change:
+
+```bash
+acton wrapper Counter
+```
+
+## Generate a TypeScript wrapper
+
+Pass `--ts` to emit a TypeScript wrapper:
+
+```bash
+acton wrapper Counter --ts
+```
+
+This writes a `Counter.gen.ts` wrapper to `wrappers-ts/` by default.
+
+<Callout type="warn">
+    Node.js, `npm`, and `npx` must be available in the `PATH`.
+</Callout>
+
+See the [dApps development guide](/docs/dapps) for working with TypeScript wrappers.
+
+## Configure wrapper defaults
+
+Set per-project defaults in `Acton.toml`:
+
+```toml title="Acton.toml"
+[wrappers.tolk]
+output-dir = "wrappers"
+generate-test = true
+test-output-dir = "tests"
+
+[wrappers.typescript]
+output-dir = "wrappers-ts"
+```
+
+See the [build reference](/docs/building/reference#wrappers-section) for all available fields.
+
+## See also
+
+- [Testing guides](/docs/testing/overview)
+- [Scripting guides](/docs/scripting/overview)
+- [Deployment](/docs/deploy)
+- [dApp development](/docs/dapps)
+- [`acton wrapper` command reference](/docs/commands/wrapper)

--- a/docs/content/docs/building/wrappers.mdx
+++ b/docs/content/docs/building/wrappers.mdx
@@ -56,7 +56,7 @@ get fun `test increase`() {
     val deployer = testing.treasury("deployer");
 
     val contract = Counter.fromStorage({ id: 0, counter: 0 });
-    val deployResult = contract.deploy(deployer.address, ton("0.05"));
+    val deployResult = contract.deploy(deployer.address, { value: ton("0.05") });
     expect(deployResult).toHaveSuccessfulDeploy({ to: contract.address });
 
     val sendResult = contract.sendIncrease(deployer.address, 5);
@@ -82,7 +82,7 @@ fun main() {
     val deployer = scripts.wallet("deployer");
 
     val contract = Counter.fromStorage({ id: 0, counter: 0 });
-    val result = contract.deploy(deployer.address, ton("0.05"));
+    val result = contract.deploy(deployer.address, { value: ton("0.05") });
     result.waitForFirstTransaction();
 
     println("Deployed to {}", contract.address);

--- a/docs/content/docs/dapps.mdx
+++ b/docs/content/docs/dapps.mdx
@@ -16,6 +16,10 @@ acton new my-dapp --template counter --app
 
 This produces the [app layout](/docs/projects#dapp-project-layout): Tolk sources under `contracts/src/`, generated TypeScript wrappers under `wrappers-ts/`, and the React frontend under `app/`.
 
+<Callout type="warn">
+    Node.js, `npm`, and `npx` must be available in the `PATH`.
+</Callout>
+
 Install workspace dependencies and start the dev server:
 
 ```bash

--- a/docs/content/docs/installation.mdx
+++ b/docs/content/docs/installation.mdx
@@ -14,9 +14,11 @@ import {SiApple, SiLinux} from "react-icons/si";
 Acton ships as a single, dependency-free executable. You can install it via the public installer, by downloading a release asset directly, or by using the published Docker image.
 
 <Callout type="info" title="Support policy">
-    Acton is stable on the latest numbered release. First-class support covers versioned releases on macOS (ARM64 and x86_64) and Linux GNU (x86_64 and ARM64). For Linux, the documented baseline is Ubuntu 22 or newer. `trunk` builds, WSL installs, and other source-built targets are beta or best-effort surfaces. Native Windows is not supported: install Acton inside WSL with Ubuntu 22 or newer and follow the Linux steps.
+    Acton is stable on the latest major numbered release. First-class support covers versioned releases on macOS (ARM64 and x86_64) and Linux GNU (x86_64 and ARM64). For Linux, the documented baseline is Ubuntu 22 or newer.
 
-    See [platform tiers](#platform-tiers) for the full matrix.
+    `trunk` builds, WSL installs, and other source-built targets are beta or best-effort surfaces. Native Windows is not supported: install Acton inside WSL with Ubuntu 22 or newer and follow the Linux steps.
+
+    See the [platform tiers](#platform-tiers) for the full matrix.
 </Callout>
 
 ## Installation
@@ -58,41 +60,6 @@ acton --version
 ```
 
 The printed line is the Acton version.
-
-If Acton is installed but the shell reports `command not found`, add the installation directory to `PATH` manually:
-
-<Accordions>
-    <Accordion title="Add Acton to the PATH">
-        <Steps>
-            <Step title="Determine which shell is active">
-                ```bash
-                echo $SHELL
-                # /bin/zsh or /bin/bash or /bin/fish
-                ```
-            </Step>
-
-            <Step title="Open the shell configuration file">
-                - For bash: `~/.bashrc`
-                - For zsh: `~/.zshrc`
-                - For fish: `~/.config/fish/config.fish`
-            </Step>
-
-            <Step title="Add the Acton directory to PATH">
-                Add this line to the configuration file:
-
-                ```bash
-                export PATH="PATH_TO_ACTON_BIN:$PATH"
-                ```
-            </Step>
-
-            <Step title="Reload the shell configuration">
-                ```bash
-                source ~/.bashrc # or ~/.zshrc
-                ```
-            </Step>
-        </Steps>
-    </Accordion>
-</Accordions>
 
 ### Shell completions
 
@@ -138,6 +105,47 @@ To download Acton binaries directly, visit the [releases page on GitHub](https:/
         Linux ARM64 binary
     </Card>
 </Cards>
+
+Extract the `acton` binary from the archive:
+
+```bash
+tar xzf acton-arch-os-archive.tar.gz
+```
+
+Place the extracted binary to a common directory in `PATH`, e.g., `~/.local/bin` or `/usr/local/bin`. Alternatively, place it in a different installation directory and manually add it to `PATH`:
+
+<Accordions>
+    <Accordion title="Add Acton to the PATH">
+        <Steps>
+            <Step title="Determine which shell is active">
+                ```bash
+                echo $SHELL
+                # /bin/zsh or /bin/bash or /bin/fish
+                ```
+            </Step>
+
+            <Step title="Open the shell configuration file">
+                - For bash: `~/.bashrc`
+                - For zsh: `~/.zshrc`
+                - For fish: `~/.config/fish/config.fish`
+            </Step>
+
+            <Step title="Add the Acton directory to PATH">
+                Add this line to the configuration file:
+
+                ```bash
+                export PATH="PATH_TO_ACTON_BIN:$PATH"
+                ```
+            </Step>
+
+            <Step title="Reload the shell configuration">
+                ```bash
+                source ~/.bashrc # or ~/.zshrc
+                ```
+            </Step>
+        </Steps>
+    </Accordion>
+</Accordions>
 
 ## Docker image
 
@@ -207,7 +215,7 @@ To uninstall Acton binaries or cache, remove the `~/.acton` directory in the hom
 
 ## Support policy
 
-Acton is stable on the latest numbered release.
+Acton is stable on the latest major numbered release.
 
 ### Platform tiers
 
@@ -222,5 +230,5 @@ Acton is stable on the latest numbered release.
 | Other source-built targets                     | Beta        |
 
 <Callout type="warn">
-  Other source-built targets are outside the official binary matrix; validation is limited and regressions may occur.
+    Other source-built targets are outside of the official binary matrix: their validation is limited, and regressions may occur.
 </Callout>

--- a/docs/content/docs/projects.mdx
+++ b/docs/content/docs/projects.mdx
@@ -122,16 +122,20 @@ acton-project/
 ├── Acton.toml
 ├── .env
 ├── .acton/
-├── app/             # React + Vite frontend
-├── wrappers-ts/     # Generated TypeScript wrappers
+├── app/             — React + Vite frontend
+├── wrappers-ts/     — Generated TypeScript wrappers
 ├── contracts/
-│   ├── src/         # Tolk source files
-│   ├── wrappers/    # Generated Tolk wrappers
-│   ├── tests/       # Test files
-│   └── scripts/     # Deployment and utility Tolk scripts
+│   ├── src/         — Tolk source files
+│   ├── wrappers/    — Generated Tolk wrappers
+│   ├── tests/       — Test files
+│   └── scripts/     — Deployment and utility Tolk scripts
 ├── build/
 └── gen/
 ```
+
+<Callout type="warn">
+    Node.js, `npm`, and `npx` must be available in the `PATH`.
+</Callout>
 
 See the [dApps development guide](/docs/dapps) for more information on features of the generated dApp and usage of TypeScript wrappers.
 

--- a/docs/content/docs/projects.mdx
+++ b/docs/content/docs/projects.mdx
@@ -49,13 +49,9 @@ acton init
 ```
 
 - When `Acton.toml` does not exist, `acton init` scans the directory tree for `.tolk` files that define `onInternalMessage()` and registers them as contracts in a newly created `Acton.toml`.
-- When `Acton.toml` already exists, `acton init` patches missing default [import mappings](#configure-import-mappings).
+- When `Acton.toml` already exists, `acton init` leaves it untouched.
 
-`acton init` also refreshes Tolk libraries in `.acton/` and updates `.gitignore` with the commonly ignored Acton-related entries. It is safe to rerun `acton init` after moving files around or after removing import mappings in `Acton.toml` by accident.
-
-<Callout type="caution">
-    `acton init` preserves other supported settings in `Acton.toml`, but does **not** preserve TOML comments and unrecognized keys.
-</Callout>
+`acton init` refreshes Tolk libraries in `.acton/` and updates `.gitignore` with the commonly ignored Acton-related entries. It is safe to rerun `acton init` after moving files around or after removing import mappings in `Acton.toml` by accident.
 
 Pass `--stdlib-only` to only refresh the standard library in `.acton/` folder:
 
@@ -84,7 +80,7 @@ It changes the project layout to the [dApp layout](#dapp-layout). The target `ap
 
 Rerun `acton init` when the project needs a light reset:
 
-- `Acton.toml` is missing the default import mappings or is nonexistent — contract files were added before the manifest was created.
+- `Acton.toml` is nonexistent, e.g., contract files were added before the manifest was created.
 - `.acton/` is stale or nonexistent.
 - `.gitignore` is missing the commonly ignored Acton-related entries.
 

--- a/docs/content/docs/quickstart.mdx
+++ b/docs/content/docs/quickstart.mdx
@@ -35,19 +35,19 @@ Run tests:
 acton test
 ```
 
-Install npm workspace dependencies:
+Install NPM dependencies:
 
 ```bash
 npm ci
 ```
 
-Start the development server:
+Start the Vite development server:
 
 ```bash
 npm run dev
 ```
 
-Open the URL shown in the terminal output. The app connects a wallet and sends transactions to the counter contract.
+Open the URL shown in the terminal output. Connect a wallet using TON Connect, then deploy and interact with the counter contract by sending transactions on the testnet or mainnet.
 
 ## Next steps
 

--- a/docs/content/docs/tutorial/frontend.mdx
+++ b/docs/content/docs/tutorial/frontend.mdx
@@ -3,9 +3,9 @@ title: "9. Build the React frontend"
 description: "Generate a TypeScript wrapper, scaffold a TON dApp with Vite + React + TON Connect UI, and build a live poll page."
 ---
 
-## Prerequisites for this page
+## Prerequisites
 
-- [Node.js](https://nodejs.org/en/download/) 20 or later
+- [Node.js](https://nodejs.org/en/download/) 22 or later
 - A deployed poll on [testnet](/docs/tutorial/testnet)
 
 ## Scaffold the dApp
@@ -118,7 +118,7 @@ TONCENTER_TESTNET_API_KEY=<TONCENTER_API_KEY>
 ```
 
 `<POLL_ADDRESS>` — the testnet address from page 8.
-`<TONCENTER_API_KEY>` — get a free key at [Toncenter TG bot](https://t.me/toncenter).
+`<TONCENTER_API_KEY>` — get a free key in [TON Center Telegram bot](https://t.me/toncenter).
 
 The bundled `vite.config.ts` exposes both `VITE_*` and `TONCENTER_*` prefixes via `envPrefix`, so the same `TONCENTER_TESTNET_API_KEY` works for the Acton CLI and the Vite dev server.
 

--- a/docs/content/docs/tutorial/meta.json
+++ b/docs/content/docs/tutorial/meta.json
@@ -1,5 +1,5 @@
 {
-  "title": "Your First Smart Contract",
+  "title": "Your first smart contract",
   "icon": "School",
   "pages": [
     "overview",

--- a/docs/content/docs/tutorial/overview.mdx
+++ b/docs/content/docs/tutorial/overview.mdx
@@ -35,7 +35,7 @@ One can think of this poll contract as a decentralized but oversimplified versio
 ## Prerequisites
 
 - **Acton**: run `acton up --stable` or follow [Installation](/docs/installation).
-- [**Node.js**](https://nodejs.org/en/download/) 20 or later: needed only for the last step when adding web frontend to the project.
+- [**Node.js**](https://nodejs.org/en/download/) 22 or later: needed only for the last step when adding web frontend to the project.
 - Funded testnet wallet: needed only for the semi-last step when deploying to testnet; created during the tutorial.
 
 ## Pages

--- a/docs/content/docs/walkthrough.mdx
+++ b/docs/content/docs/walkthrough.mdx
@@ -61,7 +61,7 @@ cd first_counter
 
 With `--app`, the project layout places Tolk sources under `contracts/src/`, tests under `contracts/tests/`, and scripts under `contracts/scripts/`. Generated TypeScript wrappers go into `wrappers-ts/`, and the React frontend lives in `app/`.
 
-Install the npm workspace dependencies before running any frontend commands:
+Install the NPM workspace dependencies before running any frontend commands:
 
 ```bash
 npm ci


### PR DESCRIPTION
Yay, no more stubs or non-code-block TODOs :tada:

If something is off, let's fix that in another PR then :)

P.S.: I'm pretty content with the achieved results in the docs, although it'd be good to continue iterating on `scripting/`, `testing/`, and `libraries` in the future, not to mention possible `tutorial/` enhancements and, of course, creation of proper `localnet/` docs and improvements in reference parts.