### PR TITLE
fix(stdlib): allow negative config param ids in emulation config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,6 +140,11 @@ integration remains hidden and preview-only.
   automatic fix. Compiler and linter diagnostics are also available through the
   language server.
 - `tolkfmt` now preserves comments placed between annotations and declarations.
+- Fixed the emulation config map (`BlockchainConfigMap`) to key parameters by a
+  signed 32-bit id, matching TON's `Hashmap 32 ^Cell = ConfigParams`. This lets
+  `setParamRaw`/`getParamRaw` address out-of-consensus **negative** config
+  params (for example `-137`) instead of throwing a range-check error, and the
+  values round-trip with `blockchain.configParam` (`CONFIGOPTPARAM`).
 
 ### Acton Studio
 

--- a/docs/content/docs/standard_library/emulation/config.mdx
+++ b/docs/content/docs/standard_library/emulation/config.mdx
@@ -44,15 +44,17 @@ println("Bit price: {}", storagePrices);
 ## `BlockchainConfigMap`
 
 ```tolk
-type BlockchainConfigMap = map<uint32, cell>
+type BlockchainConfigMap = map<int32, cell>
 ```
 
 Type representing the blockchain configuration.
 
-The configuration is a key-value map where keys are parameter indices (0-255)
-and values are cells containing the serialized configuration parameter data.
-Configuration parameters are defined in the [`block.tlb`](https://github.com/ton-blockchain/ton/blob/master/crypto/block/block.tlb)
-TL-B schema.
+The configuration is a key-value map where keys are parameter indices and
+values are cells containing the serialized configuration parameter data.
+It mirrors TON's `HashmapE 32 ^Cell = ConfigParam` (see [`block.tlb`](https://github.com/ton-blockchain/ton/blob/master/crypto/block/block.tlb)):
+keys are **signed** 32-bit integers, so besides the in-consensus params
+(typically 0-90) it can also carry the out-of-consensus **negative** params
+(e.g. -137, -138, -1000) that `CONFIGPARAM`/`CONFIGOPTPARAM` read on-chain.
 
 `BlockchainConfigMap.set*` methods mutate only this in-memory map.
 To apply updates to the emulator globally, call [testing.setConfig](/docs/standard_library/emulation/testing#testingsetconfig) with the
@@ -60,12 +62,12 @@ mutated config. That apply step updates both the emulator world state and
 the current VM context's C7-visible config mirrors, so follow-up reads in
 the same test run see the committed values.
 
-<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/emulation/config.tolk#L46" />
+<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/emulation/config.tolk#L48" />
 
 ## `BlockchainConfigMap.setParamRaw`
 
 ```tolk
-fun BlockchainConfigMap.setParamRaw(mutate self, index: uint32, data: cell): void
+fun BlockchainConfigMap.setParamRaw(mutate self, index: int32, data: cell): void
 ```
 
 Sets a raw configuration parameter at the given index.
@@ -76,20 +78,22 @@ For type-safe parameter access, prefer using specialized setter functions such a
 This mutates only the local [BlockchainConfigMap](#blockchainconfigmap) value until you call [testing.setConfig](/docs/standard_library/emulation/testing#testingsetconfig).
 
 Parameters:
-- `index`: The configuration parameter index (typically 0-90)
+- `index`: The configuration parameter index. It is a signed 32-bit integer,
+  so negative (out-of-consensus) indices such as `-137` are valid.
 - `data`: The serialized cell containing the parameter value
 
 Example:
 ```tolk
 config.setParamRaw(20, gasCell);
+config.setParamRaw(-137, someCell); // out-of-consensus param
 ```
 
-<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/emulation/config.tolk#L63" />
+<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/emulation/config.tolk#L67" />
 
 ## `BlockchainConfigMap.getParamRaw`
 
 ```tolk
-fun BlockchainConfigMap.getParamRaw(self, index: uint32): cell
+fun BlockchainConfigMap.getParamRaw(self, index: int32): cell
 ```
 
 Retrieves a raw configuration parameter at the given index.
@@ -99,7 +103,8 @@ For type-safe parameter access, prefer using specialized getter functions such a
 [BlockchainConfigMap.getGasPrices](#blockchainconfigmapgetgasprices), [BlockchainConfigMap.getStoragePrices](#blockchainconfigmapgetstorageprices), or [BlockchainConfigMap.getGlobalVersion](#blockchainconfigmapgetglobalversion).
 
 Parameters:
-- `index`: The configuration parameter index (typically 0-90)
+- `index`: The configuration parameter index. It is a signed 32-bit integer,
+  so negative (out-of-consensus) indices such as `-137` are valid.
 
 Returns: The raw cell containing the serialized parameter value.
 
@@ -108,7 +113,7 @@ Example:
 val paramCell = config.getParamRaw(20);
 ```
 
-<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/emulation/config.tolk#L82" />
+<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/emulation/config.tolk#L87" />
 
 ## `GLOBAL_VERSION_INDEX`
 
@@ -121,7 +126,7 @@ Configuration parameter index for global network version (Param 8).
 This parameter contains the network version number and capability flags supported by validators.
 It is used to coordinate network upgrades and enable/disable protocol features.
 
-<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/emulation/config.tolk#L90" />
+<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/emulation/config.tolk#L95" />
 
 ## `GlobalVersion`
 
@@ -139,7 +144,7 @@ Network version and capabilities information (Param 8).
 This struct contains the current network version and a set of capability flags
 that indicate which features are supported by the network.
 
-<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/emulation/config.tolk#L96" />
+<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/emulation/config.tolk#L101" />
 
 ## `BlockchainConfigMap.setGlobalVersion`
 
@@ -169,7 +174,7 @@ if (!testing.setConfig(config)) {
 }
 ```
 
-<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/emulation/config.tolk#L124" />
+<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/emulation/config.tolk#L129" />
 
 ## `BlockchainConfigMap.getGlobalVersion`
 
@@ -190,7 +195,7 @@ val version = config.getGlobalVersion();
 println("Network version: {}, capabilities: {}", version.version, version.capabilities);
 ```
 
-<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/emulation/config.tolk#L140" />
+<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/emulation/config.tolk#L145" />
 
 ## `STORAGE_PRICES_INDEX`
 
@@ -203,7 +208,7 @@ Configuration parameter index for storage prices (Param 18).
 Storage prices determine the cost of storing data on the TON Blockchain.
 These costs are used to prevent spam and ensure network maintenance is properly funded.
 
-<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/emulation/config.tolk#L148" />
+<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/emulation/config.tolk#L153" />
 
 ## `StoragePrices`
 
@@ -228,7 +233,7 @@ This struct defines the pricing for data storage in both the masterchain and reg
 Prices are given per 65536 seconds of storage. Storage fees are calculated based on the number
 of bits and cells used to represent contract code and data.
 
-<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/emulation/config.tolk#L155" />
+<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/emulation/config.tolk#L160" />
 
 ## `StoragePricesDict`
 
@@ -241,7 +246,7 @@ Dictionary mapping Unix timestamps to storage price configurations.
 This allows different storage prices to apply at different periods in time.
 The dictionary is indexed by Unix timestamp values.
 
-<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/emulation/config.tolk#L172" />
+<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/emulation/config.tolk#L177" />
 
 ## `INITIAL_UNIXTIME_STORAGE_INDEX`
 
@@ -254,7 +259,7 @@ Configuration parameter index for the initial storage price (timestamp 0).
 This index refers to the storage price entry at index 0, which represents the initial
 storage price configuration that applies from the beginning of time.
 
-<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/emulation/config.tolk#L178" />
+<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/emulation/config.tolk#L183" />
 
 ## `StoragePricesDict.getInitial`
 
@@ -276,7 +281,7 @@ val initialPrices = storagePrices.getInitial();
 println("Initial bit price: {}", initialPrices.bitPrice);
 ```
 
-<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/emulation/config.tolk#L193" />
+<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/emulation/config.tolk#L198" />
 
 ## `StoragePricesDict.setInitial`
 
@@ -309,7 +314,7 @@ if (!testing.setConfig(config)) {
 }
 ```
 
-<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/emulation/config.tolk#L226" />
+<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/emulation/config.tolk#L231" />
 
 ## `BlockchainConfigMap.setStoragePrices`
 
@@ -343,7 +348,7 @@ if (!testing.setConfig(config)) {
 }
 ```
 
-<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/emulation/config.tolk#L255" />
+<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/emulation/config.tolk#L260" />
 
 ## `BlockchainConfigMap.getStoragePrices`
 
@@ -366,7 +371,7 @@ println("Bit price: {}, Cell price: {}, Masterchain bit price: {}",
     prices.bitPrice, prices.cellPrice, prices.masterchainBitPrice);
 ```
 
-<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/emulation/config.tolk#L276" />
+<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/emulation/config.tolk#L281" />
 
 ## `GasPricesExtended`
 
@@ -393,7 +398,7 @@ Gas price configuration for extended gas schemes (Param 20/21 variant).
 
 This variant includes a special gas limit for system contracts.
 
-<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/emulation/config.tolk#L285" />
+<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/emulation/config.tolk#L290" />
 
 ## `GasPrices`
 
@@ -413,7 +418,7 @@ Gas price configuration with flat pricing prefix.
 This allows for two-tiered pricing where a flat fee and price are applied first,
 followed by the standard pricing structure.
 
-<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/emulation/config.tolk#L306" />
+<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/emulation/config.tolk#L311" />
 
 ## `MASTERCHAIN_GAS_PRICES_INDEX`
 
@@ -423,7 +428,7 @@ const MASTERCHAIN_GAS_PRICES_INDEX = 20
 
 Configuration parameter index for masterchain gas prices (Param 20).
 
-<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/emulation/config.tolk#L316" />
+<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/emulation/config.tolk#L321" />
 
 ## `BASECHAIN_GAS_PRICES_INDEX`
 
@@ -433,7 +438,7 @@ const BASECHAIN_GAS_PRICES_INDEX = 21
 
 Configuration parameter index for basechain gas prices (Param 21).
 
-<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/emulation/config.tolk#L319" />
+<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/emulation/config.tolk#L324" />
 
 ## `BlockchainConfigMap.setGasPrices`
 
@@ -453,7 +458,7 @@ Parameters:
 
 This mutates only the local [BlockchainConfigMap](#blockchainconfigmap) value until you call [testing.setConfig](/docs/standard_library/emulation/testing#testingsetconfig).
 
-<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/emulation/config.tolk#L332" />
+<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/emulation/config.tolk#L337" />
 
 ## `BlockchainConfigMap.getGasPrices`
 
@@ -476,7 +481,7 @@ val gasPrices = config.getGasPrices(BASECHAIN);
 println("Gas limit basechain: {}", gasPrices);
 ```
 
-<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/emulation/config.tolk#L353" />
+<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/emulation/config.tolk#L358" />
 
 ## `MsgForwardPrices`
 
@@ -502,7 +507,7 @@ Message forwarding price configuration (Param 24/25).
 This struct defines the costs associated with forwarding messages between accounts and shards
 in the TON Blockchain. Message routing uses these prices to calculate fees for message delivery.
 
-<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/emulation/config.tolk#L364" />
+<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/emulation/config.tolk#L369" />
 
 ## `MASTERCHAIN_MSG_FORWARD_PRICES_INDEX`
 
@@ -512,7 +517,7 @@ const MASTERCHAIN_MSG_FORWARD_PRICES_INDEX = 24
 
 Configuration parameter index for masterchain message forwarding prices (Param 24).
 
-<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/emulation/config.tolk#L380" />
+<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/emulation/config.tolk#L385" />
 
 ## `BASECHAIN_MSG_FORWARD_PRICES_INDEX`
 
@@ -522,7 +527,7 @@ const BASECHAIN_MSG_FORWARD_PRICES_INDEX = 25
 
 Configuration parameter index for basechain message forwarding prices (Param 25).
 
-<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/emulation/config.tolk#L383" />
+<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/emulation/config.tolk#L388" />
 
 ## `BlockchainConfigMap.setMsgForwardPrices`
 
@@ -561,7 +566,7 @@ if (!testing.setConfig(config)) {
 }
 ```
 
-<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/emulation/config.tolk#L411" />
+<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/emulation/config.tolk#L416" />
 
 ## `BlockchainConfigMap.getMsgForwardPrices`
 
@@ -585,7 +590,7 @@ println("Lump price: {}, Bit price: {}, Cell price: {}",
     msgPrices.lumpPrice, msgPrices.bitPrice, msgPrices.cellPrice);
 ```
 
-<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/emulation/config.tolk#L438" />
+<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/emulation/config.tolk#L443" />
 
 ## `PRECOMPILED_CONTRACTS_CONFIG_INDEX`
 
@@ -599,7 +604,7 @@ Precompiled contracts are built-in smart contracts optimized for specific comput
 They consume a fixed amount of gas regardless of input size, making them more efficient
 than general-purpose contracts for their specific functions.
 
-<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/emulation/config.tolk#L451" />
+<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/emulation/config.tolk#L456" />
 
 ## `PrecompiledSmartContract`
 
@@ -614,7 +619,7 @@ Precompiled smart contract configuration.
 
 Specifies the gas usage for a precompiled contract.
 
-<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/emulation/config.tolk#L456" />
+<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/emulation/config.tolk#L461" />
 
 ## `PrecompiledContractsConfig`
 
@@ -630,7 +635,7 @@ Configuration for all precompiled contracts (Param 45).
 Contains a dictionary mapping contract code hashes to their gas usage specifications.
 Precompiled contracts are optimized implementations of common operations provided by the system.
 
-<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/emulation/config.tolk#L465" />
+<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/emulation/config.tolk#L470" />
 
 ## `PrecompiledContractsConfig.addContractGas`
 
@@ -647,7 +652,7 @@ Adds a precompiled contract gas entry if `hash` is not already present.
 Returns `true` when a new entry is inserted.
 Returns `false` for duplicate `hash` values, and keeps the original `gasUsage` unchanged.
 
-<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/emulation/config.tolk#L474" />
+<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/emulation/config.tolk#L479" />
 
 ## `BlockchainConfigMap.setPrecompiledContractsConfig`
 
@@ -681,7 +686,7 @@ if (!testing.setConfig(config)) {
 }
 ```
 
-<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/emulation/config.tolk#L504" />
+<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/emulation/config.tolk#L509" />
 
 ## `BlockchainConfigMap.getPrecompiledContractsConfig`
 
@@ -705,5 +710,5 @@ val precompiledConfig = config.getPrecompiledContractsConfig();
 val contractsList = precompiledConfig.list;
 ```
 
-<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/emulation/config.tolk#L526" />
+<SourceCodeLink href="https://github.com/ton-blockchain/acton/blob/master/lib/emulation/config.tolk#L531" />
 

--- a/lib/emulation/config.tolk
+++ b/lib/emulation/config.tolk
@@ -33,17 +33,19 @@ import "../testing/assert"
 
 /// Type representing the blockchain configuration.
 ///
-/// The configuration is a key-value map where keys are parameter indices (0-255)
-/// and values are cells containing the serialized configuration parameter data.
-/// Configuration parameters are defined in the [`block.tlb`](https://github.com/ton-blockchain/ton/blob/master/crypto/block/block.tlb)
-/// TL-B schema.
+/// The configuration is a key-value map where keys are parameter indices and
+/// values are cells containing the serialized configuration parameter data.
+/// It mirrors TON's `HashmapE 32 ^Cell = ConfigParam` (see [`block.tlb`](https://github.com/ton-blockchain/ton/blob/master/crypto/block/block.tlb)):
+/// keys are **signed** 32-bit integers, so besides the in-consensus params
+/// (typically 0-90) it can also carry the out-of-consensus **negative** params
+/// (e.g. -137, -138, -1000) that `CONFIGPARAM`/`CONFIGOPTPARAM` read on-chain.
 ///
 /// `BlockchainConfigMap.set*` methods mutate only this in-memory map.
 /// To apply updates to the emulator globally, call [testing.setConfig] with the
 /// mutated config. That apply step updates both the emulator world state and
 /// the current VM context's C7-visible config mirrors, so follow-up reads in
 /// the same test run see the committed values.
-type BlockchainConfigMap = map<uint32, cell>
+type BlockchainConfigMap = map<int32, cell>
 
 /// Sets a raw configuration parameter at the given index.
 ///
@@ -53,14 +55,16 @@ type BlockchainConfigMap = map<uint32, cell>
 /// This mutates only the local [BlockchainConfigMap] value until you call [testing.setConfig].
 ///
 /// Parameters:
-/// - `index`: The configuration parameter index (typically 0-90)
+/// - `index`: The configuration parameter index. It is a signed 32-bit integer,
+///   so negative (out-of-consensus) indices such as `-137` are valid.
 /// - `data`: The serialized cell containing the parameter value
 ///
 /// Example:
 /// ```tolk
 /// config.setParamRaw(20, gasCell);
+/// config.setParamRaw(-137, someCell); // out-of-consensus param
 /// ```
-fun BlockchainConfigMap.setParamRaw(mutate self, index: uint32, data: cell): void {
+fun BlockchainConfigMap.setParamRaw(mutate self, index: int32, data: cell): void {
     self.set(index, data);
 }
 
@@ -71,7 +75,8 @@ fun BlockchainConfigMap.setParamRaw(mutate self, index: uint32, data: cell): voi
 /// [BlockchainConfigMap.getGasPrices], [BlockchainConfigMap.getStoragePrices], or [BlockchainConfigMap.getGlobalVersion].
 ///
 /// Parameters:
-/// - `index`: The configuration parameter index (typically 0-90)
+/// - `index`: The configuration parameter index. It is a signed 32-bit integer,
+///   so negative (out-of-consensus) indices such as `-137` are valid.
 ///
 /// Returns: The raw cell containing the serialized parameter value.
 ///
@@ -79,7 +84,7 @@ fun BlockchainConfigMap.setParamRaw(mutate self, index: uint32, data: cell): voi
 /// ```tolk
 /// val paramCell = config.getParamRaw(20);
 /// ```
-fun BlockchainConfigMap.getParamRaw(self, index: uint32): cell {
+fun BlockchainConfigMap.getParamRaw(self, index: int32): cell {
     return self.get(index).loadValue();
 }
 

--- a/tests/integration/ffi/config.test.tolk
+++ b/tests/integration/ffi/config.test.tolk
@@ -40,6 +40,61 @@ get fun `test bad config`() {
     expect(result).toBeFalse();
 }
 
+get fun `test set negative config param`() {
+    var config = testing.getConfig();
+
+    val negPayload = beginCell().storeUint(0xABCD1234, 32).endCell();
+    // Before the fix this call threw "Range check error": the config map used
+    // uint32 keys, so a signed id like -137 could not be encoded. TON's config
+    // dict is `Hashmap 32 ^Cell` keyed by the *signed* 32-bit index.
+    config.setParamRaw(-137, negPayload);
+
+    // the negative id round-trips locally
+    expect(config.getParamRaw(-137)).toEqual(negPayload);
+
+    // and does not collide with its positive twin (+137)
+    val posPayload = beginCell().storeUint(0x5555AAAA, 32).endCell();
+    config.setParamRaw(137, posPayload);
+    expect(config.getParamRaw(-137)).toEqual(negPayload);
+    expect(config.getParamRaw(137)).toEqual(posPayload);
+}
+
+get fun `test negative config param read by contract`() {
+    // Deploy a contract that reads an out-of-consensus param via CONFIGOPTPARAM.
+    val readerCode = build("config_reader");
+    val readerInit = AutoDeployAddress {
+        stateInit: { code: readerCode, data: beginCell().endCell() },
+    };
+    val readerAddr = readerInit.calculateAddress();
+
+    val deployMsg = createMessage({
+        dest: readerInit,
+        bounce: false,
+        value: ton("1"),
+    });
+    val deployer = testing.treasury("deployer");
+    val deployRes = net.send(deployer.address, deployMsg);
+    expect(deployRes).toHaveSuccessfulDeploy({
+        from: deployer.address,
+        to: readerAddr,
+    });
+
+    // Set the out-of-consensus negative param and commit it.
+    var config = testing.getConfig();
+    val payload = beginCell().storeUint(0x00C0FFEE, 32).endCell();
+    config.setParamRaw(-137, payload);
+    expect(testing.setConfig(config)).toBeTrue();
+
+    // It survives the round-trip through the raw config dict...
+    expect(testing.getConfig().getParamRaw(-137)).toEqual(payload);
+
+    // ...and the deployed contract reads back the same value via
+    // `blockchain.configParam(-137)` (CONFIGOPTPARAM), proving the 32-bit
+    // signed key bit-pattern matches what the VM looks up on-chain.
+    val readBack = net.runGetMethod(readerAddr, "readNegParam") as int;
+    expect(readBack).toEqual(0x00C0FFEE);
+}
+
 get fun `test get executor config`() {
     val simpleCode = build("simple");
     val getAddress = AutoDeployAddress {

--- a/tests/integration/ffi/mod.rs
+++ b/tests/integration/ffi/mod.rs
@@ -13,14 +13,14 @@ get fun getParam() {
 }
 "#;
 
-    const CONFIG_READER_CONTRACT: &str = r#"
+    const CONFIG_READER_CONTRACT: &str = r"
 fun onInternalMessage(in: InMessage) {}
 fun onBouncedMessage(_: InMessageBounced) {}
 get fun readNegParam(): int {
     val c = blockchain.configParam(-137);
     return c!.beginParse().loadUint(32);
 }
-"#;
+";
 
     #[test]
     fn test_get_config() {

--- a/tests/integration/ffi/mod.rs
+++ b/tests/integration/ffi/mod.rs
@@ -13,6 +13,15 @@ get fun getParam() {
 }
 "#;
 
+    const CONFIG_READER_CONTRACT: &str = r#"
+fun onInternalMessage(in: InMessage) {}
+fun onBouncedMessage(_: InMessageBounced) {}
+get fun readNegParam(): int {
+    val c = blockchain.configParam(-137);
+    return c!.beginParse().loadUint(32);
+}
+"#;
+
     #[test]
     fn test_get_config() {
         ProjectBuilder::new("simple")
@@ -50,6 +59,34 @@ get fun getParam() {
             .acton()
             .test()
             .filter("test bad config")
+            .run()
+            .success()
+            .assert_passed(1);
+    }
+
+    #[test]
+    fn test_set_negative_config_param() {
+        ProjectBuilder::new("simple")
+            .contract("simple", SIMPLE_CONTRACT)
+            .test_file_from_path("test", "tests/integration/ffi/config.test.tolk")
+            .build()
+            .acton()
+            .test()
+            .filter("test set negative config param")
+            .run()
+            .success()
+            .assert_passed(1);
+    }
+
+    #[test]
+    fn test_negative_config_param_read_by_contract() {
+        ProjectBuilder::new("simple")
+            .contract("config_reader", CONFIG_READER_CONTRACT)
+            .test_file_from_path("test", "tests/integration/ffi/config.test.tolk")
+            .build()
+            .acton()
+            .test()
+            .filter("test negative config param read by contract")
             .run()
             .success()
             .assert_passed(1);


### PR DESCRIPTION
## Problem

The emulation config API represents the blockchain config-param dictionary as `map<uint32, cell>`. Because the key type is unsigned, setting a **negative** config-param id throws a range-check error:

```
BlockchainConfigMap.setParamRaw   at lib/emulation/config.tolk
map<uint32, cell>.set             (Range check error — integer out of range)
```

But TON's real config dictionary is `_ config:^(Hashmap 32 ^Cell) = ConfigParams;` (`block.tlb`), keyed by the **signed** 32-bit parameter index. `CONFIGPARAM`/`CONFIGOPTPARAM` export that index with `signed = true` (`crypto/vm/tonops.cpp`, `exec_get_config_param`: `idx->export_bits(key.bits(), key.size(), true)`), so out-of-consensus **negative** params (e.g. `-137`, `-138`, `-1000`) are valid and readable on-chain via `blockchain.configParam(-137)`.

A contract can read those params fine, but the emulation test API could not **set** them — the only workaround was passing the uint32 two's-complement (`0xFFFFFF77` for `-137`), which is obscure and easy to get wrong.

## Fix

Key `BlockchainConfigMap` by `int32` instead of `uint32`, and take `int32` in `setParamRaw`/`getParamRaw`.

- For positive ids (0–90) the 32-bit key bit-pattern is identical, so existing behavior is unchanged.
- For negative ids the key now encodes as the exact two's-complement 32-bit key the VM looks up, so values round-trip with `CONFIGPARAM`/`CONFIGOPTPARAM`.

`map<int32, ...>` is already an established key type in the stdlib (e.g. `ExtraCurrenciesMap = map<int32, varuint32>`, matching `extra_currencies$_ dict:(HashmapE 32 ...)` in `block.tlb`).

## Tests

Added two emulation tests in `tests/integration/ffi/config.test.tolk` (registered in `tests/integration/ffi/mod.rs`):

- `test set negative config param` — `setParamRaw(-137, ...)` (which previously threw) round-trips through `getParamRaw(-137)` and does not collide with its positive twin `+137`.
- `test negative config param read by contract` — after `testing.setConfig`, `getConfig().getParamRaw(-137)` round-trips **and** a deployed contract reads the same value back via `blockchain.configParam(-137)` (CONFIGOPTPARAM), proving the 32-bit signed key bit-pattern matches the VM.

All existing `ffi::` and `config_*` param tests still pass (19/19), confirming no regression on positive keys.

Docs regenerated via `acton docgen`; changelog updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)