### PR TITLE
Fix ls stdlib resolution from project root

### DIFF
--- a/src/commands/ls/mod.rs
+++ b/src/commands/ls/mod.rs
@@ -1,4 +1,4 @@
-use crate::paths;
+use crate::{paths, stdlib};
 use acton_config::config::{ActonConfig, project_root as configured_project_root};
 use dashmap::DashMap;
 use std::collections::BTreeMap;
@@ -19,18 +19,19 @@ pub async fn ls_cmd(
         setup_ls_logging(log_file)?;
     }
 
-    let stdlib_path =
-        dunce::canonicalize(PathBuf::from(".acton/tolk-stdlib")).expect("Failed to canonicalize");
-    let acton_stdlib_path =
-        dunce::canonicalize(PathBuf::from(".acton/")).unwrap_or_else(|_| PathBuf::from(".acton/"));
+    let project_root = dunce::canonicalize(configured_project_root())
+        .unwrap_or_else(|_| configured_project_root().to_path_buf());
+    stdlib::ensure_latest(&project_root)?;
+
+    let stdlib_path = dunce::canonicalize(project_root.join(".acton/tolk-stdlib"))?;
+    let acton_stdlib_path = dunce::canonicalize(project_root.join(".acton"))
+        .unwrap_or_else(|_| project_root.join(".acton"));
     let common_tolk = stdlib_path.join("common.tolk");
 
     let file_db = FileDb::new(stdlib_path, Some(acton_stdlib_path));
     if common_tolk.exists() {
         let _ = file_db.process(&common_tolk);
     }
-    let project_root = dunce::canonicalize(configured_project_root())
-        .unwrap_or_else(|_| configured_project_root().to_path_buf());
     let mappings = match ActonConfig::load() {
         Ok(config) => config.mappings(),
         Err(e) => {

--- a/src/commands/ls/mod.rs
+++ b/src/commands/ls/mod.rs
@@ -21,7 +21,11 @@ pub async fn ls_cmd(
 
     let project_root = dunce::canonicalize(configured_project_root())
         .unwrap_or_else(|_| configured_project_root().to_path_buf());
-    stdlib::ensure_latest(&project_root)?;
+    if port.is_none() {
+        stdlib::ensure_latest_quiet(&project_root)?;
+    } else {
+        stdlib::ensure_latest(&project_root)?;
+    }
 
     let stdlib_path = dunce::canonicalize(project_root.join(".acton/tolk-stdlib"))?;
     let acton_stdlib_path = dunce::canonicalize(project_root.join(".acton"))

--- a/src/stdlib.rs
+++ b/src/stdlib.rs
@@ -24,7 +24,7 @@ pub fn ensure_latest(project_root: &Path) -> anyhow::Result<()> {
     ensure_latest_with_output(project_root, true)
 }
 
-pub fn ensure_latest_quiet(project_root: &Path) -> anyhow::Result<()> {
+pub(crate) fn ensure_latest_quiet(project_root: &Path) -> anyhow::Result<()> {
     ensure_latest_with_output(project_root, false)
 }
 

--- a/src/stdlib.rs
+++ b/src/stdlib.rs
@@ -21,6 +21,14 @@ pub(crate) fn current_stdlib_version() -> String {
 }
 
 pub fn ensure_latest(project_root: &Path) -> anyhow::Result<()> {
+    ensure_latest_with_output(project_root, true)
+}
+
+pub fn ensure_latest_quiet(project_root: &Path) -> anyhow::Result<()> {
+    ensure_latest_with_output(project_root, false)
+}
+
+fn ensure_latest_with_output(project_root: &Path, report_progress: bool) -> anyhow::Result<()> {
     if auto_install_disabled() {
         return Ok(());
     }
@@ -30,11 +38,11 @@ pub fn ensure_latest(project_root: &Path) -> anyhow::Result<()> {
         return Ok(());
     }
 
-    install_latest(project_root, false)
+    install_latest(project_root, false, report_progress)
 }
 
 pub fn update_latest(project_root: &Path) -> anyhow::Result<()> {
-    install_latest(project_root, true)
+    install_latest(project_root, true, true)
 }
 
 #[must_use]
@@ -45,7 +53,7 @@ fn auto_install_disabled() -> bool {
     })
 }
 
-fn install_latest(project_root: &Path, force: bool) -> anyhow::Result<()> {
+fn install_latest(project_root: &Path, force: bool, report_progress: bool) -> anyhow::Result<()> {
     let acton_dir = project_root.join(".acton");
     if !acton_dir.exists() {
         fs::create_dir_all(&acton_dir)?;
@@ -62,18 +70,20 @@ fn install_latest(project_root: &Path, force: bool) -> anyhow::Result<()> {
     };
 
     if needs_update {
-        if version_path.exists() {
-            println!(
-                "    {} standard library to v{}",
-                "Updating".green().bold(),
-                current_version
-            );
-        } else {
-            println!(
-                "  {} standard library v{}",
-                "Installing".green().bold(),
-                current_version
-            );
+        if report_progress {
+            if version_path.exists() {
+                println!(
+                    "    {} standard library to v{}",
+                    "Updating".green().bold(),
+                    current_version
+                );
+            } else {
+                println!(
+                    "  {} standard library v{}",
+                    "Installing".green().bold(),
+                    current_version
+                );
+            }
         }
 
         let tolk_stdlib_dir = acton_dir.join("tolk-stdlib");

--- a/tests/integration/ls_tests.rs
+++ b/tests/integration/ls_tests.rs
@@ -1,4 +1,4 @@
-use crate::support::project::ProjectBuilder;
+use crate::support::{TestOutputExt, project::ProjectBuilder};
 use std::fs;
 
 #[test]
@@ -19,7 +19,7 @@ fn test_ls_ensure_latest_uses_project_root_from_nested_directory() {
         "stdlib must not exist in nested cwd before ls command"
     );
 
-    project
+    let output = project
         .acton()
         .arg("--project-root")
         .arg("..")
@@ -29,6 +29,8 @@ fn test_ls_ensure_latest_uses_project_root_from_nested_directory() {
         .current_dir(&nested_dir)
         .run()
         .success();
+    output.assert_not_contains("Installing standard library");
+    output.assert_not_contains("Updating standard library");
 
     assert!(
         root_stdlib.exists(),

--- a/tests/integration/ls_tests.rs
+++ b/tests/integration/ls_tests.rs
@@ -1,0 +1,41 @@
+use crate::support::project::ProjectBuilder;
+use std::fs;
+
+#[test]
+fn test_ls_ensure_latest_uses_project_root_from_nested_directory() {
+    let project = ProjectBuilder::new("ls-ensure-latest-project-root").build();
+
+    let nested_dir = project.path().join("nested");
+    fs::create_dir_all(&nested_dir).expect("Failed to create nested test directory");
+
+    let root_stdlib = project.path().join(".acton/tolk-stdlib");
+    let nested_stdlib = nested_dir.join(".acton/tolk-stdlib");
+    assert!(
+        !root_stdlib.exists(),
+        "stdlib must not exist before ls command"
+    );
+    assert!(
+        !nested_stdlib.exists(),
+        "stdlib must not exist in nested cwd before ls command"
+    );
+
+    project
+        .acton()
+        .arg("--project-root")
+        .arg("..")
+        .arg("ls")
+        .arg("--stdio")
+        .arg("--no-log")
+        .current_dir(&nested_dir)
+        .run()
+        .success();
+
+    assert!(
+        root_stdlib.exists(),
+        "stdlib should be installed in project root"
+    );
+    assert!(
+        !nested_stdlib.exists(),
+        "stdlib should not be installed relative to nested cwd"
+    );
+}

--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -25,6 +25,7 @@ mod init_tests;
 mod library_tests;
 mod localnet_tests;
 mod logging_tests;
+mod ls_tests;
 mod mappings_tests;
 mod new_tests;
 mod parse_int_tests;


### PR DESCRIPTION
Summary: resolves acton ls stdlib paths from the configured project root instead of the current working directory, and ensures the stdlib is available before scanning. Uses a quiet stdlib install path for stdio LSP startup so human-readable install/update banners do not corrupt the LSP stdout stream. Adds an integration test covering ls from a nested working directory with --project-root and asserts the stdlib banner is not written to stdout.

Verification: cargo fmt --check passed; git diff --check passed; targeted integration test passed in Ubuntu WSL: cargo test --test integration_test integration::ls_tests::test_ls_ensure_latest_uses_project_root_from_nested_directory -- --exact.