### PR TITLE
feat(explorer): support gasless_request and change_wallet_key actions

### DIFF
--- a/crates/ton-api/src/toncenter/v3/responses.rs
+++ b/crates/ton-api/src/toncenter/v3/responses.rs
@@ -607,6 +607,8 @@ pub struct Action {
     pub end_lt: String,
     pub end_utime: u32,
     pub finality: String,
+    #[serde(default)]
+    pub parent_gasless_action: Option<String>,
     pub start_lt: String,
     pub start_utime: u32,
     #[serde(default)]

--- a/packages/explorer-core/src/api/types.ts
+++ b/packages/explorer-core/src/api/types.ts
@@ -180,6 +180,7 @@ export interface V3ActionBase<TType extends string, TDetails> {
   readonly end_lt: string
   readonly end_utime: number
   readonly finality: string
+  readonly parent_gasless_action?: string | null
   readonly start_lt: string
   readonly start_utime: number
   readonly success: boolean | null
@@ -207,6 +208,17 @@ export interface V3ActionDetailsContractDeploy {
   readonly source?: V3ActionAddress
   readonly destination?: V3ActionAddress
   readonly value?: V3ActionString
+}
+
+export interface V3ActionDetailsChangeWalletKey {
+  readonly source?: V3ActionAddress
+  readonly destination: V3ActionAddress
+}
+
+export interface V3ActionDetailsGaslessRequest {
+  readonly source: V3ActionAddress
+  readonly destination: V3ActionAddress
+  readonly value: V3ActionString
 }
 
 export interface V3ActionDetailsTonTransfer {
@@ -1045,6 +1057,8 @@ export type V3Action =
   | V3ActionBase<"cocoon_grant_refund", V3ActionDetailsCocoonGrantRefund>
   | V3ActionBase<"cocoon_client_increase_stake", V3ActionDetailsCocoonClientIncreaseStake>
   | V3ActionBase<"cocoon_client_withdraw", V3ActionDetailsCocoonClientWithdraw>
+  | V3ActionBase<"change_wallet_key", V3ActionDetailsChangeWalletKey>
+  | V3ActionBase<"gasless_request", V3ActionDetailsGaslessRequest>
 
 export interface V3TransactionsResponse {
   readonly address_book: Record<string, V3AddressBookRow>

--- a/packages/explorer-core/src/components/AccountDetails.tsx
+++ b/packages/explorer-core/src/components/AccountDetails.tsx
@@ -60,6 +60,7 @@ import {
   FileCode2,
   Filter,
   Flame,
+  Fuel,
   Gavel,
   Globe2,
   History,
@@ -2266,6 +2267,7 @@ const ACTION_TYPE_LABELS = {
   auction_outbid: "Auction outbid",
   call_contract: "Called contract",
   change_dns: "Change DNS",
+  change_wallet_key: "Change wallet key",
   cocoon_client_change_secret_hash: "Change secret hash",
   cocoon_client_increase_stake: "Increase stake",
   cocoon_client_register: "Register client",
@@ -2297,6 +2299,7 @@ const ACTION_TYPE_LABELS = {
   evaa_supply: "EVAA supply",
   evaa_withdraw: "EVAA withdraw",
   extra_currency_transfer: "Extra currency transfer",
+  gasless_request: "Gasless request",
   jetton_burn: "Burn token",
   jetton_mint: "Mint token",
   jetton_swap: "Swap tokens",
@@ -2352,6 +2355,7 @@ const ACTION_TYPE_ICONS = {
   auction_outbid: Gavel,
   call_contract: Code2,
   change_dns: Globe2,
+  change_wallet_key: KeyRound,
   cocoon_client_change_secret_hash: KeyRound,
   cocoon_client_increase_stake: Pickaxe,
   cocoon_client_register: ServerCog,
@@ -2383,6 +2387,7 @@ const ACTION_TYPE_ICONS = {
   evaa_supply: Landmark,
   evaa_withdraw: Landmark,
   extra_currency_transfer: WalletCards,
+  gasless_request: Fuel,
   jetton_burn: Flame,
   jetton_mint: BadgePlus,
   jetton_swap: RefreshCw,
@@ -2519,12 +2524,35 @@ function buildHistoryActionRows(
   }))
 }
 
-function getHistoryActionLabel(action: V3Action, isIncoming: boolean): string {
+export function getHistoryActionLabel(action: V3Action, isIncoming: boolean): string {
+  const label = getHistoryActionBaseLabel(action, isIncoming)
+
+  // A `gasless_request` marker is itself relayable, so never read "Gasless gasless request".
+  if (action.type === "gasless_request" || !isNonEmptyString(action.parent_gasless_action)) {
+    return label
+  }
+
+  return `Gasless ${uncapitalizeLabel(label)}`
+}
+
+function getHistoryActionBaseLabel(action: V3Action, isIncoming: boolean): string {
   if (action.type === "ton_transfer") {
     return isIncoming ? "Received GRAM" : "Send GRAM"
   }
 
   return ACTION_TYPE_LABELS[action.type] ?? "Unsupported action"
+}
+
+// Base labels are sentence case, so they lowercase cleanly behind a prefix - unless the first
+// word carries its own capitals ("DNS purchase", "LayerZero send"), which stay untouched.
+function uncapitalizeLabel(label: string): string {
+  const [firstWord = ""] = label.split(" ")
+  const rest = firstWord.slice(1)
+  if (rest !== rest.toLowerCase()) {
+    return label
+  }
+
+  return `${label.charAt(0).toLowerCase()}${label.slice(1)}`
 }
 
 function getHistoryActionIcon(action: V3Action, info: HistoryActionInfo): LucideIcon {
@@ -2570,7 +2598,9 @@ function collectActionMessageNameAddresses(actions: readonly V3Action[]): string
 
     switch (action.type) {
       case "call_contract":
+      case "change_wallet_key":
       case "contract_deploy":
+      case "gasless_request":
         addHistoryAddress(addresses, action.details.source)
         addHistoryAddress(addresses, action.details.destination)
         break
@@ -3453,6 +3483,23 @@ function getHistoryActionDisplay(
         context.ownerAddress,
         () => EMPTY_VALUE_LINES,
         "Cocoon",
+      )
+    case "change_wallet_key":
+      return sourceDestinationAction(
+        action.details.source ?? null,
+        action.details.destination,
+        context.ownerAddress,
+        () => EMPTY_VALUE_LINES,
+        "Wallet",
+      )
+    case "gasless_request":
+      return sourceDestinationAction(
+        action.details.source,
+        action.details.destination,
+        context.ownerAddress,
+        isIncoming =>
+          valueLines(tonValueLine(action.details.value, isIncoming ? "positive" : "negative")),
+        "Relayer",
       )
     default:
       return unsupportedActionDisplay(action)

--- a/packages/explorer-core/tests/client.test.ts
+++ b/packages/explorer-core/tests/client.test.ts
@@ -2,6 +2,7 @@ import {expect, mock, test} from "bun:test"
 import {beginCell} from "@ton/core"
 
 import {buildToncoinBlockDownloadUrl, TonClient} from "../src/api/client"
+import {getHistoryActionLabel} from "../src/components/AccountDetails"
 
 const mockFetch = (
   implementation: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>,
@@ -742,6 +743,79 @@ test("account action metadata skips master lookup when the symbol is present", a
         ],
       }
     `)
+  } finally {
+    globalThis.fetch = originalFetch
+  }
+})
+
+test("account actions keep gasless markers and label the actions they produced", async () => {
+  const originalFetch = globalThis.fetch
+  globalThis.fetch = mockFetch(async () =>
+    Response.json({
+      actions: [
+        {
+          action_id: "gasless-request",
+          type: "gasless_request",
+          success: true,
+          details: {source: "0:relayer", destination: "0:wallet", value: "25000000"},
+          parent_gasless_action: "outer-gasless-request",
+        },
+        {
+          action_id: "change-wallet-key",
+          type: "change_wallet_key",
+          success: true,
+          details: {source: null, destination: "0:wallet"},
+          parent_gasless_action: "gasless-request",
+        },
+        {
+          action_id: "relayed-jetton-transfer",
+          type: "jetton_transfer",
+          success: true,
+          details: {},
+          parent_gasless_action: "gasless-request",
+        },
+        {
+          action_id: "relayed-dns-purchase",
+          type: "dns_purchase",
+          success: true,
+          details: {},
+          parent_gasless_action: "gasless-request",
+        },
+        {
+          action_id: "plain-jetton-transfer",
+          type: "jetton_transfer",
+          success: true,
+          details: {},
+        },
+      ],
+      address_book: {},
+      metadata: {},
+    }),
+  )
+
+  try {
+    const client = new TonClient({
+      v2BaseUrl: "https://toncenter.example/api/v2",
+      v3BaseUrl: "https://toncenter.example/api/v3",
+      addressNameBaseUrl: "https://toncenter.example/api",
+    })
+    const response = await client.getAccountActions("EQAddress")
+
+    expect(
+      response.actions.map(action => ({
+        type: action.type,
+        parent: action.parent_gasless_action ?? null,
+        label: getHistoryActionLabel(action, false),
+      })),
+    ).toEqual([
+      // A relayed relay stays "Gasless request" instead of "Gasless gasless request".
+      {type: "gasless_request", parent: "outer-gasless-request", label: "Gasless request"},
+      {type: "change_wallet_key", parent: "gasless-request", label: "Gasless change wallet key"},
+      {type: "jetton_transfer", parent: "gasless-request", label: "Gasless token transfer"},
+      // Labels that start with their own capitals keep them.
+      {type: "dns_purchase", parent: "gasless-request", label: "Gasless DNS purchase"},
+      {type: "jetton_transfer", parent: null, label: "Token transfer"},
+    ])
   } finally {
     globalThis.fetch = originalFetch
   }


### PR DESCRIPTION
The TON Center indexer API (v3) gained two action types and one new field. Without this change actonscan renders them as "Unsupported action".

## What is new in the API

- **`gasless_request`** — a marker on the internal message that carries a wallet's signed request which a relayer delivered and paid the gas for. `details.source` is the relayer, `details.destination` is the wallet, `details.value` is the TON attached for gas. Like `contract_deploy`, it sits next to the actions the request produced rather than replacing them. Emitted for wallet v5 (`'sint'`) and for the Telegram wallet.
- **`change_wallet_key`** — a wallet rotated its signing key. `details.destination` is the wallet; `details.source` is the relayer, or `null` when the owner sent the request directly as an external message. No key material is carried.
- **`parent_gasless_action`** — optional, top level of any action: the `action_id` of the `gasless_request` this action is the immediate result of. Only immediate results are linked, so a deeper chain of contract calls is not tagged. A relayed request may itself be relayed, in which case the inner marker points at the outer one.

## What this PR does

- `explorer-core/src/api/types.ts` — `parent_gasless_action` on `V3ActionBase`, details interfaces for both types, two members in the `V3Action` union.
- `explorer-core/src/components/AccountDetails.tsx` — labels, icons (`KeyRound`, `Fuel`), display cases (counterparty reads "Wallet" / "Relayer", the marker shows the attached gas), and both types added to address-book resolution.
- The "Gasless …" prefix is applied in `getHistoryActionLabel`, the single place the label is computed, so a relayed token transfer reads *Gasless token transfer*. The marker itself is never prefixed — a relayed relay would otherwise read "Gasless gasless request". Labels that carry their own capitals keep them (*Gasless DNS purchase*, not *Gasless dNS purchase*).
- `crates/ton-api/.../v3/responses.rs` — `parent_gasless_action` on `Action`; without it the field is silently dropped when the struct is re-serialized by the emulate/streaming consumers.
- `explorer-core/tests/client.test.ts` — a case covering both new types, the recursive marker and the label rules. No snapshots were regenerated.

## Try it

A simple mainnet trace: a relayer pays for a wallet's request, the wallet sends 0.1 TON.

```
https://toncenter.com/api/v3/actions?trace_id=XG36%2BOp92Sg6NIPxSlhNrPWaprGkJEWsmHIWhApmMRA%3D
```

A trace with fan-out and a recursive relay, plus a key rotation: `iFRET9Pnv9C7McjSW11EcrnZJlxqJurmrA30q1N661Y=`.

## Checks

`tsc --noEmit`, `bun test tests` (188 pass), `bun run lint`, `bun run fmt:check` across all workspaces, `cargo check -p ton-api`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)