### PR TITLE
feat(transaction-ui): show meta fields for external-in messages

### DIFF
--- a/packages/explorer-core/src/api/traceTransactions.ts
+++ b/packages/explorer-core/src/api/traceTransactions.ts
@@ -50,6 +50,7 @@ export const buildTraceTransactionInfos = (
       blockRef: tx.block_ref,
       address: parseTonAddress(tx.account),
       transaction: synthesizeTransaction(tx),
+      inMessageHash: hashToHex(tx.in_msg?.hash),
       vmLogDiff: "",
       executorLogs: "",
       executorActions: [],

--- a/packages/transaction-ui/src/components/TransactionDetails/TransactionDetails.tsx
+++ b/packages/transaction-ui/src/components/TransactionDetails/TransactionDetails.tsx
@@ -509,6 +509,48 @@ function TransactionDetailsContent({
         </div>
       )}
 
+      {!isTickTock && inMessage && inMessage.info.type === "external-in" && (
+        <div className={styles.labeledSectionRow}>
+          <div className={styles.labeledSectionTitle}>In Message</div>
+
+          <div className={styles.labeledSectionContent}>
+            <div className={styles.multiColumnRow}>
+              <div className={styles.multiColumnItem}>
+                <div className={styles.multiColumnItemTitle}>Created At</div>
+                <DateTime
+                  className={`${styles.multiColumnItemValue} ${styles.timestampValue}`}
+                  data-visual-dynamic="timestamp"
+                  data-visual-placeholder="<timestamp>"
+                  display="date-time-numeric-seconds"
+                  unit="seconds"
+                  value={tx.transaction.now}
+                />
+              </div>
+              <div className={styles.multiColumnItem}>
+                <div className={styles.multiColumnItemTitle}>Created Lt</div>
+                <div className={`${styles.multiColumnItemValue} ${styles.numberValue}`}>
+                  {tx.transaction.lt.toString()}
+                </div>
+              </div>
+              {messageHashHex && (
+                <div className={styles.multiColumnItem}>
+                  <div className={styles.multiColumnItemTitle}>Hash</div>
+                  <div className={styles.multiColumnItemValue}>
+                    <TechnicalValue
+                      copyLabel="message hash"
+                      endLength={3}
+                      startLength={3}
+                      value={messageHashHex}
+                      copyVisibility="always"
+                    />
+                  </div>
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+
       {!isTickTock && (
         <div className={styles.labeledSectionRow}>
           <div className={styles.labeledSectionTitle}>Message Data</div>

--- a/packages/transaction-ui/src/components/TransactionDetails/TransactionDetails.tsx
+++ b/packages/transaction-ui/src/components/TransactionDetails/TransactionDetails.tsx
@@ -238,10 +238,10 @@ function TransactionDetailsContent({
     })()
   const messageBodyBocHex = inMessage ? formatCellBocHex(inMessage.body) : undefined
   const messageBocHex = inMessage ? formatMessageBocHex(inMessage) : undefined
-  const messageHashHex = inMessage ? formatMessageHashHex(inMessage) : undefined
-  // For external-driven transactions the hash shown is the transaction's own
-  // hash, taken from the raw cell the backend returned (not re-serialized).
-  const transactionHashHex = tx.transaction.hash().toString("hex")
+  // Prefer the data source's in-message hash; hashing the re-serialized
+  // message is a fallback that can diverge from the on-chain cell.
+  const messageHashHex =
+    tx.inMessageHash ?? (inMessage ? formatMessageHashHex(inMessage) : undefined)
   const stateInitCode = inMessage?.init?.code ?? undefined
   const stateInitData = inMessage?.init?.data ?? undefined
   const stateInitBocHex = inMessage?.init ? formatStateInitBocHex(inMessage.init) : undefined
@@ -535,18 +535,20 @@ function TransactionDetailsContent({
                   {tx.transaction.lt.toString()}
                 </div>
               </div>
-              <div className={styles.multiColumnItem}>
-                <div className={styles.multiColumnItemTitle}>Hash</div>
-                <div className={styles.multiColumnItemValue}>
-                  <TechnicalValue
-                    copyLabel="transaction hash"
-                    endLength={3}
-                    startLength={3}
-                    value={transactionHashHex}
-                    copyVisibility="always"
-                  />
+              {messageHashHex && (
+                <div className={styles.multiColumnItem}>
+                  <div className={styles.multiColumnItemTitle}>Hash</div>
+                  <div className={styles.multiColumnItemValue}>
+                    <TechnicalValue
+                      copyLabel="message hash"
+                      endLength={3}
+                      startLength={3}
+                      value={messageHashHex}
+                      copyVisibility="always"
+                    />
+                  </div>
                 </div>
-              </div>
+              )}
             </div>
           </div>
         </div>

--- a/packages/transaction-ui/src/components/TransactionDetails/TransactionDetails.tsx
+++ b/packages/transaction-ui/src/components/TransactionDetails/TransactionDetails.tsx
@@ -239,6 +239,9 @@ function TransactionDetailsContent({
   const messageBodyBocHex = inMessage ? formatCellBocHex(inMessage.body) : undefined
   const messageBocHex = inMessage ? formatMessageBocHex(inMessage) : undefined
   const messageHashHex = inMessage ? formatMessageHashHex(inMessage) : undefined
+  // For external-driven transactions the hash shown is the transaction's own
+  // hash, taken from the raw cell the backend returned (not re-serialized).
+  const transactionHashHex = tx.transaction.hash().toString("hex")
   const stateInitCode = inMessage?.init?.code ?? undefined
   const stateInitData = inMessage?.init?.data ?? undefined
   const stateInitBocHex = inMessage?.init ? formatStateInitBocHex(inMessage.init) : undefined
@@ -532,20 +535,18 @@ function TransactionDetailsContent({
                   {tx.transaction.lt.toString()}
                 </div>
               </div>
-              {messageHashHex && (
-                <div className={styles.multiColumnItem}>
-                  <div className={styles.multiColumnItemTitle}>Hash</div>
-                  <div className={styles.multiColumnItemValue}>
-                    <TechnicalValue
-                      copyLabel="message hash"
-                      endLength={3}
-                      startLength={3}
-                      value={messageHashHex}
-                      copyVisibility="always"
-                    />
-                  </div>
+              <div className={styles.multiColumnItem}>
+                <div className={styles.multiColumnItemTitle}>Hash</div>
+                <div className={styles.multiColumnItemValue}>
+                  <TechnicalValue
+                    copyLabel="transaction hash"
+                    endLength={3}
+                    startLength={3}
+                    value={transactionHashHex}
+                    copyVisibility="always"
+                  />
                 </div>
-              )}
+              </div>
             </div>
           </div>
         </div>

--- a/packages/transaction-ui/src/model/transaction.ts
+++ b/packages/transaction-ui/src/model/transaction.ts
@@ -72,6 +72,9 @@ export interface TransactionInfo {
   readonly blockRef?: TransactionBlockRef
   readonly address: Address | undefined
   readonly transaction: Transaction
+  // In-message hash as reported by the data source (hex). Preferred over
+  // hashing a re-serialized message, which can diverge from the on-chain cell.
+  readonly inMessageHash?: string
   readonly vmLogDiff: string
   readonly executorLogs: string
   readonly executorActions: readonly BackendExecutorAction[]


### PR DESCRIPTION
## What

Transactions triggered by an external message now get the same **In Message** meta block that internal in-messages already have — **Created At / Created Lt / Hash** — in the trace event overview and the transactions tab alike (both render through `TransactionDetails`).

## Why

For an external-driven transaction the details card showed no message hash at all, and the external's hash is exactly the handle you need when you broadcast an external and want to locate where it landed (`sendBocReturnHash` → `transactionsByMessage`). Load-generator debugging hits this constantly.

## How

- **Hash** — the in-message hash **as reported by the data source**: `TransactionInfo` gains an optional `inMessageHash`, filled on trace pages from the API's `in_msg.hash`. This also fixes a latent bug for internal cards: previously the field hashed a *re-serialized* message, and re-serialization can flip the body between inline and ref, producing a hash that exists nowhere on-chain (verified against a real testnet transaction: recomputed inline-body hash matched neither toncenter's `in_msg.hash` nor any cell in the raw transaction tree). The re-serialized hash remains only as a fallback for paths with no API-provided value (emulation, localnet).
- **Created At / Created Lt** — taken from the accepting transaction (`tx.transaction.now` / `tx.transaction.lt`), since an `ext_in_msg_info` carries no such fields of its own; this is the point where the message entered the chain.

Internal messages keep their own `created_at`/`created_lt`; tick-tock and everything else are untouched.

## Testing

- Verified in the vite build on a real testnet trace (external → WalletSpam → jetton transfer chain): the External In card shows Created At / Created Lt matching the accepting transaction and a copyable hash byte-identical to toncenter's `in_msg.hash` for that transaction (independently confirmed against the raw transaction boc: the value is the actual embedded message cell's hash, and — src/import_fee/init being zero and body a ref — also its TEP-467 normalized hash).
- `bun fmt` / `bun lint` / `tsc --noEmit` clean in `transaction-ui` and `explorer-core`; full explorer-core test suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)