### PR TITLE
fix(ls): apply per-root lint settings, matching acton check

### DIFF
--- a/crates/ton-ls/src/backend/mod.rs
+++ b/crates/ton-ls/src/backend/mod.rs
@@ -40,6 +40,7 @@ pub struct Backend {
     pub file_db: Arc<FileDb>,
     pub project_root: PathBuf,
     pub mappings: Option<BTreeMap<String, String>>,
+    pub acton_config: Option<Arc<acton_config::config::ActonConfig>>,
     pub documents: DashMap<Url, String>,
     pub analysis: DashMap<Url, Arc<AnalysisResult>>,
     pub file_urls: DashMap<FileId, Url>,

--- a/crates/ton-ls/src/languages/tolk/analysis_engine.rs
+++ b/crates/ton-ls/src/languages/tolk/analysis_engine.rs
@@ -1,13 +1,15 @@
 use crate::AnalysisResult;
 use crate::backend::Backend;
 use crate::backend::utils::FileInfoExt;
+use acton_config::config::LintLevel;
 use lsp_types::MessageType;
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Instant;
-use tolk_linter::Checker;
+use tolk_linter::{Checker, Rule};
 use tolk_resolver::ProjectIndexBuilder;
+use tolk_resolver::file_db::FileInfo;
 use tolk_resolver::symbol_resolver::resolve;
 use tolk_ty::{TypeDb, TypeInterner, infer};
 use tower_lsp::lsp_types::Url;
@@ -128,8 +130,16 @@ impl Backend {
         );
 
         let now = Instant::now();
+
+        let root_file = self
+            .file_db
+            .get_by_id(root_file_id)
+            .expect("root file not found");
+        let lint_settings = self.settings_for_root(&root_file);
+
         let mut checker = Checker::new(&self.file_db, &mut type_db, &all_body_types)
-            .with_project_root(self.project_root.clone());
+            .with_project_root(self.project_root.clone())
+            .with_settings(lint_settings);
 
         for file_id in &reachable {
             let file_info = self.file_db.get_by_id(*file_id).expect("file not found");
@@ -150,5 +160,40 @@ impl Backend {
             all_body_types,
             diagnostics,
         })
+    }
+
+    /// Mirrors the per-root lint-settings dispatch used by `acton check`. The root file
+    /// (the one currently being analyzed) determines which rule set is applied to every
+    /// reachable file, so wrappers, helpers, and the test file itself share one config:
+    /// contract-only rules (`ActonImportInContract`, `RandomRequiresInitialization`,
+    /// `DivideBeforeMultiply`) are suppressed whenever the root is a test or script.
+    fn settings_for_root(&self, root_file: &FileInfo) -> HashMap<Rule, LintLevel> {
+        let Some(config) = self.acton_config.as_deref() else {
+            return HashMap::new();
+        };
+
+        let root_path = root_file.path();
+        let canonical_root = self
+            .file_db
+            .canonicalize(root_path)
+            .unwrap_or_else(|_| root_path.clone());
+
+        if let Some(contracts) = config.contracts() {
+            for (id, contract) in contracts {
+                let source = contract.absolute_source_path(&self.project_root);
+                let canonical_source = self.file_db.canonicalize(&source).unwrap_or(source);
+                if canonical_source == canonical_root {
+                    return Checker::build_settings(config, Some(id.as_str()));
+                }
+            }
+        }
+
+        // Any file that is not a declared contract source is treated like a test or
+        // script root — matching `acton check`'s behavior when invoked on a bare path.
+        let mut settings = Checker::build_settings(config, None);
+        settings.insert(Rule::ActonImportInContract, LintLevel::Allow);
+        settings.insert(Rule::RandomRequiresInitialization, LintLevel::Allow);
+        settings.insert(Rule::DivideBeforeMultiply, LintLevel::Allow);
+        settings
     }
 }

--- a/crates/ton-ls/tests/self_contained/harness/runner.rs
+++ b/crates/ton-ls/tests/self_contained/harness/runner.rs
@@ -624,6 +624,7 @@ impl TestServer {
             file_db: Arc::new(FileDb::new(stdlib_root.clone(), Some(acton_root.clone()))),
             project_root: project_root.clone(),
             mappings: Option::<BTreeMap<String, String>>::None,
+            acton_config: None,
             documents: DashMap::new(),
             analysis: DashMap::new(),
             file_urls: DashMap::new(),

--- a/src/commands/ls/mod.rs
+++ b/src/commands/ls/mod.rs
@@ -31,20 +31,20 @@ pub async fn ls_cmd(
     }
     let project_root = dunce::canonicalize(configured_project_root())
         .unwrap_or_else(|_| configured_project_root().to_path_buf());
-    let mappings = match ActonConfig::load() {
-        Ok(config) => config.mappings(),
+    let (mappings, acton_config) = match ActonConfig::load() {
+        Ok(config) => (config.mappings(), Some(Arc::new(config))),
         Err(e) => {
             eprintln!("  ⚠ Failed to load Acton.toml: {e:#}");
-            None
+            (None, None)
         }
     };
 
     if port.is_none() && !stdio {
         // default to stdio if no port is provided and stdio is not explicitly set
-        return ls_cmd_internal(port, true, file_db, project_root, mappings).await;
+        return ls_cmd_internal(port, true, file_db, project_root, mappings, acton_config).await;
     }
 
-    ls_cmd_internal(port, stdio, file_db, project_root, mappings).await
+    ls_cmd_internal(port, stdio, file_db, project_root, mappings, acton_config).await
 }
 
 async fn ls_cmd_internal(
@@ -53,6 +53,7 @@ async fn ls_cmd_internal(
     file_db: FileDb,
     project_root: PathBuf,
     mappings: Option<BTreeMap<String, String>>,
+    acton_config: Option<Arc<ActonConfig>>,
 ) -> anyhow::Result<()> {
     let (service, socket) = LspService::new(|client| {
         #[cfg(feature = "profiling")]
@@ -75,6 +76,7 @@ async fn ls_cmd_internal(
             file_db: Arc::new(file_db),
             project_root: project_root.clone(),
             mappings: mappings.clone(),
+            acton_config: acton_config.clone(),
             documents: DashMap::new(),
             analysis: DashMap::new(),
             file_urls: DashMap::new(),


### PR DESCRIPTION
## Summary

`acton ls` built its `Checker` without ever calling `.with_settings(...)`, so it diverged from `acton check` in two ways:

1. The `[lint]` block from `Acton.toml` was ignored — neither global nor per-contract overrides took effect.
2. `*.test.tolk` files and script roots got contract-level diagnostics. The visible symptom: false-positive `E010` (`acton_import_in_contract`) on `@acton/...` imports inside test files, and — because the auto-generated `Counter.gen.tolk` wrapper is reachable from the test — three E010s inside that wrapper as well.

## Reproduction

```sh
acton new repro && cd repro
$EDITOR contracts/tests/counter.test.tolk   # open in any LSP-enabled editor
```

The first three `import "@acton/..."` lines are flagged with E010. `acton check` is clean.

## Fix

Mirror the dispatch from `src/commands/check/mod.rs`:

- Load the full `ActonConfig` in the LSP (`Backend.acton_config: Option<Arc<ActonConfig>>`), not just `mappings`.
- Build lint settings **once per analysis root** in `Backend::settings_for_root`:
  - root is a declared contract source → `Checker::build_settings(config, Some(id))`
  - otherwise → `build_settings(config, None)` plus the three contract-only allowances that `check_test_file` already grants (`ActonImportInContract`, `RandomRequiresInitialization`, `DivideBeforeMultiply`).
- Apply that one setting to every reachable file in the analysis. This matches `check_root_file` in CLI, so wrappers reached transitively from a test no longer inherit contract-level rules.

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo test -p ton-ls` (57 passed)
- [x] `cargo test -p tolk-linter -p acton-config`
- [x] `cargo test --test integration_test acton_import` (5 passed — existing CLI coverage for the rule is intact)
- [x] Manual verification by driving `acton ls --stdio` against an `acton new` project: E010 disappears on `counter.test.tolk`, `deploy.tolk`, and `Counter.gen.tolk`, but still fires when an `@acton/...` import is added to `Counter.tolk`.

## Follow-ups (not in this PR)

- LSP-level regression test for diagnostics. The existing self-contained harness (`crates/ton-ls/tests/self_contained/harness/`) is built around goto / hover / completion responses; capturing `publishDiagnostics` would need new infrastructure.
- CLI and LSP currently duplicate the dispatch logic. Extracting a shared helper in `tolk-linter` is a natural next step but out of scope here.