### PR TITLE
docs(first-contract): correct TVM stack and cell limit explanation in…

### DIFF
--- a/docs/content/docs/tutorial/naive-centralized-poll.mdx
+++ b/docs/content/docs/tutorial/naive-centralized-poll.mdx
@@ -44,7 +44,15 @@ With a small number of voters it works correctly.
 
 ## The wall
 
-TON contracts store persistent data in a **cell tree**. A single cell holds at most 1023 bits and up to 4 references. The full tree must fit in the TVM stack when the contract runs. One `address → bool` entry per voter fills up that tree long before a popular poll ends.
+TON contracts store persistent data in a cell tree. A single cell holds at most **1023 bits** and up to **4 references**.
+
+While the TVM lazily traverses this tree via cell references rather than loading the entire state into memory, there is a hard protocol limit: **a single contract's persistent state is strictly capped at a maximum of 65,536 unique cells.**
+
+Furthermore, as the official TON documentation explicitly warns:
+
+> *"Every map that is expected to grow beyond 1,000 values is dangerous. In the TVM map, key access is asymptotically logarithmic, meaning that gas consumption continuously increases to find keys as the map grows."*
+
+Because of this, storing an `address → bool` entry per voter in a single contract is a fatal architectural flaw. It will rapidly hit the hard 65k cell ceiling, and even before that, gas costs to update and query the dictionary will skyrocket, rendering the contract economically unviable long before a popular poll ends.
 
 More fundamentally: **TON itself shards**. Different contracts run in parallel on different shards. A single contract holding all voter state becomes a sequential bottleneck — every vote is a write to the same storage.
 

--- a/docs/content/docs/tutorial/naive-centralized-poll.mdx
+++ b/docs/content/docs/tutorial/naive-centralized-poll.mdx
@@ -44,15 +44,13 @@ With a small number of voters it works correctly.
 
 ## The wall
 
-TON contracts store persistent data in a cell tree. A single cell holds at most **1023 bits** and up to **4 references**.
+TON contracts store persistent data in a cell tree. A single cell holds at most **1023 bits** and up to **4 references**. While the TVM lazily traverses this tree via cell references rather than loading the entire state into memory, there is a hard limit: a single contract's persistent state is capped at **65,536** unique cells.
 
-While the TVM lazily traverses this tree via cell references rather than loading the entire state into memory, there is a hard protocol limit: **a single contract's persistent state is strictly capped at a maximum of 65,536 unique cells.**
+Furthermore, as TON documentation explicitly warns:
 
-Furthermore, as the official TON documentation explicitly warns:
+> Every map that is expected to grow beyond 1,000 values is dangerous. In the TVM map, key access is asymptotically logarithmic, meaning that gas consumption continuously increases to find keys as the map grows.
 
-> *"Every map that is expected to grow beyond 1,000 values is dangerous. In the TVM map, key access is asymptotically logarithmic, meaning that gas consumption continuously increases to find keys as the map grows."*
-
-Because of this, storing an `address → bool` entry per voter in a single contract is a fatal architectural flaw. It will rapidly hit the hard 65k cell ceiling, and even before that, gas costs to update and query the dictionary will skyrocket, rendering the contract economically unviable long before a popular poll ends.
+Because of this, storing an `address → bool` entry per voter in a single contract is a fatal architectural flaw. It will rapidly hit the hard 65k cell ceiling, and even before that, gas costs for updating and querying the dictionary will soar, rendering the contract economically unviable long before a popular poll ends.
 
 More fundamentally: **TON itself shards**. Different contracts run in parallel on different shards. A single contract holding all voter state becomes a sequential bottleneck — every vote is a write to the same storage.
 


### PR DESCRIPTION
The original text in the "Your First TON Smart Contract" guide stated that 
"The full tree must fit in the TVM stack when the contract runs." 

This is technically incorrect. The TVM does not load the entire state tree 
into the stack; it lazily traverses the cell tree via references. 

This commit rewrites "The wall" section to accurately explain the actual 
limitations developers will hit:
1. The hard protocol limit of 65,536 unique cells per contract.
2. The official TON documentation warning regarding maps growing beyond  1,000 values and the resulting logarithmic gas cost increases.

This ensures readers understand the true architectural bottlenecks (state 
bloat and gas costs) rather than a non-existent stack capacity issue.