### PR TITLE
fix(explorer): prevent ABI row link from covering the page

### DIFF
--- a/packages/explorer-core/src/components/AbiCatalog.module.css
+++ b/packages/explorer-core/src/components/AbiCatalog.module.css
@@ -130,7 +130,6 @@
 }
 
 .tableRow {
-  position: relative;
   background: var(--acton-color-surface-raised);
   cursor: pointer;
   transition: background-color var(--acton-duration-fast) var(--acton-ease-standard);
@@ -141,34 +140,8 @@
   background: var(--acton-color-surface-row);
 }
 
-.rowOverlayLink {
-  position: absolute;
-  inset: 0;
-  z-index: 1;
-  text-decoration: none;
-}
-
-.rowOverlayLink:focus-visible {
-  outline: none;
-  box-shadow: inset 0 0 0 2px var(--acton-color-focus-ring);
-}
-
-.visuallyHidden {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
-  border: 0;
-}
-
 .nameCell {
   min-width: 0;
-  position: relative;
-  z-index: 2;
   width: fit-content;
 }
 
@@ -201,6 +174,7 @@
 
 .nameText {
   color: var(--acton-color-text);
+  text-decoration: none;
 }
 
 .environmentBadge {

--- a/packages/explorer-core/src/components/AbiCatalog.tsx
+++ b/packages/explorer-core/src/components/AbiCatalog.tsx
@@ -4,7 +4,7 @@ import {AbiPanel, type AbiTab} from "@acton/transaction-ui/abi"
 import {InlineAction, InlineActions, Input, Pagination, useToast} from "@acton/ui"
 import type {ContractABI} from "@ton/tolk-abi-to-typescript"
 import {CircleAlert, Plus, Trash2, Upload} from "lucide-react"
-import {Link} from "react-router"
+import {Link, useNavigate} from "react-router"
 
 import type {ExtendedContractABI} from "../api/compilerAbi"
 import {
@@ -39,6 +39,7 @@ export interface AbiCatalogTableEntry {
 
 export const AbiCatalog: FC = () => {
   const routes = useExplorerRoutePaths()
+  const navigate = useNavigate()
   const metadataRegistry = useMetadataRegistry()
   const {showToast} = useToast()
   const [state, setState] = useState<AbiCatalogState>({loading: true, entries: []})
@@ -275,16 +276,14 @@ export const AbiCatalog: FC = () => {
                   const title = abiTitle(entry.abi)
                   const contractName = entry.abi.compiler_abi.contract_name
                   const deleteCodeHash = entry.deleteCodeHash
+                  const detailsPath = routes.abiDetailsPath(entry.slug)
                   return (
-                    <tr key={entry.slug} className={styles.tableRow}>
+                    <tr
+                      key={entry.slug}
+                      className={styles.tableRow}
+                      onClick={() => void navigate(detailsPath)}
+                    >
                       <td>
-                        <Link
-                          className={styles.rowOverlayLink}
-                          to={routes.abiDetailsPath(entry.slug)}
-                          aria-label={`Open ${title} ABI`}
-                        >
-                          <span className={styles.visuallyHidden}>Open {title} ABI</span>
-                        </Link>
                         <InlineActions
                           className={styles.nameCell}
                           visibility="always"
@@ -304,7 +303,14 @@ export const AbiCatalog: FC = () => {
                         >
                           <span className={styles.primaryCell}>
                             <span className={styles.nameLine}>
-                              <span className={styles.nameText}>{title}</span>
+                              <Link
+                                className={styles.nameText}
+                                to={detailsPath}
+                                aria-label={`Open ${title} ABI`}
+                                onClick={event => event.stopPropagation()}
+                              >
+                                {title}
+                              </Link>
                               {entry.source === "environment" && (
                                 <span className={styles.environmentBadge}>environment</span>
                               )}


### PR DESCRIPTION
Clicking anywhere in the ABI catalog body, including pagination, opened the Bidask ABI.
An absolutely positioned row link escaped its table row and covered the page.
This removes the overlay while keeping rows clickable and ABI names as native links.