### PR TITLE
chore(explorer): add explicit USDT alias for Tether USD to aid with search

### DIFF
--- a/packages/address-registry/scripts/conflict-resolutions.ts
+++ b/packages/address-registry/scripts/conflict-resolutions.ts
@@ -277,6 +277,11 @@ export const CONFLICT_RESOLUTIONS = [
     name: "Zero Address",
   },
   {
+    address: "0:b113a994b5024a16719f69139328eb759596c38a25f59028b146fecdc3621dfe",
+    source: "acton",
+    name: "Tether USD (USDT)",
+  },
+  {
     address: "-1:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
     source: "ton-assets",
     name: "Blackhole Address",

--- a/packages/address-registry/scripts/sources/acton.ts
+++ b/packages/address-registry/scripts/sources/acton.ts
@@ -20,6 +20,10 @@ export const ACTON_MAINNET_ADDRESSES = [
     address: "Ef_q19o4m94xfF-yhYB85Qe6rTHDX-VTSzxBh4XpAfZMaOvk",
     name: "BTC Teleport Coordinator",
   },
+  {
+    address: "EQCxE6mUtQJKFnGfaROTKOt1lZbDiiX1kCixRv7Nw2Id_sDs",
+    name: "Tether USD (USDT)",
+  },
 ] as const satisfies readonly SourceAddress[]
 
 export const ACTON_TESTNET_ADDRESSES = [

--- a/packages/address-registry/src/mainnet.json
+++ b/packages/address-registry/src/mainnet.json
@@ -2589,7 +2589,7 @@
   },
   {
     "address": "0:b113a994b5024a16719f69139328eb759596c38a25f59028b146fecdc3621dfe",
-    "name": "Tether USD"
+    "name": "Tether USD (USDT)"
   },
   {
     "address": "0:b16a061860c9f389d4ef41fdfdaa7914bc09167db9f5377b5ea95c504ed76b77",

--- a/packages/address-registry/tests/sources.test.ts
+++ b/packages/address-registry/tests/sources.test.ts
@@ -64,7 +64,7 @@ describe("source address validation", () => {
 describe("Acton address networks", () => {
   test("mainnet list has the expected size", () => {
     // Think carefully before adding a mainnet address; prefer an upstream registry when possible.
-    expect(ACTON_MAINNET_ADDRESSES).toHaveLength(4)
+    expect(ACTON_MAINNET_ADDRESSES).toHaveLength(5)
   })
 
   test("mainnet list contains only mainnet friendly addresses", () => {


### PR DESCRIPTION
Basically, "Tether USD" became "Tether USD (USDT)"